### PR TITLE
fixed units tests that validate parameter checking is handled correctly

### DIFF
--- a/stellar/data/explorer.py
+++ b/stellar/data/explorer.py
@@ -121,42 +121,42 @@ class UniformRandomWalk(GraphWalk):
                 )
             )
 
-        if n <= 0:
-            raise ValueError(
-                "({}) The number of walks per root node, n, should be a positive integer.".format(
-                    type(self).__name__
-                )
-            )
         if type(n) != int:
             raise ValueError(
                 "({}) The number of walks per root node, n, should be integer type.".format(
                     type(self).__name__
                 )
             )
-
-        if length <= 0:
+        if n <= 0:
             raise ValueError(
-                "({}) The walk length, length, should be positive integer.".format(
+                "({}) The number of walks per root node, n, should be a positive integer.".format(
                     type(self).__name__
                 )
             )
+
         if type(length) != int:
             raise ValueError(
                 "({}) The walk length, length, should be integer type.".format(
                     type(self).__name__
                 )
             )
+        if length <= 0:
+            raise ValueError(
+                "({}) The walk length, length, should be positive integer.".format(
+                    type(self).__name__
+                )
+            )
 
         if seed is not None:
-            if seed < 0:
-                raise ValueError(
-                    "({}) The random number generator seed value, seed, should be positive integer or None.".format(
-                        type(self).__name__
-                    )
-                )
             if type(seed) != int:
                 raise ValueError(
                     "({}) The random number generator seed value, seed, should be integer type or None.".format(
+                        type(self).__name__
+                    )
+                )
+            if seed < 0:
+                raise ValueError(
+                    "({}) The random number generator seed value, seed, should be positive integer or None.".format(
                         type(self).__name__
                     )
                 )

--- a/tests/data/test_edge_splitter.py
+++ b/tests/data/test_edge_splitter.py
@@ -211,6 +211,7 @@ class TestEdgeSplitterHeterogeneous(object):
                 attribute_is_datetime=True,
                 edge_attribute_threshold="01/01/2008",
             )
+        with pytest.raises(KeyError):
             # This call will raise and exception because edges of type 'towards' don't have a 'date' attribute
             self.es_obj.train_test_split(
                 p=p,
@@ -242,6 +243,7 @@ class TestEdgeSplitterHeterogeneous(object):
                 attribute_is_datetime=True,
                 edge_attribute_threshold="01/2008",
             )
+        with pytest.raises(ValueError):
             self.es_obj.train_test_split(
                 p=p,
                 method=method,
@@ -250,7 +252,7 @@ class TestEdgeSplitterHeterogeneous(object):
                 attribute_is_datetime=True,
                 edge_attribute_threshold="Jan 2005",
             )
-
+        with pytest.raises(ValueError):
             self.es_obj.train_test_split(
                 p=p,
                 method=method,
@@ -259,6 +261,7 @@ class TestEdgeSplitterHeterogeneous(object):
                 attribute_is_datetime=True,
                 edge_attribute_threshold="01-01-2000",
             )
+        with pytest.raises(ValueError):
             # month is out of range; no such thing as a 14th month in a year
             self.es_obj.train_test_split(
                 p=p,
@@ -268,7 +271,7 @@ class TestEdgeSplitterHeterogeneous(object):
                 attribute_is_datetime=True,
                 edge_attribute_threshold="01/14/2008",
             )
