### PR TITLE
add code coverage results and push to coveralls

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,6 +10,7 @@ steps:
         workdir: /app
         environment:
           - PYTHONDONTWRITEBYTECODE=1
+          - COVERALLS_REPO_TOKEN=$COVERALLS_REPO_TOKEN
 
   - label: "style"
     command:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,8 +1,9 @@
 steps:
   - label: ":python:"
     command:
-      - pip install -q --no-cache-dir -r requirements.txt
-        && python -m pytest tests -p no:cacheprovider
+      - pip install -q --no-cache-dir -r requirements.txt -e .
+        && py.test -ra --cov=stellargraph tests/ --doctest-modules --doctest-modules --cov-report=term-missing -p no:cacheprovider
+        && coveralls
     plugins:
       docker#v1.3.0:
         image: "python:3.6"

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@
     <img src="https://img.shields.io/badge/contributions-welcome-brightgreen.svg"/></a>
   <a href="https://github.com/stellargraph/stellargraph/blob/develop/LICENSE" alt="license">
     <img src="https://img.shields.io/github/license/stellargraph/stellargraph.svg"/></a>
+  <a href="https://coveralls.io/github/stellargraph/stellargraph" alt="code coverage">
+    <img src="https://coveralls.io/repos/github/stellargraph/stellargraph/badge.svg"/></a>
 </p>
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,5 @@ pandas==0.23.4
 gensim==3.4.0
 pytest>=3.6.0
 pytest-benchmark>=3.1
+pytest-cov>=2.6.0
+coveralls>=1.5.1


### PR DESCRIPTION
PR to address #258 

A few changes

* Adds `pytest-cov` and `coveralls` to `requirements.txt`
* Adds the `-e` flag  to `pip install` for [editable installs](https://pip.pypa.io/en/stable/reference/pip_install/#editable-installs) required for `pytest-cov` following [the doc's practices](https://docs.pytest.org/en/latest/goodpractices.html)
* Add the coveralls.io coverage badge 

Coverage can be viewed here 
https://coveralls.io/github/stellargraph/stellargraph