### PR TITLE
Demos/genes

### DIFF
--- a/demos/genes.ipynb
+++ b/demos/genes.ipynb
@@ -21,7 +21,7 @@
     "from keras import backend as K\n",
     "import numpy as np\n",
     "import pandas as pd\n",
-    "from typing import List, Dict, Union"
+    "from typing import List"
    ]
   },
   {
@@ -58,9 +58,9 @@
     "\n",
     "# List of IDs\n",
     "rnd = np.random.uniform(0, 1, len(gene_attr))\n",
-    "ids_train = gene_attr.loc[rnd<=0.5].index.values\n",
-    "ids_val = gene_attr.loc[np.where((rnd>0.5) & (rnd<0.7))].index.values\n",
-    "ids_test = gene_attr.loc[rnd>=0.7].index.values\n",
+    "ids_train = gene_attr.loc[rnd <= 0.5].index.values\n",
+    "ids_val = gene_attr.loc[(rnd > 0.5) & (rnd < 0.7)].index.values\n",
+    "ids_test = gene_attr.loc[rnd >= 0.7].index.values\n",
     "\n",
     "# Features\n",
     "feats = gene_attr.drop(['node_type'], axis=1)\n",
@@ -304,7 +304,6 @@
     "    def __getitem__(self, index):\n",
     "        'Generate one batch of data'\n",
     "        end = min(self.idx + self.batch_size, self.data_size)\n",
-    "#         print(\"Fetching {} batch {}:{}\".format(self.name, str(self.idx), str(end)))\n",
     "        indices = list(self.ids[range(self.idx, end)])\n",
     "        tgt, inp = get_batch(indices, self.ns)\n",
     "        self.y_true += [tgt]\n",
@@ -352,7 +351,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "y_trues_bin = np.concatenate(test_iter.y_true).ravel()[:9469]\n",
+    "y_trues_bin = np.concatenate(test_iter.y_true).ravel()[:len(ids_test)]\n",
     "y_preds_bin = np.array(np.reshape(y_preds, (-1,)) >= 0.5, dtype=np.float64)"
    ]
   },
@@ -362,9 +361,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "met = lambda f,k: sum([f(y_trues_bin[i], y_preds_bin[i]) and y_preds_bin[i]==k for i in range(9469)])\n",
-    "confu_mat = {'tn': met(lambda t,p: t==p, 0), 'fp': met(lambda t,p: t!=p, 1),\n",
-    "             'fn': met(lambda t,p: t!=p, 0), 'tp': met(lambda t,p: t==p, 1)}"
+    "met = lambda f,k: sum([f(y_trues_bin[i], y_preds_bin[i]) and y_preds_bin[i] == k for i in range(len(ids_test))])\n",
+    "confu_mat = {'tn': met(lambda t, p: t == p, 0), 'fp': met(lambda t, p: t != p, 1),\n",
+    "             'fn': met(lambda t, p: t != p, 0), 'tp': met(lambda t, p: t == p, 1)}"
    ]
   },
   {


### PR DESCRIPTION
Notebook demo for gene data.

Fixed issues raised in review:
* hard-coded true label array length set to `len(ids_test)`
* checked whether the use of `np.where` was necessary and it isn't, so it's been removed. The way it was being used seemed to be incompatible with different versions of `pandas` and `numpy`.