### PR TITLE
Modifications for NetworkX 1.x/2.x compatibility

### DIFF
--- a/stellar/data/explorer.py
+++ b/stellar/data/explorer.py
@@ -26,6 +26,9 @@ class GraphWalk(object):
     def __init__(self, graph):
         self.graph = graph
 
+    def neighbors(self, graph, node):
+        return list(nx.neighbors(graph, node))
+
     def run(self, **kwargs):
         """
         To be overridden by subclasses. It is the main entry point for performing random walks on the given
@@ -69,7 +72,7 @@ class UniformRandomWalk(GraphWalk):
                 current_node = node
                 for _ in range(length):
                     walk.extend([current_node])
-                    neighbours = nx.neighbors(self.graph, current_node)
+                    neighbours = self.neighbors(self.graph, current_node)
                     if (
                         len(neighbours) == 0
                     ):  # for whatever reason this node has no neighbours so stop
@@ -236,7 +239,7 @@ class SampledBreadthFirstWalk(GraphWalk):
                     if (
                         depth <= d
                     ):  # consider the subgraph up to and including depth d from root node
-                        neighbours = nx.neighbors(self.graph, frontier[0])
+                        neighbours = self.neighbors(self.graph, frontier[0])
                         if len(neighbours) == 0:
                             # Oops, this node has no neighbours and it doesn't have a self link.
                             # We can't handle this so raise an exception.

--- a/tests/data/test_edge_splitter.py
+++ b/tests/data/test_edge_splitter.py
@@ -53,7 +53,7 @@ def read_graph(graph_file, dataset_name, directed=False, weighted=False):
         else:
             # This is the correct way to set the edge weight in a MultiGraph.
             edge_weights = {e: 1 for e in g.edges(keys=True)}
-            nx.set_edge_attributes(g, "weight", edge_weights)
+            nx.set_edge_attributes(g, name="weight", values=edge_weights)
     except:  # otherwise, assume arg.input points to an edgelist file
         if weighted:
             g = nx.read_edgelist(


### PR DESCRIPTION
I've updated the explorer and edge splitters to be compatible with both NetworkX 1.x and 2.x versions. 

There are a few issues that I'm not certain about:
* Should these functions work with nx.Graph and nx.MultiGraph? Currently I'm not sure what is happening with edge splitters in mutigraphs.
* In v1.x the  `nx.minimum_spanning_edges` function doesn't return edge keys, i.e. it doesn't support multigraphs - in v2.x it does return keys. I've tested for this to support both return types, but I have not really looked into what the different versions return for a multigraph - does v2.x return all edges between two nodes, or just one?

All tests pass in both versions of NetworkX, is this enough to make us comfortable that they are doing the same thing?
  
