### PR TITLE
Updated GraphSAGENodeMapper to create sampler internally

### DIFF
--- a/demos/node-classification/epgm-example.py
+++ b/demos/node-classification/epgm-example.py
@@ -192,23 +192,20 @@ def train(
     train_ids = [v[0] for v in train_nodes]
     val_ids = [v[0] for v in val_nodes]
     test_ids = [v[0] for v in test_nodes]
-    all_ids = list(G.nodes())
-
-    # Sampler chooses random sampled subgraph for each head node
-    sampler = SampledBreadthFirstWalk(G)
+    all_ids = list(G)
 
     # Mapper feeds data from sampled subgraph to GraphSAGE model
     train_mapper = GraphSAGENodeMapper(
-        G, train_ids, sampler, batch_size, num_samples, target_id="target", name="train"
+        G, train_ids, batch_size, num_samples, target_id="target", name="train"
     )
     val_mapper = GraphSAGENodeMapper(
-        G, val_ids, sampler, batch_size, num_samples, target_id="target", name="val"
+        G, val_ids, batch_size, num_samples, target_id="target", name="val"
     )
     test_mapper = GraphSAGENodeMapper(
-        G, test_ids, sampler, batch_size, num_samples, target_id="target", name="test"
+        G, test_ids, batch_size, num_samples, target_id="target", name="test"
     )
     all_mapper = GraphSAGENodeMapper(
-        G, all_ids, sampler, batch_size, num_samples, target_id="target", name="all"
+        G, all_ids, batch_size, num_samples, target_id="target", name="all"
     )
 
     # GraphSAGE model
@@ -284,13 +281,9 @@ def test(G, model_file: AnyStr, batch_size: int):
         for ii in range(len(model.input_shape) - 1)
     ]
 
-    # Sampler chooses random sampled subgraph for each head node
-    sampler = SampledBreadthFirstWalk(G)
-    all_ids = list(G.nodes())
-
-    # Mapper feeds data from sampled subgraph to GraphSAGE model
+    # Mapper for all nodes to feed data to GraphSAGE model
     all_mapper = GraphSAGENodeMapper(
-        G, all_ids, sampler, batch_size, num_samples, target_id="target", name="test"
+        G, list(G), batch_size, num_samples, target_id="target", name="test"
     )
 
     # Evaluate and print metrics

--- a/stellar/mapper/node_mappers.py
+++ b/stellar/mapper/node_mappers.py
@@ -50,7 +50,6 @@ class GraphSAGENodeMapper(Sequence):
         self,
         G: StellarGraphBase,
         ids: List[Any],
-        sampler: Callable[[List[Any]], List[List[Any]]],
         batch_size: int,
         num_samples: List[int],
         target_id: AnyStr = None,
@@ -58,7 +57,6 @@ class GraphSAGENodeMapper(Sequence):
         name: AnyStr = None,
     ):
         self.G = G
-        self.sampler = sampler
         self.num_samples = num_samples
         self.ids = list(ids)
         self.data_size = len(self.ids)
@@ -66,11 +64,8 @@ class GraphSAGENodeMapper(Sequence):
         self.name = name
         self.label_id = target_id
 
-        # Check correct graph sampler is used
-        if not isinstance(sampler, SampledBreadthFirstWalk):
-            raise TypeError(
-                "Sampler must be an instance of from SampledBreadthFirstWalk"
-            )
+        # Create sampler for GraphSAGE
+        self.sampler = SampledBreadthFirstWalk(G)
 
         # Ensure features are available:
         nodes_have_features = all(


### PR DESCRIPTION
The `GraphSAGENodeMapper` class has been updated  to work in the same way as the `GraphSAGELinkMapper` and create the required sampler internally. This means we pass the graph but not the sampler. This seems a better way to do things now as there is only a single GraphWalker (sampler) class that will work for the GraphSAGE models.
