### PR TITLE
use docker hub image + update docs

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,7 +15,7 @@ steps:
       - --check stellar tests
     plugins:
       docker#v1.3.0:
-        image: "513929068678.dkr.ecr.ap-southeast-2.amazonaws.com/black"
+        image: "stellargraph/black"
         workdir: /app
         entrypoint: /usr/bin/black
         environment:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,21 @@
 # Stellar Graph Machine Learning Library
 
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
+
+
 ## Build Status
 |Branch|Build|
 |:-----|:----:|
 |*master*|[![Build status](https://badge.buildkite.com/34d537a018c6bf27cf154aa5bcc287b2e170d6e3391cd40c64.svg)](https://buildkite.com/stellar/stellar-ml?branch=master)|
 |*devel*|[![Build status](https://badge.buildkite.com/34d537a018c6bf27cf154aa5bcc287b2e170d6e3391cd40c64.svg)](https://buildkite.com/stellar/stellar-ml?branch=develop)|
+
+## CI
+
+### buildkite integration
+
+Pipeline is defined in `.buildkite/pipeline.yml`
+
+### Docker images
+
+* Tests: Uses the official [python:3.6](https://hub.docker.com/_/python/) image.
+* Style: Uses [black](https://hub.docker.com/r/stellargraph/black/) from the `stellargraph` docker hub organisation.


### PR DESCRIPTION
A few small changes

* Updated pipeline so that BK pulls the `black` docker image from our new docker hub org https://hub.docker.com/r/stellargraph/black/
* Added documentation on the buildkite pipeline and a `black` code style badge

The black image had been optimised for size (`13MBs` currently), so the time it will take for BK to pull from docker hub vs ECR will be negligible.