### PR TITLE
Issue/70

### DIFF
--- a/stellar/data/edge_splitter.py
+++ b/stellar/data/edge_splitter.py
@@ -931,14 +931,6 @@ class EdgeSplitter(object):
             np.random.shuffle(end_nodes)
             for u, v in zip(start_nodes, end_nodes):
                 u_v_edge_type = (u[1]["label"], v[1]["label"])
-                # if (
-                #     (u_v_edge_type in edge_source_target_node_types)
-                #     and (u != v)
-                #     and ((u[0], v[0]) not in edges)
-                #     and ((v[0], u[0]) not in edges)
-                #     and ((u[0], v[0], 0) not in sampled_edges)
-                #     and ((v[0], u[0], 0) not in sampled_edges)
-                # ):
                 if (
                     (u_v_edge_type in edge_source_target_node_types)
                     and (u != v)
@@ -952,9 +944,6 @@ class EdgeSplitter(object):
                     )  # the last entry is the class label
                     sampled_edges_set.add(u[0] + v[0])
                     count += 1
-                    # self.negative_edge_node_distances.append(
-                    #     nx.shortest_path_length(self.g, source=u[0], target=v[0])
-                    # )
                     if count % 1000 == 0:
                         print("Sampled", count, "negative edges")
 


### PR DESCRIPTION
Hi @adocherty 

I've updated the EdgeSplitter methods to run much faster by using lookup tables (dictionary and set where necessary) so that operations that required O(N^2) time now run in O(1) except for the O(N) operation to build the lookup tables to begin with. The difference in speed is huge!

Nothing changes with regards to functionality of the class and all the tests pass on both homogeneous and heterogeneous networks (tried on cora and BlogCatalog3). There is no code for timing but the difference is obvious if you run the examples in the README file in link-prediction demo (you can just copy paste the examples just need to update the input directory; BlogCatalog3 data are on SERENE drive if you don't have a copy) using the current develop branch and the issue/70 branch. The BlogCatalog3 dataset is good for testing because it has about 350k edges so the difference in speed is big.

Regards,

P.