-
+        with pytest.raises(ValueError):
             # day is out of range; no such thing as a 32nd day in October
             self.es_obj.train_test_split(
                 p=p,

--- a/tests/data/test_metapath_walker.py
+++ b/tests/data/test_metapath_walker.py
@@ -83,23 +83,34 @@ class TestMetaPathWalk(object):
         seed = None
         metapaths = [["n", "s", "n"]]
 
+        # nodes should be a list of node ids even for a single node
         with pytest.raises(ValueError):
-            # nodes should be a list of node ids even for a single node
             mrw.run(nodes=None, n=n, length=length, metapaths=metapaths, seed=seed)
+        with pytest.raises(ValueError):
             mrw.run(nodes=0, n=n, length=length, metapaths=metapaths, seed=seed)
-            # only list is acceptable type for nodes
+        # only list is acceptable type for nodes
+        with pytest.raises(ValueError):
             mrw.run(nodes=(1, 2), n=n, length=length, metapaths=metapaths, seed=seed)
-            # n has to be positive integer
+        # n has to be positive integer
+        with pytest.raises(ValueError):
             mrw.run(nodes=nodes, n=-1, length=length, metapaths=metapaths, seed=seed)
+        with pytest.raises(ValueError):
             mrw.run(nodes=nodes, n=11.4, length=length, metapaths=metapaths, seed=seed)
+        with pytest.raises(ValueError):
             mrw.run(nodes=nodes, n=0, length=length, metapaths=metapaths, seed=seed)
-            # length has to be positive integer
+        # length has to be positive integer
+        with pytest.raises(ValueError):
             mrw.run(nodes=nodes, n=n, length=-3, metapaths=metapaths, seed=seed)
+        with pytest.raises(ValueError):
             mrw.run(nodes=nodes, n=n, length=0, metapaths=metapaths, seed=seed)
+        with pytest.raises(ValueError):
             mrw.run(nodes=nodes, n=n, length=4.6, metapaths=metapaths, seed=seed)
+        with pytest.raises(ValueError):
             mrw.run(nodes=nodes, n=n, length=1.0000001, metapaths=metapaths, seed=seed)
-            # metapaths have to start and end with the same node type
+        # metapaths have to start and end with the same node type
+        with pytest.raises(ValueError):
             mrw.run(nodes=nodes, n=n, length=length, metapaths=[["s", "n"]], seed=seed)
+        with pytest.raises(ValueError):
             mrw.run(
                 nodes=nodes,
                 n=n,
@@ -107,14 +118,19 @@ class TestMetaPathWalk(object):
                 metapaths=[["s", "n", "s"], ["n", "s"]],
                 seed=seed,
             )
-            # metapaths have to have minimum length of two
+        # metapaths have to have minimum length of two
+        with pytest.raises(ValueError):
             mrw.run(nodes=nodes, n=n, length=length, metapaths=[["s"]], seed=seed)
-            # metapaths has to be a list of lists of strings denoting the node labels
+        # metapaths has to be a list of lists of strings denoting the node labels
+        with pytest.raises(ValueError):
             mrw.run(nodes=nodes, n=n, length=length, metapaths=["n", "s"], seed=seed)
+        with pytest.raises(ValueError):
             mrw.run(nodes=nodes, n=n, length=length, metapaths=[[1, 2]], seed=seed)
+        with pytest.raises(ValueError):
             mrw.run(
                 nodes=nodes, n=n, length=length, metapaths=[["n", "s"], []], seed=seed
             )
+        with pytest.raises(ValueError):
             mrw.run(
                 nodes=nodes,
                 n=n,
@@ -122,7 +138,9 @@ class TestMetaPathWalk(object):
                 metapaths=[["n", "s"], ["s", 1]],
                 seed=seed,
             )
+        with pytest.raises(ValueError):
             mrw.run(nodes=nodes, n=n, length=length, metapaths=[("n", "s")], seed=seed)
+        with pytest.raises(ValueError):
             mrw.run(
                 nodes=nodes,
                 n=n,
@@ -130,8 +148,10 @@ class TestMetaPathWalk(object):
                 metapaths=(["n", "s"], ["s", "n", "s"]),
                 seed=seed,
             )
-            # seed has to be integer or None
+        # seed has to be integer or None
+        with pytest.raises(ValueError):
             mrw.run(nodes=nodes, n=n, length=length, metapaths=metapaths, seed=-1)
+        with pytest.raises(ValueError):
             mrw.run(nodes=nodes, n=n, length=length, metapaths=metapaths, seed=1000.345)
 
         # If no root nodes are given, an empty list is returned which is not an error but I thought this method

--- a/tests/data/test_uniform_random_walker.py
+++ b/tests/data/test_uniform_random_walker.py
@@ -68,33 +68,47 @@ class TestUniformRandomWalk(object):
         length = 2
         seed = None
 
+        # nodes should be a list of node ids even for a single node
         with pytest.raises(ValueError):
-            # nodes should be a list of node ids even for a single node
             urw.run(nodes=None, n=n, length=length, seed=seed)
+        with pytest.raises(ValueError):
             urw.run(
                 nodes="0", n=n, length=length, seed=seed
             )  # can't just pass a node id, need list, e.g., ["0"]
+        with pytest.raises(ValueError):
             urw.run(
                 nodes=(1, 2), n=n, length=length, seed=seed
             )  # tuple is not accepted, only list
-
-            # n has to be positive integer
+        # n has to be positive integer
+        with pytest.raises(ValueError):
             urw.run(nodes=nodes, n=0, length=length, seed=seed)
+        with pytest.raises(ValueError):
             urw.run(nodes=nodes, n=-121, length=length, seed=seed)
+        with pytest.raises(ValueError):
             urw.run(nodes=nodes, n=21.4, length=length, seed=seed)
+        with pytest.raises(ValueError):
             urw.run(nodes=nodes, n=-0.5, length=length, seed=seed)
+        with pytest.raises(ValueError):
             urw.run(nodes=nodes, n=0.0001, length=length, seed=seed)
+        with pytest.raises(ValueError):
             urw.run(nodes=nodes, n="2", length=length, seed=seed)
 
-            # length has to be positive integer
+        # length has to be positive integer
+        with pytest.raises(ValueError):
             urw.run(nodes=nodes, n=n, length=0, seed=seed)
+        with pytest.raises(ValueError):
             urw.run(nodes=nodes, n=n, length=-5, seed=seed)
+        with pytest.raises(ValueError):
             urw.run(nodes=nodes, n=n, length=11.9, seed=seed)
+        with pytest.raises(ValueError):
             urw.run(nodes=nodes, n=n, length=-9.9, seed=seed)
+        with pytest.raises(ValueError):
             urw.run(nodes=nodes, n=n, length="10", seed=seed)
 
-            # seed has to be None, 0,  or positive integer
+        # seed has to be None, 0,  or positive integer
+        with pytest.raises(ValueError):
             urw.run(nodes=nodes, n=n, length=length, seed=-1)
+        with pytest.raises(ValueError):
             urw.run(nodes=nodes, n=n, length=length, seed=1010.8)
 
         # If no root nodes are given, an empty list is returned which is not an error but I thought this method


### PR DESCRIPTION
Hi @adocherty 

this pull request is about fixing the remaining unit tests that were not correctly checking that exceptions were raised as necessary due to the fact that I had a single with block for all tests. As a result, once the first method call raised an exception, all other calls were skipped, hence never checked.

I have corrected this behaviour now and all should be good. Thanks for having a look, although not much has really changed in the code.

Regards,

P.