### PR TITLE
Fixed the bug in LinkSequence that threw an error when no link targets were given

### DIFF
--- a/stellargraph/mapper/link_mappers.py
+++ b/stellargraph/mapper/link_mappers.py
@@ -75,6 +75,9 @@ class LinkSequence(Sequence):
                 raise ValueError(
                     "The length of the targets must be the same as the length of the ids"
                 )
+            self.targets = np.asanyarray(targets)
+        else:
+            self.targets = targets
 
         # Ensure number of labels matches number of ids
         if targets is not None and len(ids) != len(targets):
@@ -82,7 +85,6 @@ class LinkSequence(Sequence):
 
         self.generator = generator
         self.ids = list(ids)
-        self.targets = np.asanyarray(targets)
         self.data_size = len(self.ids)
 
         # Get head node types from all src, dst nodes extracted from all links,

--- a/tests/mapper/test_link_mappers.py
+++ b/tests/mapper/test_link_mappers.py
@@ -374,3 +374,17 @@ class Test_HinSAGELinkGenerator(object):
 
         with pytest.raises(IndexError):
             nf, nl = mapper[2]
+
+    def test_HinSAGELinkGenerator_no_targets(self):
+        """
+        This tests link generator's iterator for prediction, i.e., without targets provided
+        """
+        G = example_HIN_1(self.n_feat)
+        links = [(1, 4), (1, 5), (0, 4), (0, 5)]  # selected ('movie', 'user') links
+        data_size = len(links)
+
+        gen = HinSAGELinkGenerator(
+            G, batch_size=self.batch_size, num_samples=self.num_samples
+        ).flow(links)
+        for i in range(len(gen)):
+            assert gen[i][1] is None

--- a/tests/mapper/test_link_mappers.py
+++ b/tests/mapper/test_link_mappers.py
@@ -241,6 +241,17 @@ class Test_GraphSAGELinkGenerator:
         with pytest.raises(ValueError):
             nf, nl = mapper[0]
 
+    def test_GraphSAGELinkGenerator_no_targets(self):
+        """
+        This tests link generator's iterator for prediction, i.e., without targets provided
+        """
+        G = example_Graph_2(self.n_feat)
+        iter = GraphSAGELinkGenerator(
+            G, batch_size=self.batch_size, num_samples=self.num_samples
+        ).flow(G.edges())
+        for i in range(len(iter)):
+            assert iter.__getitem__(i)[1] is None
+
 
 class Test_HinSAGELinkGenerator(object):
     """

--- a/tests/mapper/test_link_mappers.py
+++ b/tests/mapper/test_link_mappers.py
@@ -246,11 +246,11 @@ class Test_GraphSAGELinkGenerator:
         This tests link generator's iterator for prediction, i.e., without targets provided
         """
         G = example_Graph_2(self.n_feat)
-        iter = GraphSAGELinkGenerator(
+        gen = GraphSAGELinkGenerator(
             G, batch_size=self.batch_size, num_samples=self.num_samples
         ).flow(G.edges())
-        for i in range(len(iter)):
-            assert iter.__getitem__(i)[1] is None
+        for i in range(len(gen)):
+            assert gen[i][1] is None
 
 
 class Test_HinSAGELinkGenerator(object):


### PR DESCRIPTION
- Fixed the bug in `LinkSequence` class that occurred when no link targets were given to the link iterator.
- Added a test, `test_GraphSAGELinkGenerator_no_targets`, covering the case of link generator with no targets (e.g., for prediction)