### PR TITLE
Fix link_inference activation function with 'ip' method

### DIFF
--- a/demos/link-prediction-graphsage/cora-links-example.ipynb
+++ b/demos/link-prediction-graphsage/cora-links-example.ipynb
@@ -25,7 +25,9 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Using TensorFlow backend.\n"
+      "Using TensorFlow backend.\n",
+      "/Users/doc019/.envs/stellarml/lib/python3.6/importlib/_bootstrap.py:219: RuntimeWarning: compiletime version 3.5 of module 'tensorflow.python.framework.fast_tensor_util' does not match runtime version 3.6\n",
+      "  return f(*args, **kwds)\n"
      ]
     }
    ],
@@ -43,6 +45,26 @@
     "from sklearn import preprocessing, feature_extraction, model_selection\n",
     "\n",
     "from stellargraph import globalvar"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<module 'stellargraph' from '/Users/doc019/Code/stellargraph/stellargraph/__init__.py'>"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sg"
    ]
   },
   {
@@ -74,9 +96,21 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'os' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-2-e90c5ddd54e0>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mdata_dir\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mos\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mpath\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mexpanduser\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"~/data/cora\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m: name 'os' is not defined"
+     ]
+    }
+   ],
    "source": [
-    "data_dir = \"~/data/cora\""
+    "data_dir = os.path.expanduser(\"~/data/cora\")"
    ]
   },
   {
@@ -88,7 +122,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -98,7 +132,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -114,7 +148,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -132,7 +166,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -149,7 +183,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -172,7 +206,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -200,7 +234,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -233,7 +267,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -271,7 +305,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -288,7 +322,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -315,7 +349,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -351,12 +385,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 98,
    "metadata": {},
    "outputs": [],
    "source": [
-    "batch_size = 50\n",
-    "epochs = 10"
+    "batch_size = 25\n",
+    "epochs = 20"
    ]
   },
   {
@@ -370,7 +404,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 99,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -379,7 +413,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 100,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -399,21 +433,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 112,
    "metadata": {},
    "outputs": [],
    "source": [
-    "layer_sizes = [50, 50]\n",
+    "layer_sizes = [20, 20]\n",
     "assert len(layer_sizes) == len(num_samples)\n",
     "\n",
     "graphsage = GraphSAGE(\n",
-    "        layer_sizes=layer_sizes, generator=train_gen, bias=True, dropout=0.0\n",
+    "        layer_sizes=layer_sizes, generator=train_gen, bias=True, dropout=0.3\n",
     "    )"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 113,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -435,7 +469,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 114,
    "metadata": {},
    "outputs": [
     {
@@ -461,7 +495,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 115,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -483,7 +517,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 116,
    "metadata": {},
    "outputs": [
     {
@@ -492,12 +526,12 @@
      "text": [
       "\n",
       "Train Set Metrics of the initial (untrained) model:\n",
-      "\tloss: 0.5847\n",
-      "\tbinary_accuracy: 0.7059\n",
+      "\tloss: 0.6744\n",
+      "\tbinary_accuracy: 0.5567\n",
       "\n",
       "Test Set Metrics of the initial (untrained) model:\n",
-      "\tloss: 0.5884\n",
-      "\tbinary_accuracy: 0.6761\n"
+      "\tloss: 0.6745\n",
+      "\tbinary_accuracy: 0.5379\n"
      ]
     }
    ],
@@ -523,33 +557,53 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 117,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Epoch 1/10\n",
-      "10/10 [==============================] - 5s 461ms/step - loss: 0.6036 - binary_accuracy: 0.6906 - val_loss: 0.5410 - val_binary_accuracy: 0.7348\n",
-      "Epoch 2/10\n",
-      "10/10 [==============================] - 4s 356ms/step - loss: 0.2997 - binary_accuracy: 0.9561 - val_loss: 0.4975 - val_binary_accuracy: 0.7822\n",
-      "Epoch 3/10\n",
-      "10/10 [==============================] - 3s 316ms/step - loss: 0.1960 - binary_accuracy: 0.9940 - val_loss: 0.4716 - val_binary_accuracy: 0.7879\n",
-      "Epoch 4/10\n",
-      "10/10 [==============================] - 3s 300ms/step - loss: 0.1414 - binary_accuracy: 0.9940 - val_loss: 0.4604 - val_binary_accuracy: 0.7955\n",
-      "Epoch 5/10\n",
-      "10/10 [==============================] - 3s 303ms/step - loss: 0.1097 - binary_accuracy: 1.0000 - val_loss: 0.4502 - val_binary_accuracy: 0.8068\n",
-      "Epoch 6/10\n",
-      "10/10 [==============================] - 3s 298ms/step - loss: 0.0899 - binary_accuracy: 1.0000 - val_loss: 0.4486 - val_binary_accuracy: 0.8049\n",
-      "Epoch 7/10\n",
-      "10/10 [==============================] - 3s 313ms/step - loss: 0.0764 - binary_accuracy: 1.0000 - val_loss: 0.4384 - val_binary_accuracy: 0.8106\n",
-      "Epoch 8/10\n",
-      "10/10 [==============================] - 3s 309ms/step - loss: 0.0655 - binary_accuracy: 1.0000 - val_loss: 0.4365 - val_binary_accuracy: 0.8030\n",
-      "Epoch 9/10\n",
-      "10/10 [==============================] - 3s 323ms/step - loss: 0.0595 - binary_accuracy: 1.0000 - val_loss: 0.4342 - val_binary_accuracy: 0.8106\n",
-      "Epoch 10/10\n",
-      "10/10 [==============================] - 3s 312ms/step - loss: 0.0514 - binary_accuracy: 1.0000 - val_loss: 0.4405 - val_binary_accuracy: 0.8030\n"
+      "Epoch 1/20\n",
+      " - 10s - loss: 0.6824 - binary_accuracy: 0.5770 - val_loss: 0.6565 - val_binary_accuracy: 0.5777\n",
+      "Epoch 2/20\n",
+      " - 6s - loss: 0.6321 - binary_accuracy: 0.7033 - val_loss: 0.6397 - val_binary_accuracy: 0.6117\n",
+      "Epoch 3/20\n",
+      " - 6s - loss: 0.6090 - binary_accuracy: 0.7594 - val_loss: 0.6276 - val_binary_accuracy: 0.6439\n",
+      "Epoch 4/20\n",
+      " - 5s - loss: 0.5833 - binary_accuracy: 0.7755 - val_loss: 0.6169 - val_binary_accuracy: 0.6951\n",
+      "Epoch 5/20\n",
+      " - 5s - loss: 0.5477 - binary_accuracy: 0.8757 - val_loss: 0.6066 - val_binary_accuracy: 0.6989\n",
+      "Epoch 6/20\n",
+      " - 5s - loss: 0.5331 - binary_accuracy: 0.8978 - val_loss: 0.5963 - val_binary_accuracy: 0.7405\n",
+      "Epoch 7/20\n",
+      " - 6s - loss: 0.5185 - binary_accuracy: 0.8917 - val_loss: 0.5934 - val_binary_accuracy: 0.7292\n",
+      "Epoch 8/20\n",
+      " - 6s - loss: 0.5007 - binary_accuracy: 0.9278 - val_loss: 0.5907 - val_binary_accuracy: 0.7330\n",
+      "Epoch 9/20\n",
+      " - 5s - loss: 0.4949 - binary_accuracy: 0.9278 - val_loss: 0.5890 - val_binary_accuracy: 0.7292\n",
+      "Epoch 10/20\n",
+      " - 5s - loss: 0.4845 - binary_accuracy: 0.9379 - val_loss: 0.5812 - val_binary_accuracy: 0.7443\n",
+      "Epoch 11/20\n",
+      " - 5s - loss: 0.4680 - binary_accuracy: 0.9539 - val_loss: 0.5848 - val_binary_accuracy: 0.7311\n",
+      "Epoch 12/20\n",
+      " - 5s - loss: 0.4563 - binary_accuracy: 0.9699 - val_loss: 0.5810 - val_binary_accuracy: 0.7348\n",
+      "Epoch 13/20\n",
+      " - 5s - loss: 0.4503 - binary_accuracy: 0.9820 - val_loss: 0.5801 - val_binary_accuracy: 0.7159\n",
+      "Epoch 14/20\n",
+      " - 4s - loss: 0.4441 - binary_accuracy: 0.9699 - val_loss: 0.5835 - val_binary_accuracy: 0.7216\n",
+      "Epoch 15/20\n",
+      " - 4s - loss: 0.4362 - binary_accuracy: 0.9739 - val_loss: 0.5809 - val_binary_accuracy: 0.7330\n",
+      "Epoch 16/20\n",
+      " - 4s - loss: 0.4298 - binary_accuracy: 0.9820 - val_loss: 0.5822 - val_binary_accuracy: 0.7254\n",
+      "Epoch 17/20\n",
+      " - 4s - loss: 0.4227 - binary_accuracy: 0.9840 - val_loss: 0.5789 - val_binary_accuracy: 0.7216\n",
+      "Epoch 18/20\n",
+      " - 4s - loss: 0.4177 - binary_accuracy: 0.9800 - val_loss: 0.5808 - val_binary_accuracy: 0.7348\n",
+      "Epoch 19/20\n",
+      " - 5s - loss: 0.4106 - binary_accuracy: 0.9940 - val_loss: 0.5789 - val_binary_accuracy: 0.7311\n",
+      "Epoch 20/20\n",
+      " - 5s - loss: 0.4070 - binary_accuracy: 0.9900 - val_loss: 0.5839 - val_binary_accuracy: 0.7159\n"
      ]
     }
    ],
@@ -558,7 +612,7 @@
     "        train_gen,\n",
     "        epochs=epochs,\n",
     "        validation_data=test_gen,\n",
-    "        verbose=1,\n",
+    "        verbose=2,\n",
     "        shuffle=True,\n",
     "    )"
    ]
@@ -572,7 +626,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 118,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -582,39 +636,31 @@
     "def plot_history(history):\n",
     "    metrics = sorted(history.history.keys())\n",
     "    metrics = metrics[:len(metrics)//2]\n",
-    "    for m in metrics:\n",
+    "    \n",
+    "    f,axs = plt.subplots(1, len(metrics), figsize=(12,4))\n",
+    "\n",
+    "    for m,ax in zip(metrics,axs):\n",
     "        # summarize history for metric m\n",
-    "        plt.plot(history.history[m])\n",
-    "        plt.plot(history.history['val_' + m])\n",
-    "        plt.title(m)\n",
-    "        plt.ylabel(m)\n",
-    "        plt.xlabel('epoch')\n",
-    "        plt.legend(['train', 'test'], loc='upper right')\n",
-    "        plt.show()"
+    "        ax.plot(history.history[m])\n",
+    "        ax.plot(history.history['val_' + m])\n",
+    "        ax.set_title(m)\n",
+    "        ax.set_ylabel(m)\n",
+    "        ax.set_xlabel('epoch')\n",
+    "        ax.legend(['train', 'test'], loc='upper right')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 119,
    "metadata": {
     "scrolled": false
    },
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYwAAAEWCAYAAAB1xKBvAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvIxREBQAAIABJREFUeJzt3Xl8VPW9//HXhxBIwk6CSBKBqKggKCii1tpqrS1qq7a21gVrl1/pYltrbau2Vi29vfXe21rrrdWqpdpqQUtrpRavu93UCiKasMjmQiYgkSUhkECWz++PcwKTjcxAhjMzeT8fj3nkzDnnO/OZUc5nzvdzzvdr7o6IiEh3+kQdgIiIZAYlDBERSYgShoiIJEQJQ0REEqKEISIiCVHCEBGRhChhSMYwszfN7IOdrD/VzF6PIiaR3qRv1AGI7C93/wdwZNRxiGQ7nWGIdMECGflvxMz0Y1B6XEb+Y5Be7QQzW2ZmW8zsN2aWZ2anmVll6w5h19W3zOw1M6sxswfNLC/cNszMHjWz6vA1HjWz0ri2z5nZj8zsX8AO4Gozezk+ADP7ppk9srcgzewcM3vFzGrNbJ2Z3dRu+3vN7Hkz2xpu/0y4Pt/Mfmpmb4Wx/zNc1+Yzxn3OD4bLN5nZPDO738xqgc+Y2TQzeyF8j/Vm9gsz6xfX/mgze9LMNpvZO2b2XTM72Mx2mFlh3H7Hhd9XboL/jSRLKWFIprkU+DBwGHAEcH0X+10ITAfKgGOAz4Tr+wC/AcYAo4F64Bft2l4GzAQGAbcBZWY2vt3233YT53bg08BQ4Bzgy2Z2PoCZjQEeA/4XGAFMBpaE7X4CHA+8BxgOfAdo6ea9Wp0HzAvf8wGgGbgKKAJOBs4AvhLGMAh4Cvg/oBg4HHja3TcAzxF8f/Gfd667NyYYh2QpJQzJNL9w93Xuvhn4EXBxF/vd5u5V4X5/ITgo4+6b3P2P7r7D3beFr/H+dm3vdfel7t7k7juBB4EZEPwqB8YCj+4tSHd/zt3L3b3F3V8D5sS9zyXAU+4+x90bw5iWhN1fnwOudPeYuze7+/NhDIl4wd3/HL5nvbu/7O4vhp/jTeBXcTF8BNjg7j919wZ33+bu/w633Rf3eXMIvuPfJRiDZDElDMk06+KW3yL4ddyZDXHLO4CBAGZWYGa/Crt8aoG/A0PDA2Nn7wHBAfQSMzOCX9sPdXcQN7MTzezZsCunBvgSwS99gEOANZ00KwLyutiWiDZxm9kRYZfbhvCz/mcCMQA8AkwwszLgTKDG3V/ax5gkiyhhSKY5JG55NFCVZPurCa6oOtHdBwPvC9db3D5thnB29xeBXcCpBGcHifza/j0wHzjE3YcAd8a9xzqCLrX23gUauti2HShofRImuBHt9mk/9PQdwApgXPhZv9suhkM7C9zdG4CHCM4yLkNnFxJSwpBMc4WZlZrZcOB7BN1FyRhEULfYGr7GjQm2+y1BraPR3f+Z4PtsdvcGM5tGkGhaPQB80MwuNLO+ZlZoZpPdvQWYDdxiZsVmlmNmJ5tZf2AlkBcW03MJajf9E4ihFqgzs6OAL8dtexQYZWbfMLP+ZjbIzE5s93k/A5yLEoaElDAk0/weeAJYS9Cl8h9Jtr8VyCf4Nf8iQdE3Eb8DJgL3J7j/V4BZZrYNuIHgFzsA7v42cDbB2c5mgoL3seHmbwHlwMJw238Bfdy9JnzNe4AYwRlHm6umOvEtgkS1DbibuOQa1m/OBD5K0H23Cjg9bvu/CIrti939rQQ/s2Q50wRKIt0zs3xgI3Ccu6+KOp4DwcyeAX7v7vdEHYukB93cI5KYLwMLe1GyOAE4juBSXRFACUOkW2b2JkGx+Px265cS3M/R3hfd/YEDEFpKmNl9BJ/1yrDrSgRQl5SIiCRIRW8REUlIVnVJFRUV+dixY6MOQ0Qko7z88svvunv7+3o6yKqEMXbsWBYtWhR1GCIiGcXMErp0Wl1SIiKSECUMERFJiBKGiIgkJKtqGCIi+6KxsZHKykoaGhqiDiWl8vLyKC0tJTd33+bCUsIQkV6vsrKSQYMGMXbsWIJR7LOPu7Np0yYqKyspKyvbp9dIaZeUmc02s41mVtHFdjOz28xsdTid5nFx2y43s1Xh4/JUxikivVtDQwOFhYVZmywAzIzCwsL9OotKdQ3jXoJpMrtyFjAufMwkGL+fuGGnTwSmATea2bCURioivVo2J4tW+/sZU9ol5e5/N7Oxe9nlPOC3HoxP8qKZDTWzUcBpwJPh9JqY2ZMEiWdOKuMVAWhqbmFDbQNVWxuo2lpPbGs9Oxubow5LUuiUokY21GR2/SIvtw9DC/ql9D2irmGU0HZaycpwXVfrOzCzmQRnJ4wePTo1UUpWqW1oJLalnqqt9WFCaNi9XLW1ng21DbS0G2KtF/z47NWO+egoNm6LLmHU1tTw2J//wKcu/39Jtbvi05/kx/97D4OHDGFwXm7WJ4z95u53AXcBTJ06VSMp9nKdnR3sSQbBum07m9q06ZfTh1FD8ygeks/JhxVRMjSP4qH5FA/Np2RYPsVD8snvl9PFO0o2WL58OeNLh0b2/m82beWROffyo+99q836pqYm+vbt+jD9j2eeTHVobUSdMGK0naO5NFwXI+iWil//3AGLStJWTX1jm7OBRM4OhhXkUjIsnzGFBZx8WCElYTIoHppHydB8igb2p08fnUJIdK699lrWrFnD5MmTyc3NJS8vj2HDhrFixQpWrlzJ+eefz7p162hoaODKK69k5syZwJ7hkOrq6jjrrLN473vfy/PPP09JSQmPPPII+fn5PRpn1AljPvBVM5tLUOCucff1ZvY48J9xhe4PAddFFWRv8+q6rTy+dANRn665w7aGxr2eHeTmGKOGBAf/9mcHrUmhoF/U/5tLJvnBX5ayrKq2R19zQvFgbvzo0V1uv/nmm6moqGDJkiU899xznHPOOVRUVOy+/HX27NkMHz6c+vp6TjjhBC644AIKCwvbvMaqVauYM2cOd999NxdeeCF//OMfmTFjRo9+jpT+SzKzOQRnCkVmVklw5VMugLvfCSwgmNt4NbAD+Gy4bbOZ/ZBgXmOAWa0FcEmdpuYWbn92Dbc9swp3p2+f6AcCKOifQ8nQfEbr7EB6kWnTprW5V+K2227j4YcfBmDdunWsWrWqQ8IoKytj8uTJABx//PG8+eabPR5Xqq+Surib7Q5c0cW22cDsVMQlHb29aQffePAVFr+9lfMnF/OD8yYyJH/f7gYVyWR7OxM4UAYMGLB7+bnnnuOpp57ihRdeoKCggNNOO63Teyn69++/ezknJ4f6+voej0vn6r2cuzPv5Upumr+UPn2Mn180mfMmd3pBmoikyKBBg9i2rfPZcGtqahg2bBgFBQWsWLGCF1988QBHt4cSRi+2dccuvvtwOQvKNzCtbDi3XHgspcMKog5LpNcpLCzklFNOYeLEieTn5zNy5Mjd26ZPn86dd97J+PHjOfLIIznppJMiizOr5vSeOnWqawKlxPxr9btc/dCrbNq+k2+eeSQz33coOaoFSC+1fPlyxo8fH3UYB0Rnn9XMXnb3qd211RlGL7OzqZmfPP46d//jDQ4dMYB7Lj+FiSVDog5LRDKAEkYvsvKdbXx9zius2LCNy04aw3fPHq8b0kQkYUoYvUBLi3PfC2/y48dWMDivL7M/M5UPHDWy23YiIvGUMLLcxtoGvjXvNf6+spoPHHUQ/3XBMYwY1L/7hiIi7ShhZLHHl27g2j++Rn1jMz88fyIzThzdK4ZwFpHUUMLIQtt3NvHDR5cxd+E6JpYM5tZPTeHwgwZGHZaIZLjox36QHrVk3VbOue0fPLhoHV8+7TD+9OVTlCxE0tzWrVv55S9/uU9tb731Vnbs2NHDEXVOCSNLNDW3cNvTq7jgjudpbHbmfOEkrpl+FP366j+xSLrLlIShLqkssG7zDq56cAmL3trCeZOLmaVxoEQySvzw5meeeSYHHXQQDz30EDt37uRjH/sYP/jBD9i+fTsXXnghlZWVNDc38/3vf5933nmHqqoqTj/9dIqKinj22WdTGqcSRgZzd/60OMaN85dioHGgRHrCY9fChvKefc2DJ8FZN3e5OX548yeeeIJ58+bx0ksv4e6ce+65/P3vf6e6upri4mL++te/AsEYU0OGDOGWW27h2WefpaioqGdj7oQSRobaumMX3/tzBX99bT3Txg7nlk9pHCiRbPDEE0/wxBNPMGXKFADq6upYtWoVp556KldffTXXXHMNH/nIRzj11FMPeGxKGBno+dXv8s2HXuXdup18Z/qRfPF9h2kcKJGespczgQPB3bnuuuv44he/2GHb4sWLWbBgAddffz1nnHEGN9xwwwGNTRXRDLKzqZn/XLCcS3/9bwr65/DwV07hK6cdrmQhkuHihzf/8Ic/zOzZs6mrqwMgFouxceNGqqqqKCgoYMaMGXz7299m8eLFHdqmms4wMsTKd7Zx5dwlLF9fy6UnjuZ754zX1KMiWSJ+ePOzzjqLSy65hJNPPhmAgQMHcv/997N69Wq+/e1v06dPH3Jzc7njjjsAmDlzJtOnT6e4uDjlRW8Nb57m3J37ng/GgRrYvy///YljOGO8xoES6Uka3lzDm2e8jdsa+PYfXuNvK6s5/cgR/PcnjtU4UCISGSWMNPXE0g1c+6fyYJiP845mxkljNA6UiERKCSPN7NgVjAM156V1HF08mJ9fNJnDDxoUdVgiWc/ds/5H2f6WIJQw0siGmgYuvvtF3ty0nS+9/zC+eeYRGtpD5ADIy8tj06ZNFBYWZm3ScHc2bdpEXl7ePr+GEkYaeWRJjDfe3c4D/+9ETjk89XdtikigtLSUyspKqqurow4lpfLy8igtLd3n9ilPGGY2Hfg5kAPc4+43t9s+BpgNjAA2AzPcvTLc1gy03qP/trufm+p4o1Qeq6FkaL6ShcgBlpubS1lZWdRhpL2UJgwzywFuB84EKoGFZjbf3ZfF7fYT4Lfufp+ZfQD4MXBZuK3e3SenMsZ0UhGrYWLJ4KjDEBHpVKo7yKcBq919rbvvAuYC57XbZwLwTLj8bCfbe4Xahkbe3LSDSSVDog5FRKRTqU4YJcC6uOeV4bp4rwIfD5c/Bgwys8LweZ6ZLTKzF83s/M7ewMxmhvssyuT+x4pYDQATlTBEJE2lwyU43wLeb2avAO8HYkBzuG1MePfhJcCtZnZY+8bufpe7T3X3qSNGjDhgQfe01oShMwwRSVepLnrHgEPinpeG63Zz9yrCMwwzGwhc4O5bw22x8O9aM3sOmAKsSXHMkSiP1VI8JI/CgbqTW0TSU6rPMBYC48yszMz6ARcB8+N3MLMiM2uN4zqCK6Yws2Fm1r91H+AUIL5YnlWCgrfOLkQkfaU0Ybh7E/BV4HFgOfCQuy81s1lm1nqJ7GnA62a2EhgJ/ChcPx5YZGavEhTDb253dVXWqG1o5I13t6s7SkTSWsrvw3D3BcCCdutuiFueB8zrpN3zwKRUx5cOlsZqAZhYqoQhIukrHYrevZ4K3iKSCZQw0kBFVQ2jhuRRpIK3iKQxJYw0UK6Ct4hkACWMiNXtbFLBW0QyghJGxJbGanBX/UJE0p8SRsTKNSSIiGQIJYyIVcRqOHhwnubqFpG0p4QRMRW8RSRTKGFEqG5nE2tV8BaRDKGEEaFlVbW4o0mTRCQjKGFEqFx3eItIBlHCiFBFrIaDBvXnoMF5UYciItItJYwIlcdqdHYhIhlDCSMi23c2saa6TldIiUjGUMKIyLL1tbrDW0QyihJGRMorw4K35sAQkQyhhBGRilgNIwb1Z6QK3iKSIZQwIqKCt4hkGiWMCOzYpYK3iGQeJYwILKuqpUUFbxHJMEoYEdAd3iKSiZQwIlAeq6FoYH9GDtaQ5iKSOVKeMMxsupm9bmarzezaTraPMbOnzew1M3vOzErjtl1uZqvCx+WpjvVAqYjVMKlkMGYWdSgiIglLOGGY2UfNLKkEY2Y5wO3AWcAE4GIzm9But58Av3X3Y4BZwI/DtsOBG4ETgWnAjWY2LJn3T0c7djWxemOduqNEJOMkkwA+Bawys/82s6MSbDMNWO3ua919FzAXOK/dPhOAZ8LlZ+O2fxh40t03u/sW4ElgehLxpqXl64OCt66QEpFMk3DCcPcZwBRgDXCvmb1gZjPNbNBempUA6+KeV4br4r0KfDxc/hgwyMwKE2xLGMMiM1tUXV2d6MeJjO7wFpFMlVQXk7vXAvMIzhRGERzgF5vZ1/Yjhm8B7zezV4D3AzGgOYmY7nL3qe4+dcSIEfsRxoFRHqulaGA/DtYd3iKSYZKpYZxrZg8DzwG5wDR3Pws4Fri6i2Yx4JC456Xhut3cvcrdP+7uU4Dvheu2JtI2E1WEc3ir4C0imSaZM4wLgJ+5+yR3/x933wjg7juAz3fRZiEwzszKzKwfcBEwP34HMyuKK6ZfB8wOlx8HPmRmw8Ji94fCdRmrflczqzZuU8FbRDJSMgnjJuCl1idmlm9mYwHc/enOGrh7E/BVggP9cuAhd19qZrPM7Nxwt9OA181sJTAS+FHYdjPwQ4KksxCYFa7LWMtU8BaRDNY3iX3/ALwn7nlzuO6EvTVy9wXAgnbrbohbnkdQF+ms7Wz2nHFkvArd4S0iGSyZM4y+4aWxAITL/Xo+pOxVHquhcEA/Rg1RwVtEMk8yCaM6rhsJMzsPeLfnQ8peKniLSCZLpkvqS8ADZvYLwAjukfh0SqLKQg2NzazaWMcHx4+MOhQRkX2ScMJw9zXASWY2MHxel7KostCy9bU0t7gK3iKSsZI5w8DMzgGOBvJau1XcfVYK4so6uwveusNbRDJUMjfu3UkwntTXCLqkPgmMSVFcWae8sobhA/pRrIK3iGSoZIre73H3TwNb3P0HwMnAEakJK/uUq+AtIhkumYTREP7dYWbFQCPBeFLSjdaC96SSwVGHIiKyz5KpYfzFzIYC/wMsBhy4OyVRZZnlYcFbN+yJSCZLKGGEYz09HQ4K+EczexTIc/ealEaXJVoL3rpCSkQyWUJdUu7eQjBzXuvznUoWiSuP1TCsIJeSoflRhyIiss+SqWE8bWYXmKq2SSuP1argLSIZL5mE8UWCwQZ3mlmtmW0zs9oUxZU1GhqbWfWOhjQXkcyXzJ3ee5uKVbqwYsM2mlTwFpEskHDCMLP3dbbe3f/ec+Fkn3IVvEUkSyRzWe2345bzgGnAy8AHejSiLFNRWcPQglxKh6ngLSKZLZkuqY/GPzezQ4BbezyiLFMeq2GSCt4ikgWSKXq3VwmM76lAslFDYzMr39mm7igRyQrJ1DD+l+DubggSzWSCO76lC6+r4C0iWSSZGsaiuOUmYI67/6uH48kq5ZrDW0SySDIJYx7Q4O7NAGaWY2YF7r4jNaFlvopYDUPyVfAWkeyQ1J3eQPyRLx94qmfDyS4qeItINkkmYeTFT8saLhf0fEjZYWeTCt4ikl2SSRjbzey41idmdjxQ310jM5tuZq+b2Wozu7aT7aPN7Fkze8XMXjOzs8P1Y82s3syWhI87k4g1cq9v2EZjswreIpI9kqlhfAP4g5lVEUzRejDBlK1dMrMcglFuzyS4DHehmc1392Vxu10PPOTud5jZBGABMDbctsbdJycRY9pQwVtEsk0yN+4tNLOjgCPDVa+7e2M3zaYBq919LYCZzQXOA+IThgOtU9ENAaoSjSmdtRa8DxmugreIZIeEu6TM7ApggLtXuHsFMNDMvtJNsxJgXdzzynBdvJuAGWZWSXB28bW4bWVhV9XfzOzULuKaaWaLzGxRdXV1oh8n5YI5vAer4C0iWSOZGsYXwhn3AHD3LcAXeiCGi4F73b0UOBv4XTjD33pgtLtPAb4J/N7MOkyK7e53uftUd586YsSIHghn/+1saub1DSp4i0h2SSZh5MRPnhTWJ/p10yYGHBL3vDRcF+/zwEMA7v4CwcCGReGsfpvC9S8Da4Ajkog3Mis31KngLSJZJ5mE8X/Ag2Z2hpmdAcwJ1+3NQmCcmZWZWT/gImB+u33eBs4AMLPxBAmj2sxGhEkJMzsUGAesTSLeyFRUqeAtItknmaukriGYde/L4fMngXv21sDdm8zsq8DjQA4w292XmtksYJG7zweuBu42s6sICuCfcXcP59+YZWaNQAvwJXffnMyHi0p5rIbBeX0ZPVy3qYhI9jB3736vDDF16lRftGhR9zum2Lm/+CcD+/fl9184KepQRES6ZWYvu/vU7vZL5iqpcWY2z8yWmdna1sf+hZl9djW1sGK95vAWkeyTTA3jN8AdBCPVng78Frg/FUFlspXvbGNXc4uukBKRrJNMwsh396cJurHecvebgHNSE1bmqtAd3iKSpZIpeu8M749YFRayY8DA1ISVucpjNQzK68uYQhW8RSS7JHOGcSXB6LRfB44HZgCXpyKoTFYRq+HoYt3hLSLZJ+GE4e4L3b3O3Svd/bPufoG7v9i6PZzCtVdrbG5h+QYVvEUkOyVzhtGdU3rwtTLSyne2satJBW8RyU49mTB6PRW8RSSbKWH0oPJYDQP792Vs4YCoQxER6XE9mTB6fZW3PFbL0cWD6dOn138VIpKFkrnTe1I3u/x8P2PJaI3NLSxfX6vuKBHJWsmcYfzSzF4ys6+YWYejorvf23NhZZ5V79Sxq6mFSaVKGCKSnZK5rPZU4FKC+S1eNrPfm9mZKYssw7QWvHWFlIhkq6RqGO6+CrieYKjz9wO3mdkKM/t4KoLLJK0F7zIVvEUkSyVTwzjGzH4GLAc+AHzU3ceHyz9LUXwZozxWwwQVvEUkiyVzhvG/wGLgWHe/wt0XA7h7FcFZR6/VpIK3iPQCCQ0+GE6VGnP333W2vav1vcWqjXXsbGpRwhCRrJbQGYa7NwOHhPNySzvlKniLSC+QzPDmbwD/MrP5wPbWle5+S49HlWEqYjUM6JfDoUUqeEuGc4eGrVC7HmqrYFtVsBz/d8cWGFwMhYfB8EPDRxkMPwzyh0b9CVKjpRlqY7B5bfDYtAY2vxEsNzXEfQ9xj2FjoG//qCPvUckkjDXhow8wKDXhZKbyWA1HFw9RwVvSW3MT1G3omABq2yWFpvqObQsKgyQxqBgOOjo4eL7xd3h1Ttv98oe3PWjGJ5X8YZDOw/43N0FtZZgM1u5JCJvXwpY3oHnXnn375sGwsuBz9e0f7FO5EHbW7tnH+sCQ0rjvI+67GDYWcvMO+EfcXwknDHf/QSoDyVStBe9Lpo2JOhTpaTvrYP0SiC2GxvrgH3jf/G7+5kFuftu/B+IguXNbeFYQg22tZwfr2yaFuo2At22X0w8GHRwkglHHwpFnw6BRMHhUsG7wqOB5V7+UG+vbHlhbH2+/AOV/aPt+eUM6Hjhbk0pB4YH5npobYevbcTGviUsKb0FL4559++YH8RWNgyOnt415UDH0adej7w47Nnd83c1rYenDUL8lbmcLk0lZuzOTw4Jk0i89J2BLOGGY2QjgO8DRwO7U6O4fSEFcGWN1dR0NjS1MKh0cdSiyP5qbYOMyiL0cPhZD9XLwlv1/7b5dJJIOf/Mgt6DrfXL6wY5NexJCfFLYta3j++YNgcElwQF/5NFxCaA4OFsYXLz/B+rcfBg5IXi019gAW99q140T/hJf+qe2323/we0OnnFJZeBBycXYtCtMCu0O2pvWBOu9OS7+AVB4aPD9jP9o2/cedHBy72sGAwqDxyEndNy+Y3MnyXUNLP9L8N813qDiMJm27+Yqg/7RTXSaTJfUA8CDwEeALxHMtlfdXSMzm04wzlQOcI+739xu+2jgPmBouM+17r4g3HYd8HmgGfi6uz+eRLwHRHmlhjTPOO7BgWN3cngZqpbs6YrJHw4lxwcHkNKpUHxc0Dff1BAcBBt3hMv1Sf7dEbSPX1e/JTjot9+3qaHr+C0nPCsYBSOOhENP35MABo3a8zfqX6m5eUF8I47suK2rg3rVElg2v+1Bvd/ATn6JHxr8d+osIdWsa5uM+g0KDrzFk2HiBW1fI9lktD8KhgeP0uM7bqvfGnR7xddGNq+F1x+D7e0OswMPbls7iu/265/aakEyCaPQ3X9tZle6+9+Av5nZwr01CC/HvR04E6gEFprZfHdfFrfb9cBD7n6HmU0AFgBjw+WLCM5oioGnzOyI8IqttFERq6GgXw5lRZrePG3t2AxVi4OzhtYE0fqPMKd/0BUz9bNBkig5LvgV19lBpN+A4EFh6mNuaYHmnUEC2Z1EdgYHnAEjoE9O6mNIpb79oOjw4NFeh26j8Jf4O0thxV+hpaljm7whwZlB6QlwzKfa1k8OVHfX/sgfCvlToHhKx20NtUEy2Z0Yw7+rnwpqUq0OPxNmzEtpmMkkjNbOvfVmdg5QBQzvps00YLW7rwUws7nAeUB8wnCgtT9nSPi6hPvNdfedwBtmtjp8vReSiDnlysM5vHNU8E4PjQ3wTgVULtqTHDavCTda8Gt33IeCxFAyNeiKyMmNNORO9ekDffKDLp/eJic3ONgXHtZxW2thevPa4IfAsLFhUujuUJTB8gYHP2pGHdtx2866PckkxWcXkFzC+I9wlNqrCe76Hgxc1U2bEmBd3PNK4MR2+9wEPGFmXwMGAB+Ma/ti3H6V4bq00dTcwrL1tVw8bXTUofROLS2waXVc19Ii2FCxp3A58OCgS2nKjODsoXhy8EtUMldO3yBJDBsbdSTpof9AOHhS8DgAkrlK6tFwsQY4vQdjuBi4191/amYnA78zs4mJNjazmcBMgNGjD+yBe0319qDgrfrFgbHtnSAp7E4Qr8DOoIZEv4HB6fzJVwTJoXRq0JcvIj0m2aukvgCMjW/n7p/bS7MYwXDorUrDdfE+D0wPX+sFM8sDihJsi7vfBdwFMHXqVG+/PZXKNYd3ajQ3BYXLzWvjupcWB10REBR9Rx4NEz8eJIaS46HoiMzv1xdJc8l0ST0C/AN4iuCqpUQsBMaZWRnBwf4i4JJ2+7wNnAHca2bjCS7ZrQbmA783s1sIit7jgJeSiDflWgveh45QwTtpuwubazu59PGttoXNoWNg9IlQ8pUgORx8TPRXAIn0QskkjAJ3vyaZF3f3JjP7KvA4wSWzs919qZnNAha5+3yCmsjdZnYVQQF8qv5ZAAAOc0lEQVT8M+7uwFIze4igQN4EXJFuV0iVx2qYMEoF7y417Wp72WP8pY9dXQ9/8ESYcO6e6+FHHAkDiqL7DCKyWzIJ41EzO7v1HolEhfsvaLfuhrjlZcApXbT9EfCjZN7vQGlucZZV1fKpEw7pfudsFn9z1qZ219Sn6/XwIrJPkkkYVwLfNbOdBJfYGuDu3itvcV5TXUd9Y3PvqF801sOWNzsmhM1roaaSjsM/ZPD18CLSpWSuktKAg3F23+FdmuEJwx0aajqOP1QTd+NUbbtrDVoHmBt9crsRS7P8eniRXq7bhGFmR7n7CjM7rrPtrTPv9TblsRryc3M4LJ0L3s1NsH1jF4PSxSWHxu0d2xYUBcmg7H3thmQoC0YdFZFeJ5EzjG8S3OfwU9oOdWnh8145+GBFOId3ZAXvnXVdJIC4Qenq3uk4eF6f3D2jkY6cCOM+vGdE0tYxiAaNysihl0UktbpNGO4+M1w8G/gK8F6CRPEP4I7UhZa+mlucpakqeLe0wI534w78rXMVtDsraL1hLV7ekD0jkh40IS4RlOwZpbSgsOOwzCIiCUim6H0fUAvcFj6/BPgtcGFPB5Xu1oYF7x6fkvXFO+GpmzpOYGM5MHBkcNAvGgdl7283X0H4t59m/BOR1EkmYUx09/hB7581s2Vd7p3FevwO75YWePL78MIv4PAPwhHT205iM/Ag3cUsIpFLJmEsNrOT3P1FADM7EViUmrDSW3mshrzcPhw2ogd+0Tc2wJ+/FMzINW0mTL9ZyUFE0lIiV0mVE9QscoHnzezt8PkYYEVqw0tPFeEd3n1z9rMWUL8F5l4Kb/0LzpwF7/m67lMQkbSVyBnGR1IeRQZpLXh/8vjS/XuhrevggU8EN8Nd8GuY9ImeCVBEJEUSuUrqrQMRSKZ44906duzaz4L3hnK4/xPBHdSX/Sm410FEJM0lU8MQ4gre+3qH95pn4cHLglm0PvdYMEy3iEgG0AX5SSqvrCUvtw+H78sd3q/ODbqhho6Gzz+pZCEiGUUJI0kVsRrGJ1vwdod//BQe/iKMeU9wZjEkrWabFRHplhJGElpanKVVNcndf9HcBH/9Jjw9CyZdCJf+UfNKi0hGUg0jCWvf3c72ZAreu7bDvM/DysfgvVfBB27QsBwikrGUMJJQkcwd3tvfhd9fCFWvwNk/gWlfSHF0IiKppYSRhPJYDf379mHcQd0UvDetCYrbtVXwqfvhqHMOTIAiIimkhJGE8kQK3pUvB2cW3gKX/wUOmXbgAhQRSSF1qCeoJZzDe6/dUa8/BveeA/0HBpfNKlmISBZRwkjQG5u2U7ezqeuEsWg2zL0EDjoqSBZFhx/YAEVEUkxdUglqLXh3uELKHZ75D/jHT4LZ6z75G81LISJZSQkjQeWVNfTr24dxI+MK3k274C9fh1fnwHGXwzm3QI6+UhHJTinvkjKz6Wb2upmtNrNrO9n+MzNbEj5WmtnWuG3NcdvmpzrWvWkteOe2FrwbaoPi9qtz4PTr4aM/V7IQkayW0iOcmeUAtwNnApXAQjOb7+67Z+pz96vi9v8aMCXuJerdfXIqY0xESzik+flTioMVtevhgU9C9XI475cw5dJoAxQROQBSfYYxDVjt7mvdfRcwFzhvL/tfDMxJcUxJe2vzjj0F740r4NdnwpY34JIHlSxEpNdIdcIoAdbFPa8M13VgZmOAMuCZuNV5ZrbIzF40s/O7aDcz3GdRdXV1T8XdRuuQ5tP6rIDZH4LmXfDZBcH82yIivUQ6XVZ7ETDP3Zvj1o1x96nAJcCtZnZY+0bufpe7T3X3qSNGjEhJYBWxGs7L/TdjF1wKA0cGl82OOjYl7yUikq5SnTBiwCFxz0vDdZ25iHbdUe4eC/+uBZ6jbX3jgCld8Rt+nvNzrOR4+NzjMGxMFGGIiEQq1QljITDOzMrMrB9BUuhwtZOZHQUMA16IWzfMzPqHy0XAKcCy9m1TqqUFf+xaPl37K8qHnAaX/RkKhh/QEERE0kVKr5Jy9yYz+yrwOJADzHb3pWY2C1jk7q3J4yJgrrt7XPPxwK/MrIUgsd0cf3VVyjU2wMMzsWWP8Oumsyh4z81Mys07YG8vIpJuUn7jgLsvABa0W3dDu+c3ddLueWBSSoPryo7NwTAfb7/A0knX8MOFx/Jo6bBIQhERSRe606y9LW8FQ5NveRM+8Rvmvz2efjlvcsTIQVFHJiISqXS6Sip6618N7rGoeyeoV0z8OOWxGo48eBD9+uqrEpHeTUfBVqufht+cDTn94HNPwNhTcHcqYjWJT8kqIpLF1CUF8Pa/g3GhRoyHS/8Ag0cFqzfvoLZhL0Oai4j0IkoYACXHw/u+Ayd9GfIG715dnswc3iIiWU4JA4JRZk+7psPq8lgNuTnGEQd3M4e3iEgvoBrGXlSEBe/+fXOiDkVEJHJKGF0ICt7dzOEtItKLKGF0Yd3memrqG3WFlIhISAmjCyp4i4i0pYTRhdaC95EH6w5vERFQwuhSRayGI0aq4C0i0koJoxPuTnmsRt1RIiJxlDA6UblFBW8RkfaUMDqhgreISEdKGJ0oj9XQt48K3iIi8ZQwOtFa8M7LVcFbRKSVEkY7KniLiHROCaOdyi31bN3RyMRSJQwRkXhKGO1UqOAtItIpJYx2WgveR6ngLSLShhJGO+WxGsap4C0i0oESRpzWObwnlQzufmcRkV4m5QnDzKab2etmttrMru1k+8/MbEn4WGlmW+O2XW5mq8LH5amONba1ni07GlW/EBHpREqnaDWzHOB24EygElhoZvPdfVnrPu5+Vdz+XwOmhMvDgRuBqYADL4dtt6Qq3taCt4YEERHpKNVnGNOA1e6+1t13AXOB8/ay/8XAnHD5w8CT7r45TBJPAtNTGWx5rIacPsb4UeqSEhFpL9UJowRYF/e8MlzXgZmNAcqAZ5Jpa2YzzWyRmS2qrq7er2DLY7WMO2igCt4iIp1Ip6L3RcA8d29OppG73+XuU9196ogRI/b5zfcUvNUdJSLSmVQnjBhwSNzz0nBdZy5iT3dUsm33W1VNA5u372KS7vAWEelUqhPGQmCcmZWZWT+CpDC//U5mdhQwDHghbvXjwIfMbJiZDQM+FK5LifJKFbxFRPYmpVdJuXuTmX2V4ECfA8x296VmNgtY5O6tyeMiYK67e1zbzWb2Q4KkAzDL3TenKtaKsOA9QQVvEZFOpTRhALj7AmBBu3U3tHt+UxdtZwOzUxZcnPJYjQreIiJ7kU5F78i0FrzVHSUi0jUlDGB9TQObtu/SFVIiInuhhAHsamrhnEmjOH7MsKhDERFJWymvYWSCsUUDuP3S46IOQ0QkrekMQ0REEqKEISIiCVHCEBGRhChhiIhIQpQwREQkIUoYIiKSECUMERFJiBKGiIgkxOIGiM14ZlYNvLUfL1EEvNtD4WQ6fRdt6fvYQ99FW9nwfYxx925noMuqhLG/zGyRu0+NOo50oO+iLX0fe+i7aKs3fR/qkhIRkYQoYYiISEKUMNq6K+oA0oi+i7b0feyh76KtXvN9qIYhIiIJ0RmGiIgkRAlDREQSooQBmNl0M3vdzFab2bVRxxMlMzvEzJ41s2VmttTMrow6pqiZWY6ZvWJmj0YdS9TMbKiZzTOzFWa23MxOjjqmKJnZVeG/kwozm2NmeVHHlEq9PmGYWQ5wO3AWMAG42MwmRBtVpJqAq919AnAScEUv/z4ArgSWRx1Emvg58H/ufhRwLL34ezGzEuDrwFR3nwjkABdFG1Vq9fqEAUwDVrv7WnffBcwFzos4psi4+3p3XxwubyM4IJREG1V0zKwUOAe4J+pYomZmQ4D3Ab8GcPdd7r412qgi1xfIN7O+QAFQFXE8KaWEERwM18U9r6QXHyDjmdlYYArw72gjidStwHeAlqgDSQNlQDXwm7CL7h4zGxB1UFFx9xjwE+BtYD1Q4+5PRBtVailhSKfMbCDwR+Ab7l4bdTxRMLOPABvd/eWoY0kTfYHjgDvcfQqwHei1NT8zG0bQG1EGFAMDzGxGtFGllhIGxIBD4p6Xhut6LTPLJUgWD7j7n6KOJ0KnAOea2ZsEXZUfMLP7ow0pUpVApbu3nnHOI0ggvdUHgTfcvdrdG4E/Ae+JOKaUUsKAhcA4Myszs34ERav5EccUGTMzgj7q5e5+S9TxRMndr3P3UncfS/D/xTPuntW/IPfG3TcA68zsyHDVGcCyCEOK2tvASWZWEP67OYMsvwigb9QBRM3dm8zsq8DjBFc5zHb3pRGHFaVTgMuAcjNbEq77rrsviDAmSR9fAx4If1ytBT4bcTyRcfd/m9k8YDHB1YWvkOXDhGhoEBERSYi6pEREJCFKGCIikhAlDBERSYgShoiIJEQJQ0REEqKEIZImzOw0jYgr6UwJQ0REEqKEIZIkM5thZi+Z2RIz+1U4X0admf0snBvhaTMbEe472cxeNLPXzOzhcPwhzOxwM3vKzF41s8Vmdlj48gPj5pt4ILyDWCQtKGGIJMHMxgOfAk5x98lAM3ApMABY5O5HA38Dbgyb/Ba4xt2PAcrj1j8A3O7uxxKMP7Q+XD8F+AbB3CyHEtx5L5IWev3QICJJOgM4HlgY/vjPBzYSDH/+YLjP/cCfwvkjhrr738L19wF/MLNBQIm7Pwzg7g0A4eu95O6V4fMlwFjgn6n/WCLdU8IQSY4B97n7dW1Wmn2/3X77OubOzrjlZvRvVNKIuqREkvM08AkzOwjAzIab2RiCf0ufCPe5BPinu9cAW8zs1HD9ZcDfwpkMK83s/PA1+ptZwQH9FCL7QL9eRJLg7svM7HrgCTPrAzQCVxBMJjQt3LaRoM4BcDlwZ5gQ4kd3vQz4lZnNCl/jkwfwY4jsE41WK9IDzKzO3QdGHYdIKqlLSkREEqIzDBERSYjOMEREJCFKGCIikhAlDBERSYgShoiIJEQJQ0REEvL/ARs3tiBu3ERgAAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAtUAAAEWCAYAAACpJ2vsAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvIxREBQAAIABJREFUeJzs3Xd4VGX2wPHvSa+EkEJLIPTeQxMRUFFQbKsiYF0L9rLruuquuq5b9LeWVexgVxRE17qggMKKhRKK9C6QBEhCQhrpyfn9cQcJEEhCMpmU83me+8zMrecGfefcd94iqooxxhhjjDHm1Hl5OgBjjDHGGGMaOkuqjTHGGGOMqSFLqo0xxhhjjKkhS6qNMcYYY4ypIUuqjTHGGGOMqSFLqo0xxhhjjKkhS6pNrRORXSJydgXrR4rIFk/EZIwxpmE50XeJMfWVj6cDME2Hqi4Bunk6DmOMMcaY2mY11abBE0eD/G9ZROzB1hhjjGkEGmQiYhqEwSKyUUQOisibIhIgIqNFJOnwDq6f9v4gImtFJEtEZotIgGtbuIh8KSJprnN8KSIx5Y5dLCL/EJEfgDzgXhFZWT4AEfm9iHx2siBF5HwRWS0i2SKSKCKPHrP9dBH5UUQyXduvc60PFJGnRWS3K/bvXeuOusdy93m26/2jIvKRiLwnItnAdSIyRER+cl1jn4i8ICJ+5Y7vJSILRCRDRFJE5E8i0kpE8kQkotx+A11/L98q/hsZY0y9JyL+IvKsiOx1Lc+KiL9rW6Tr+yHTVUYuOVzJIiL3i0iyiOSIyBYROcuzd2IaO0uqjbtcCZwLdAK6Ag+dYL+JwDigA9AXuM613gt4E2gPtAPygReOOfZqYCoQCkwDOohIj2O2v1NJnIeAa4DmwPnArSJyMYCItAfmAc8DUUB/YI3ruKeAQcBpQAvgj0BZJdc67CLgI9c1ZwKlwO+ASGA4cBZwmyuGUGAh8BXQBugMfKOq+4HFOH+/8vc7S1WLqxiHMcY0BH8GhuGUwf2AIRz5TrkXSMIpo1sCfwJURLoBdwCDVTUU5/toV92GbZoaS6qNu7ygqomqmgH8A5h8gv2mqepe135f4BSaqGq6qn6sqnmqmuM6x6hjjn1LVTeoaomqFgKzgavAqd0F4oAvTxakqi5W1XWqWqaqa4EPyl1nCrBQVT9Q1WJXTGtctSDXA3erarKqlqrqj64YquInVf3Udc18VV2pqktd97ELeLVcDBOA/ar6tKoWqGqOqi5zbXu73P164/yN361iDMYY01BcCTymqqmqmgb8FacSAaAYaA20d5XTS1RVcSor/IGeIuKrqrtUdYdHojdNhiXVxl0Sy73fjVPLWpH95d7nASEAIhIkIq+6mldkA98BzV3JY0XXACfJnCIiglPgflhZoisiQ0VkkavZRBZwC06NMUAsUFEhHAkEnGBbVRwVt4h0df18ud91r/+sQgwAn+F8YXQAxgJZqrr8FGMyxpj6qg3O98hh5b9TngS2A/NFZKeIPACgqtuBe4BHgVQRmSUiJ/oeMqZWWFJt3CW23Pt2wN5qHn8vzkghQ1W1GXCGa72U20fLH6CqS4EiYCROLXNVam3fBz4HYlU1DHil3DUScZqvHOsAUHCCbYeAoMMfXA8BUcfso8d8fhnYDHRx3eufjomhY0WBq2oB8CFObfXVWC21MaZx2ovTFPCwX79TXL/e3auqHYELgd8fbjutqu+r6umuYxX4v7oN2zQ1llQbd7ldRGJEpAVOe7jZ1Tw+FKcddabrHH+p4nHv4LS9LlbV76t4nQxVLRCRITjJ+GEzgbNFZKKI+IhIhIj0V9Uy4A3gGRFpIyLeIjLc1XFmKxDg6gDpi9Puz78KMWQDuSLSHbi13LYvgdYico+rs06oiAw95n6vw/kysaTaGNMYfQA8JCJRIhIJPAK8ByAiE0Sks+sXyiycZh9lItJNRM50lcsFON8nVe33YswpsaTauMv7wHxgJ07zhb9X8/hngUCcWuGlOB31quJdoDeuArcKbgMeE5EcnIL6w8MbVHUPcB5OrXkGTifFfq7NfwDWAStc2/4P8FLVLNc5XwOScWqujxoNpAJ/wEnmc4AZlHsAcbUnHwtcgNNUZhswptz2H3C+KFapavmfR40xprH4O5AArMUpd1dx5DulC05n7lzgJ+AlVV2EU5nxBM53yH4gGniwbsM2TY047fmNaRxEJBBIBQaq6jZPx1MXRORb4H1Vfc3TsRhjjDFNlU08YRqbW4EVTSihHgwMxBmmzxhjjDEeYkm1aTREZBdOB7+Lj1m/gaM7uRx2s6rOrIPQ3EJE3sa517tdzUSMMcYY4yHW/MMYY4wxxpgaso6KxhhjjDHG1FCDbP4RGRmpcXFxng7DGGOqbeXKlQdU9dixyxs1K7ONMQ1ZVcvtBplUx8XFkZCQ4OkwjDGm2kSkyQ19aGW2MaYhq2q5bc0/jDHGGGOMqSFLqo0xxhhjjKkhtybVIvKGiKSKyPoTbBcRmSYi20VkrYgMdGc8xhhjjDHGuIO721S/BbwAvHOC7eNxphjtAgwFXna9GmMaqeLiYpKSkigoKPB0KG4VEBBATEwMvr6+ng7FGGNOWVMps6Hm5bZbk2pV/U5E4k6yy0XAO+oMlr1URJqLSGtV3efOuIwxnpOUlERoaChxcXGIiKfDcQtVJT09naSkJDp06ODpcIwx5pQ1hTIbaqfc9nSb6rZAYrnPSa51xxGRqSKSICIJaWlpdRKcMab2FRQUEBER0agLZxEhIiKiSdTsGGMat6ZQZkPtlNueTqqrTFWnq2q8qsZHRTWpIV6NaXQae+EMTeMejTFNQ1Mpz2p6n54epzoZiC33Oca1zhhj3KpMlaz8YkpKFT8fL/y8vfDzEby9GkxdQ6M2d90+0g8VcfWw9p4OxRhjqsTT3x6fA9e4RgEZBmRZe2pjjDsdyMjg/555ji37c0jMyGNfVj670w+xLTWHDXuz2bg3i22pOexOP8S+rHzScwvJKShm3PjxZBw86Onwm4y56/bx1NdbKCgu9XQoxhgPyszM5KWXXqr2ceeddx6ZmZluiOjE3D2k3gfAT0A3EUkSkRtE5BYRucW1y1xgJ7AdmAHc5s54jDFNV1FJGXsz81m5NYkZr76Cv48XHSKD6dm6GZ2jQ2jTzI9WYQE0C/TFW4SC4lIO5BaRnJnPLwcO8a8ZH5B8SNi8L5sdabkkZuRZwudGU4a0Iyu/mHnrrZ7FmKbsREl1SUnJSY+bO3cuzZs3d1dYFXL36B+TK9muwO3ujMEY07TlF5WSlltIVl4xAC/+628k79nFb8aejq+vLwEBAYSHh7N582a2bt3KxRdfTGJiIgUFBdx111389oabKCoto2fXzsxb9D0Z2TlcPfFiBg4exvrVCcTGtOWzzz4jMDDQw3fauAzrGEFcRBAfLEvkkgExng7HGOMhDzzwADt27KB///6Vltl33303U6dOBSAuLo6EhARyc3MZP348p59+Oj/++CNt27qvzPZ0m2pjTBP21y82sHFvdq2es2ebZjwyoSe5hSWk5RSSW1iClwgRIX5Ehvgz7ZknmbB1E2vWrGHx4sWcf/75rF+//tchlN544w1atGhBfn4+gwcP5rLLLiMiIgIvgZbNAgj2KmH3zh18/OFs+vfvz8SJE/n444+56qqravU+mjovL2HSkHY8MW8z21Nz6Rwd4umQjGny3FVm/+WCXifc/sQTT7B+/foql9mXXnopERERR51j27ZtfPDBB8yYMcOtZbYl1cYYtykuLSMrv5is/GKyXa+hRSWk5xZSWqYcKiyhsKQMUFRBBATBS5xe2CLgVc3e2IUlZWxPzSW/uBQfby9ahQXQIsgPH++KW7sNGTLkqDFJp02bxieffAJAYmIi27ZtO66A7tChA/379wdg0KBB7Nq1q1oxmqq5bFAMT8/fwqzle3hoQk9Ph2OMqQfqc5ltSbUx9VR6biGfrE5m0ZZU4tu3YOLgWNo2r59NDPZm5vPD9gP8uCOdTfuyf02k84qOb3M848LW+GbmA3DN8Di8vQQvEby9hNIypai0DKdl2BG+3odH53AWX28v/F2vvt5CmULGoSLScwspKi2jTCEmPIjmQb6VJuXBwcG/vl+8eDELFy7kp59+IigoiNGjR1c4Zqm/v/+v7729vcnPz6/W38tUTWSIP2N7tuTjVUn84dxuBPh6ezokY5q0k9Uo15X6XGZbUm1MPVJWpvyw4wCzViQyf8N+ikuVDpHBTNuxjWnfbuOMLlFMGhzLWT1a4ufjucF7Mg4V8dOOdH7YcYAftx9gV3oeAC2C/RgQ25w+bcMIC/SlWaAvYa6lWaAPYYG++Obso0frZniL4OV1fMKrqpSUKUUlZc5SeuQ1t7CE4ryyo/YXEQRniLxgfx/aNA8kNMDnhOONhoaGkpOTU+G2rKwswsPDCQoKYvPmzSxdurRmfyhTY5OHtGPuuv18vWE/F/WvcG4wY0wj1pDKbEuqjakH9mXlMychiQ8TEkk6mE/zIF+uHhbHFYNj6dYqlMSMPOasTGJOQiK3zlxFZIgflw6MYeLgWDpFub+t6aHCEpb/kvFrbfTGfU6bumA/b4Z2jOCqYe0Z0TmSbi1DK0yUy9u0KQXfEzTFACdJ9vUWfL29CPY/fnuZKsXHJNtlZRAe7EuQX+VFWkREBCNGjKB3794EBgbSsmXLX7eNGzeOV155hR49etCtWzeGDRtW6fmMe43oFElsi0A+WL7HkmpjmqCGVGbLsT+zNgTx8fGakJDg6TCMqZHi0jK+3ZzK7BWJLN6SSpnCiM4RXDG4Hef0bFnhT92lZcp3W9OYtWIP32xKpaRMGRLXgisGx3Jen9YE+tXOz+OFJaWs2ZPJDzvS+XH7AdYkZlJSpvh5ezGwfXNGdIrktM6R9I0JO2mCXJFNmzbRo0ePWomzvqvoXkVkparGeygkj6hpmf3iou08+fUWvr13FB3r4CHSGHNEUyqzoWblttVUG1PHdh04xOyERD5amURaTiHRof7cOroTV8S3o11E0EmP9fYSxnSPZkz3aFJzCvh4ZTKzV+zh3jk/8+gXG7i4f1uuGBxL77ZhJz2PqpKZV0ziwTz2ZOSRmJHPnow8klyf92bmU1yqeAn0aRvGTWd05LROEcS3b1FribsxVXV5fAz/XrCV2SsSefC8pvPlboxpWCypNqYOFBSX8vWG/XywfA9Ld2Y4yXG3aCYNjmV0t6gTjkxxMtGhAdw6uhO3jOrIsl8ymLV8D7MTEnl36W56t23GpMHtGBzXgr2Z+a7E2ZVAH8wnMSOP3MKjB84PD/KlXYsgercNY3zv1gxo15xhHSMIC/StrT+DMackOjSAs3pEM2dlEr8/pyv+PvZgZ4ypfyypNsaNikrKmL1iD89/u53UnELatQjivnO7cdmgGFo2C6iVa4gIwzpGMKxjBH/NK+bTNcl8sHwPD326/qj9Any9iA0PIrZFEEPiwolt4bxv53oN8bfiwNRfk4e04+sNKSzYmMKEvm08HY4xxhzHvkWNcYPSMuWT1ck8u3ArSQfzGRwXztMT+zGiU2SlHflqIizIl2tPi+Oa4e1Zm5TFrvRDxIQHEdsikKgQ/xOOiGFMfTeySxRtmzsdFi2pNsbUR5ZUG1OLVJWv1u/n6QVb2Z6aS++2zfj7xb0Z1TWqThNaEaFfbHP6xTavs2sa407eXsKkwbE8vWAruw4cIi4yuPKDjDGmDnluoFtjGhFVZfGWVC544XtunbkKgJevHMgXd5zO6G7RVkNsTC24PD4Wby9h1opET4dijDHHsaTamBpa/ksGV7y6lOveXEFmXjFPX96Pr+85g/F9WlsyXQ9lZmby0ksvndKxzz77LHl5ebUckamqVmEBnNk9mo9WJlJUUlb5AcaYBq8hldmWVBtzitYlZXHtG8uZ+OpP7Eo/xN8u7s23947m0kExeLux3bSpmYZUQJvjTR4Sy4HcIr7ZlOLpUIwxdaAhldnWptqYatqWksMzC7Yyb/1+mgf58uD47lwzPM7Gb24gHnjgAXbs2EH//v0ZO3Ys0dHRfPjhhxQWFnLJJZfw17/+lUOHDjFx4kSSkpIoLS3l4YcfJiUlhb179zJmzBgiIyNZtGiRp2+lSRrVNZrWYQG8v3wP4/u09nQ4xhg3a0hltiXVxlRRYkYe/164lU9XJxPk58PdZ3XhxpEdCA2wcZxP2bwHYP+62j1nqz4w/okTbn7iiSdYv349a9asYf78+Xz00UcsX74cVeXCCy/ku+++Iy0tjTZt2vDf//4XgKysLMLCwnjmmWdYtGgRkZGRtRuzOV5eBogXBB7d2dbbS7hicCzPLtxGYkYesS1OPmGSMaYWWZl9Utb8w5hKpGQX8NCn6zjz6cX8d+0+bhzZke/+OIbfje1qCXUDN3/+fObPn8+AAQMYOHAgmzdvZtu2bfTp04cFCxZw//33s2TJEsLCTj5DpallqvDxjfD6WEjfcdzmifGxeAnMWrHHA8EZYzylvpfZVlNtzAkcPFTEK//bwVs/7qK0TJk0JJY7z+xSa5O2GE5aO1EXVJUHH3yQm2+++bhtq1atYu7cuTz00EOcddZZPPLIIx6IsIkSgZH3wuyr4LWzYOI70OGMXze3aR7ImG7RzElI4p6zu+J7CjOSGmNOgZXZJ2UlkTHHyCko5tmFWxn5r0VMX7KT8/u05tt7R/P3i/tYQt0IhIaGkpOTA8C5557LG2+8QW5uLgDJycmkpqayd+9egoKCuOqqq7jvvvtYtWrVccc2dCIyTkS2iMh2EXngBPtMFJGNIrJBRN4vt75URNa4ls/dEmDcCLjpWwhpCe9eAivfOmrz5CHtSM0p5NvNqW65vDGmfmhIZbbVVBvjUlBcyjs/7eLlxTs4mFfMuF6t+P05XenaMtTToZlaFBERwYgRI+jduzfjx49nypQpDB8+HICQkBDee+89tm/fzn333YeXlxe+vr68/PLLAEydOpVx48bRpk2bBt1RUUS8gReBsUASsEJEPlfVjeX26QI8CIxQ1YMiEl3uFPmq2t/tgbboADfMh4+uhy/uhrQtcM7fwcub0d2iaNnMnw+W7+HcXq3cHooxxjMaUpktqur2i9S2+Ph4TUhI8HQYppEoKinjw4REnv92GynZhYzsEskfzulmsxG6yaZNm+jRo4enw6gTFd2riKxU1XgPhXQ4huHAo6p6ruvzgwCq+ni5ff4FbFXV1yo4PldVQ6p6vRqX2aUlsOBhWPoSdB4Ll70BAc14Zv4Wnl+0nSV/HENMuHVYNMYdmlKZDTUrt635h2mySsuU/6xK4qxnFvPQp+uJDQ9i1tRhvHvDUEuoTWPXFig/LWGSa115XYGuIvKDiCwVkXHltgWISIJr/cUVXUBEprr2SUhLS6tZtN4+MO5xmPBv2LnI6cCY8QsTB8cC8KHNsGiMqQes+YdpclSVrzfs5+n5W9mWmkuvNs1487rejO4WZTMgGnOED9AFGA3EAN+JSB9VzQTaq2qyiHQEvhWRdap61DAdqjodmA5OTXWtRBR/PbToBB9eA6+dRcwV7zGqaxSzExK566wu+FiHRWOMB1kJZJqM7ak5TPtmG+c++x23vLeKUlVenDKQL+44nTHdoy2hrkMNsdlZddXze0wGYst9jnGtKy8J+FxVi1X1F2ArTpKNqia7XncCi4EB7g74Vx1HOR0YA8Ph7Qu5N2oFKdmFLN5Sw9pwY8wJ1fPyrNbU9D6tpto0WqrKpn05fLV+H3PX72d7ai4iMKhdOE9e1pdLBrS1mi0PCAgIID09nYiIiEb7IKOqpKenExBQb0eLWQF0EZEOOMn0JGDKMft8CkwG3hSRSJzmIDtFJBzIU9VC1/oRwL/qLnQgohPcuBDmXEefhD/xt6ALmbUsgrN7tqzTMIxpCppCmQ21U25bUm0aFVVlXXIWc9ft56v1+9iVnoeXwNAOEVwzvD3n9mplw+J5WExMDElJSdS4nW09FxAQQExMjKfDqJCqlojIHcDXgDfwhqpuEJHHgARV/dy17RwR2QiUAveparqInAa8KiJlOL92PlF+1JA6ExgOV34EXz3I1Stm0HpnEvtSP6R1dFSdh2JMY9ZUymyoeblto3+YBq+sTFmdeJB56/Yzb/1+kjPz8fEShneK4Lw+rRnbsyWRIf6eDtMYoH6M/lHX3F1mH1z0IqGLH+JgcEeipn4Czdu57VrGmKanquW21VQbj8ouKCY9t+iUjt2fVcDXG/Yzb/0+UrIL8fP2YmSXSO45uwtje7akeZBfLUdrjKmPwsfczv9tFG5L+xs640zkipnQbqinwzLGNDGWVBuPWZ+cxaTpS8ktLDnlc/j7eDG6WxTn9WnNmO7RNAvwrcUIjTENRd8zLuHi9334IuQFgt6eAGP+BMNuBx97uDbG1A1Lqo1H7M8q4Ia3V9AswIfHLuqF1yl0fgjx92F4pwiC/e0/Y2OaurN7tuTh4I48GPEszwW+DgsfhdUz4bwnodMYT4dnjGkCLBsxde5QYQk3vL2C3IISPrr1NHq0bubpkIwxDZyvtxeXDYphxpKdPHj/67QatATm3gfvXgy9LoFz/gFhx85vY4wxtcfGEzN1qrRMuXvWGjbty+aFKQMtoTbG1JpJg2MpLVPmJCRCl7Fw21IY8xBsmQcvDIYfnoOSU+vDYYwxlbGk2tSpx+duYuGmFP5yQS/GdI/2dDjGmEYkLjKYEZ0jmLUikdIyBd8AGHUf3L4MOo6GBY/AK6fDzv95OlRjTCNkSbWpMzOX7ea173/h2uHtufa0OE+HY4xphCYPaUdyZj5fb9h/ZGV4HEx+H6Z8CKWF8M6FMOe3kL3XY3EaYxofS6pNnViyLY1HPtvA6G5RPDyhp6fDMcY0Uuf0bEX3VqE89Ol6UrILjt7Y9Vy4bRmM/hNsmetqEjINSos9E6wxplGxpNq43baUHG57bxVdokN4fvIAmxrcGOM2fj5evDBlAHlFJfxu9hqnGUh5vgEw+n6nvXXc6bDgYadJyC/feSZgY0yj4fbsRkTGicgWEdkuIg9UsL29iHwjImtFZLGI1M95fc0pOZBbyG/fWoG/rzevXzeYUBtH2hjjZp2jQ3n0gl78uCOdV/63o+KdWnSAKbNh8iwozoe3L4CPboDsfXUbrDGm0XBrUi0i3sCLwHigJzBZRI797f8p4B1V7Qs8BjzuzphM3SkoLuWmdxI4kFvI69fG07Z5oKdDMsY0EVcMjuX8vq15ZsFWVu05eOIdu413OjKOuh82fQHPD4Jv/wEF2XUXrDGmUXB3TfUQYLuq7lTVImAWcNEx+/QEvnW9X1TBdtMAlZUpf5jzM6v3ZPLvif3pF9vc0yEZY5oQEeGfl/ShVbMA7vpgNVn5J2k37RvozMB4+1Loeg589y+Y1h+WvgwlhXUXtDGmQXN3Ut0WSCz3Ocm1rryfgd+43l8ChIpIhJvjMm727MKtfLl2H/eP6874Pq09HY4xpgkKC/Rl2uQB7Msq4M+frENVT35Ai45w+Vtw0yJo2Ru+egBeiIefZ0FZaZ3EbIxpuOpDj7E/AKNEZDUwCkgGjiu9RGSqiCSISEJaWlpdx2iq4eOVSUz7djsT42O4ZVRHT4djjGnCBrUP5/dju/Ll2n18mJBY+QEAbQfCtZ/D1Z9AYDh8cjO8egZsnQ+VJebGmCbL3Ul1MhBb7nOMa92vVHWvqv5GVQcAf3atyzz2RKo6XVXjVTU+KirKnTGbGli2M50H/rOW4R0j+PvFfRART4dkjGnibhnVidM6RfDo5xvZnppT9QM7nQk3LYZLX4eiQ/D+5fDW+ZC4wm2xGmMaLncn1SuALiLSQUT8gEnA5+V3EJFIETkcx4PAG26OyVTg+20HuOD577nytaU8PncTn/+8l51puZQdOxzVSew6cIib31tJbHgQr1w1CD+f+vBDiDGmqfP2Ev59RX8C/by54/3VFBRXoymHlxf0uQxuXw7nPQUHtsLrZ8OsKyFtq/uCNsY0OD7uPLmqlojIHcDXgDfwhqpuEJHHgARV/RwYDTwuIgp8B9zuzpjM0YpKynh6/hZe/W4n7SOCEIE3f9hFUWkZACH+PvRs3YzebcPo3dZ57RgZfNxY05l5RVz/llN788Z1gwkLsqHzjDH1R8tmATx1eV+ufyuBJ+Zt5tELe1XvBD5+MOQm6DcZlr4EPzznTCAz4CoY/SA0a+OewI0xDYZbk2oAVZ0LzD1m3SPl3n8EfOTuOMzxdqblctes1axPzmbK0HY8fH5PAv28KSopY1tqDhuSs1m/N4v1yVm8v3w3BcVOoh3g60WP1s3o3cZJtHu2DuOfczeReDCPmTcOIy4y2MN3Zowxxzuze0uuH9GBN374hRGdIxnbs2X1T+IfAqP+CPHXw3dPwYrXYO2HMPRmGHEPBLWo/cCNMQ2CVNobuh6Kj4/XhIQET4fRYKkqHyYk8ujnG/H39eKJ3/RlXO9WJz2mpLSMXw4cYl1yFutdyfbGvdnkFpb8us8zE/vxm4E2d48xJyMiK1U13tNx1KX6VGYXlpTym5d+JDkzn3l3j6R1WA3Hzz+4Cxb900ms/UNh+O0w7FYICKuVeI0xnlfVctuS6iYmK6+YBz9Zy9x1+xneMYJ/X9GfVmEBp3SusjJld0Ye65OzCAv05Yyu1oHUmMpYUu15O9NymfD89/RpG8b7Nw3D26sWOlTvXw+LH4fNX0JAczjtTqf22j+05uc2xnhUVctt60nWhCzdmc64575j/oYU7h/XnfduHHrKCTWAl5fQITKYC/q1sYTaGNNgdIwK4bGLerPslwxeXLS9dk7aqjdMmglT/wfthsG3f4Pn+jltr4vyaucaxph6zZLqJqC4tIynvt7C5BlL8ffx4uNbT+PW0Z1qp3bGGGMaoEsHtuWi/m14duFWEnZl1N6J2/SHKbPhxm+gdX9Y8IiTXP/0EhTn1951jDH1jiXVjdye9Dwuf+UnXli0ncsGxvDfu0balOHGmCZPRPj7xb2JCQ/i7llryMo7yTTmpyImHq7+D/z2K4juDl8/CNMGwPIZNvW5MY2UJdWN2Cerkzhv2hJ2pOXy/OQBPHl5P4L93T7gizHGNAihAc405inZBTzwn7WVT2N+KtoPh2vv+mUeAAAgAElEQVS/gGu/hPA4mPsHmDYQEt6EkqLav54xxmMsqW6EsguKuXvWan43+2d6tA5l3t0juaCfjaFqjDHH6h/bnPvO7ca89ft5f/ke912ow0j47Txn6vPQVvDlPfDCIFj9HpSWVH68Mabes6S6kVmfnMV5zy3hy7X7+P3Yrnxw0zBiwoM8HZYxxtRbN43syMgukTz2xUa2plRjGvPqEnGmPr9xIUyZA4Et4LPb4cXBsHYOlFVjpkdjTL1jSXUj88hn6ykqKePDm4dx11ldjpv50BhjzNG8vISnJ/YjNMCHW99byYFcN7d5FoGu58DUxTDpffANgv/cCC+PgI2fQwMc6tYYY0l1o5KaU8DqxEyuGtaeQe1tVi9jjKmq6NAAXpgykOTMfCZPX0pqToH7LyoC3c+Hm5fAZW9CWQl8eDVMHwVb51tybUwDY0l1I/LtplRU4ewepzD1rjGmSRGRcSKyRUS2i8gDJ9hnoohsFJENIvJ+ufXXisg213Jt3UXtXsM6RvDmdUNIOpjPpOlLScmug8QawMsLev8GblsKF78C+Znw/uXw+jmw8391E4MxpsYsqW5EFm5KoW3zQHq0thm8jDEnJiLewIvAeKAnMFlEeh6zTxfgQWCEqvYC7nGtbwH8BRgKDAH+IiLhdRi+Ww3vFMHb1w8hJauASdOXsj+rjhJrAG8f6D8Z7lwJE56F7GR450J4awLsWVZ3cRhjTokl1Y1EflEpS7YdYGzPlojYpC7GmJMaAmxX1Z2qWgTMAi46Zp+bgBdV9SCAqqa61p8LLFDVDNe2BcC4Ooq7Tgzp0IJ3bhhCWk4hV0z/ib2ZdTxpi7cvxP8W7lwF456AtM3wxjnw3mWwd3XdxmKMqbIqJ9UicoGIWBJeTy3ZlkZhSRlje1rTD2NMpdoCieU+J7nWldcV6CoiP4jIUhEZV41jEZGpIpIgIglpaWm1GHrdGNS+Be/eMISM3CKumP4TiRkemGrcNwCG3Qp3/wxnPwrJCTB9NMy+ClI21n08xpiTqk6SfAWwTUT+JSLd3RWQOTULN6UQGuDDkA7WQdEYUyt8gC7AaGAyMENEqjwdq6pOV9V4VY2PiopyU4juNaBdODNvGkpWXjGTpi9lT7oHEmsAv2A4/Xdw91oY/aDTzvrl0+DjG2HbQsjYaWNdG1MPVHl6PVW9SkSa4RSub4mIAm8CH6iqGwf2NJUpLVO+2ZTKmG7R+NoQesaYyiUDseU+x7jWlZcELFPVYuAXEdmKk2Qn4yTa5Y9d7LZIPaxvTHPev2kYV72+jEnTf+L9m4YRFxnsmWACmsHoB2DIVPhxGix7FdbNcbZ5+TozNkZ0ghadIKIjRHR23jdr63SGNMa4VbXmrFbVbBH5CAjE6bRyCXCfiExT1efdEaCp3JrEg6QfKuJsa/phjKmaFUAXEemAkyRPAqYcs8+nOJUob4pIJE5zkJ3ADuCf5TonnoPTobHR6t02jPdvHMaVry1l0vSlvH/TUDpGhXguoKAWTnOQEfdA6kZI3wEZO1yvO52a7JJy7cB9AiC8gyvhdiXbEZ2cdaGtLeE2ppZUOakWkQuB3wKdgXeAIaqaKiJBwEbAkmoPmb8xBR8vYXS3hvkTqzGmbqlqiYjcAXwNeANvqOoGEXkMSFDVz13bzhGRjUApcJ+qpgOIyN9wEnOAx1Q1o+7vom71bNOMD6YO48oZy1yJ9TA6R3swsQYIbA7tT3OW8srKIGdfuUTb9XpgG2ybD6VFR/b19ofw9k4td3gH57WF6zU8DnwD6+5+jGngRKs4uLyIvA28rqrfVbDtLFX9praDO5H4+HhNSEioq8vVe2c9vZjWYYG8d+NQT4dijKmEiKxU1XhPx1GXGlOZvS0lh8kznOHt3r9pKF1bNrAhTMtKISvJSbQP7oKMX5zXg79Axi4oOqY1Z0irckm26zWsLQRHQVAkBIZbTbdp9Kpablen+cejwL5yFwgEWqrqrrpMqM3RdqblsiPtENcMj/N0KMYY0+h1aRnKrKnDmDJjKZOnL2XmTUPp3qqZp8OqOi9vV810++O3qUJexpEk+3CifXAX/PId/DwLOKYiTrwgKMJJsINdS1Ckk3QHRxxJvoMjISTaScKNaaSqk1TPAcr/xlTqWje4ViMy1bJwUwoAZ/WI9nAkxhjTNHSODmH2zcOZPN1JrN+7cSi92oR5OqyaE3ElwhEQM+j47cUFkLnHaVpyKA3y0p3XQweOfN6/zvlckFnxNdqfDgOvhh4Xgl+Qe+/HmDpWnaTaxzVJAACqWiQifm6IyVTDgo0p9GjdjJhwK5yMMaaudIgMZvbNw5g8fSlTZixj5o1D6d22ESTWJ+MbAFFdnaUypcXHJN0HnCYnP8+CT26GuX+EvpfDwGugdT/3x25MHahOQ6g0V2dFAETkIuBA7Ydkqio9t5CVuw/ahC/GGOMB7SOCmX3zcEL8fZgyYykb9mZ5OqT6w9sXQltBqz7QaYyTQI9+wJkl8tovoeu5sOpdePUMZ1nxGuSfoHbbmAaiOjXVtwAzReQFQHBm1LrGLVGZKvl2cyplCmN7WFJtjDGeENsiiNk3D+PSl3/kvjlr+eLO0/H2Ek+HVX95eUGHkc5y3r9g7RxY9Q789174+s/Q82Kn9rr9aU5zlOrITYPUDZByeFkPaVshtKWT3Lfq61r6QLM21T9/XSgtdh5ITO3K3ge7f4Cobs6/v5tUZ/KXHcAwEQlxfc51W1SmShZuSqFVswB6t21AnWSMMaaRiQkP4pEJvbj9/VXMXLbbOo5XVWA4DJ0KQ26CfWuc5HrdR7B2ljNpzcBroN9kJykur6QQ0rYcSZwPJ9GHUo/sE9ISWvaCQdc5bcD3r4NNX5S7dgtXot3nSKId2aXuEtq8DEjbDKmbjrymboK8A07nzubtoHl75zXc9do8DsJinGY4tUEVinKhON/pTNqYRnHJSnaS6F3fO0vGDmf9aXfVj6QaQETOB3oBAeJ6wlPVx9wQl6lEQXEp3209wKWD2iL18WnbGGOakPP6tOL0zpE8+fUWzuvTmsgQf0+H1HCIQJsBznLOP2DjZ06CvfAv8M1j0G08tOkPqZud5Dl9G5S5pmX39ofoHtDlHCeJPrwERx5/ncIcSNkI+9e6lnWwfAaUFh59rsOJdlRX8A8FvxDwDXKmi/cLAZ9qdCcryD4med7o3Efu/iP7+IVAVHfoNg6axUDOXqdD6N7VzoNAWfHR5wxpVS7RPvzaDnz8oSCrgiXzBOuzQMucc/oGu9rLd4dI12tUN2cIRS/vqt9vVZSVQv5B52/rU0v/n2QmupLoJbDrB2fkGgD/MOdXj/jfQtzpzr+rG1VnnOpXgCBgDPAacBmwXFVvcF94FWtMY56eqm83p3D9Wwm8ff0QRnW1SV+MaShsnOrGa3tqLuOf+46L+rflqcut812NHdjmJNc/f+B0eAxrd3Ti3LK3M0Okd7XqB49WWuIk6fvXHUm0962F/JPMZ+TleyTB9gsut7g++wY6teOpmyE76chxPoFOohrdE6K7Q1QP5zUs9sRNUcpKIWc/ZO52Eu3MPXBwt+vzbqdGVktPHKtfCASEnXzx9neS0LTNzi8A2clHjvf2dyXZ3Y4k2lHdnbHLy9fqqzoPLbmpzgNDborrves1Z/+Rz3kHjiTzAWEQHO0MtxgS7Xof5fzScNT7qKMT8IO7j66JztztOl9zaD8C4kY4SXTL3rXyUFDVcrs6SfVaVe1b7jUEmKeqI2sabHU1lQL6ZB78zzq++HkvKx8+G3+fWn6KNMa4jSXVjdv/fbWZlxfv4KNbhhMf18LT4TQOpcVQUuDUbNYFVdeMlDuh6JDTRKLoUAXvD3/OO35bSNSRpDm6p5OINm9f+00sSkucmu2Du53k+tdkuTn4Nzu1B46CLOeBJm3zkUQ7bbOT0B/m5etMd+8feiRxLsk//lxePk5S/OsS7bwGRTgTDeWmHlkOpTrt4gtP0OE3IMw5tjgfshKddYEtnJrouJFOIh3dyy3NWNwx+UuB6zVPRNoA6UDrUwnO1ExZmbJwUwqjukZZQm2MMfXInWd25rPVyTz82Qa+uGMEPt6NqJ2qp3j71m3nPRGnI2OzNnV3zVPl7XOk+UdtCQiDmHhnKa8w16nVP5xkp26G4kMQO/RIshzS0mkDf/h9QPPqJ7nFBa4Eu3yyXe69eDlto+NGOA8u9agteHWS6i9EpDnwJLAKZ1qlGW6JypzU2uQs0nIKObunTfhijDH1SZCfDw9N6MltM1cxc9kerj0tztMhGVM7/EOOtH13J9+A2n9QqCNVSu9FxAv4RlUzVfVjoD3QXVUfcWt0pkILNu7H20sY082SamOMqW/G927FyC6RPDV/C2k5hZ4OxxhTR6qUVKtqGfBiuc+Fqmqj3HvIwo2pDI4Lp3mQTWhpjDH1jYjw6IW9KCgu5Yl5mz0djjGmjlSnIco3InKp2PhtHrUnPY8tKTmM7dnK06EYY4w5gU5RIdw0siMfr0pixa6TjCRhjGk0qpNU3wzMAQpFJFtEckQk201xmRNYsCkFgLN7WNMPY4ypz+44szNtwgJ4+NP1lJSWeTocY4ybVTmpVtVQVfVSVT9Vbeb6bFP51bEFG/fTtWUI7SOCPR2KMcaYkwjy8+HhCT3ZvD+Hd5fu9nQ4xhg3q/LoHyJyRkXrVfW72gvHnExmXhErdh3kllEdPR2KMcaYKhjn6rT4zPytTOjbhqhQm2nRmMaqOs0/7iu3PAx8ATzqhpjMCSzakkppmXJ2j5aeDsUYY0wViAh/vbAXBSWlPD5vk6fDMca4UXWaf1xQbhkL9AYOVnaciIwTkS0isl1EHqhgezsRWSQiq0VkrYicV71baDoWbkwlKtSffjHNPR2KMcaYKuoYFcLUMzryn1XJLP/FOi0a01jVZBqaJKDHyXYQEW+cofjGAz2BySLS85jdHgI+VNUBwCTgpRrE1GgVlpSyeEsqZ/eIxsvLBmAxxpiG5PYxTqfFRz6zTovGNFZVTqpF5HkRmeZaXgCW4MyseDJDgO2qulNVi4BZwEXH7KPA4Q6PYcDeqsbUlCzdmcGholLG9rSmH8YY09AE+fnwyAVOp8V3frJOi8Y0RtWZpjyh3PsS4ANV/aGSY9oCieU+JwFDj9nnUWC+iNwJBANnV3QiEZkKTAVo167hTV1ZUws3phDo681pnSI9HYoxxphTcG6vVpzRNYp/L9jKhH6tiQ4N8HRIxphaVJ3mHx8B76nq26o6E1gqIkG1EMNk4C1VjQHOA951TYt+FFWdrqrxqhofFRVVC5dtOFSVhZtSOKNrJAG+3p4OxxhjzCk43GmxsKSMJ+baTIvGNDbVmlERCCz3ORBYWMkxyUBsuc8xrnXl3QB8CKCqPwEBgFXHlrNhbzb7sgps1A9jjGngOkQGO50WVyezbGe6p8MxxtSi6iTVAaqae/iD631lNdUrgC4i0kFE/HA6In5+zD57gLMARKQHTlKdVo24Gr35G1PwEjizu82iaIwxDd3tYzrTtnkgj3y2gWLrtGhMo1GdpPqQiAw8/EFEBgH5JztAVUuAO4CvgU04o3xsEJHHRORC1273AjeJyM/AB8B1qqrVuYnGbuHGFAa1DycixCYNMMaYhi7Qz5uHJ/RkS4p1WjSmMalOR8V7gDkishcQoBVwRWUHqepcYO4x6x4p934jMKIacTQpSQfz2LgvmwfHd/d0KMaYekhE7gbeBHKA14ABwAOqOt+jgZmTOrdXS0a5Oi1e0Lc10c2s06IxDV11Jn9ZAXQHbgVuAXqo6kp3BWYc32xKBbCh9IwxJ3K9qmYD5wDhwNXAE5UdVIWJua4TkTQRWeNabiy3rbTc+mOb9JkqEBEevbAXRSVl/GPuJuwHWmMavuqMU307EKyq61V1PRAiIre5LzQDsGBjCh2jgukYFeLpUIwx9dPh2aDOA95V1Q3l1lV8QNUm5gKYrar9Xctr5dbnl1t/YQXHmSroEBnMLaM68tmavdw752fyi0o9HZIxpgaq06b6JlXNPPxBVQ8CN9V+SOaw7IJilu5Mt1pqY8zJrBSR+ThJ9dciEgpU1vutKhNzmTpw99ldufusLnyyOplLXvqBXw4c8nRIxphTVJ2k2ltEfq39cNV0+NV+SOawxVvSKClTxtpQesaYE7sBeAAYrKp5gC/w20qOqWhirrYV7HepiKwVkY9EpPzwqAEikiAiS0Xk4oouICJTXfskpKXZgE4n4u0l/G5sV964bjD7swu48Pnv+XrDfk+HZYw5BdVJqr8CZovIWSJyFs5IHV+5JywDzqgfEcF+DGgX7ulQjDH113Bgi6pmishVwENAVi2c9wsgTlX7AguAt8tta6+q8cAU4FkR6XTswU15wq5TMaZbNF/ccTpxkcHc/O5KHp+3iRIbbs+YBqU6SfX9wCKcjoq34kwG80d3BGWguLSMRVtSObN7NN5eJ20eaYxp2l4G8kSkH84QpTuAdyo5ptKJuVQ1XVULXR9fAwaV25bset0JLMYZccTUUGyLIObcMpwpQ9vx6v92ctXry0jNKfB0WMaYKqrO6B9lqvqyql7mWl5VVetV4SbLf8kgp6DE2lMbYypT4hrb/yLgBVV9EQit5JhKJ+YSkdblPl6IM9cAIhIuIv6u95E4Q6JurJU7MQT4evPPS/rw1OX9WL0nkwnTvmfFrgxPh2WMqYLqjP7RxdWubqOI7Dy8uDO4pmzBxhT8fbw4vYvN2G6MOakcEXkQZyi9/4qIF0676hOq4sRcd4nIBtfEXHcB17nW9wASXOsXAU+45hswteiyQTF8ctsIAv28mTR9Ka8t2WnD7hlTz1Vn8pc3gb8A/wbG4HSEqU7zEVNFqsqCjSmM7BJJkF91/omMMU3QFThtm69X1f0i0g54srKDqjAx14PAgxUc9yPQp6ZBm8r1bNOMz+84nT/M+Zm//3cTq/Yc5F+X9SPE374XjKmPqpMUB6rqN4Co6m5VfRQ43z1hNV05BcU8s2AryZn5nG2jfhhjKqGq+4GZQJiITAAKVLWyNtWmgQgL9GX61YN4YHx3vlq/nwtf+J6tKTmeDssYU4HqJNWFrp8Vt4nIHSJyCWAzktSSguJSZny3kzP+tYjnv93O+N6tuLB/G0+HZYyp50RkIrAcuByYCCwTkcs8G5WpTSLCLaM6MfPGYWTnF3PRCz/w2Zrkyg80xtSp6vyGdDcQhNO27m84TUCudUdQTUlxaRmzVyTy/LfbSMkuZGSXSP5wTjf6xTb3dGjGmIbhzzhjVKcCiEgUsBD4yKNRmVo3vFME/71rJLfPXMXds9awavdB/nx+T/x8rCWmMfVBlZNqVV3heptLBRMLiMjzqnpnbQXW2JWWKZ+tSebZhdvYk5FHfPtwnps0gGEdIzwdmjGmYfE6nFC7pGP9XRqtls0C+GDqMJ6Yt5nXv/+FtclZvHTlQFqHBXo6NGOavNrs7TCiFs/VaKkqX29I4en5W9iWmkuvNs1487rBjO4WRbkJK40xpqq+EpGvcSbkAqfj4tyT7G8aOF9vLx6e0JOB7cL540c/c/6073l+8gBGdLbRoozxJOtCXEdUlSXbDvDU/C2sTcqiY1QwL04ZyPjerfCyyV2MMadIVe8TkUs5UrExXVU/8WRMpm6c37c13VqFcut7K7n69WXce043bh3Vyb5TjPEQS6rrQMKuDJ78egvLfsmgbfNAnrysL5cMaIuPt/1Ca4ypOVX9GPjY03GYutc5OoRPbx/Bg/9Zx5Nfb2HV7oM8M7E/YUEnHarcGOMGtZlU26PxMbam5PD43E0s2pJGZIg/j13UiysGx+Lv4+3p0IwxDZyI5AAVzQYigKpqszoOyXhIsL8Pz03qz6D24fz9vxuZ8MISXr5yEL3bhnk6NGOalCon1SLSR1XXnWSX52ohnkbjUGEJV762jKKSMu4f151rT2tvE7kYY2qNqlY2FblpQkSEa0+Lo3fbMG6fuYpLX/6Rv13cm4nxsZ4OzZgmozrtD14SkeUicpuIHPf4q6pv1V5YDd+MJTtJyynkrd8O5tbRnSyhri/Sd8BXf4JFj0OWjfNqjGlcBrUP5793nU58XDh//GgtD3y8loLiUk+HZUyTUJ0h9UaKSBfgemCliCwH3lTVBW6LroFKzSlg+nc7Ob9Pawa0C/d0OAZg38/w/bOw8VMQbygrge+ehG7jYfAN0GE0eFkbd2NMwxcR4s871w/lmQVbeHHRDtbvzeLlKwcR2yLI06EZ06hVK4tQ1W3AQ8D9wChgmohsFpHfuCO4hurZhdsoKinjvnO7eTqUqkvdDM/0hHcvgTUfQEG2pyOqOVXY9T28dym8egZsWwCn3QW/Ww93rYbT7oQ9Pzn3/MIg+PEFyMvwdNTGGFNj3l7Cfed257Vr4tmdnsf505bw7eYUT4dlTKMmqhX1c6lgR5G+OJO+nA8sAF5X1VUi0gb4SVXbuy/Mo8XHx2tCQkJdXa5atqfmcO6zS7h6WHsevbCXp8OpmsIcmHEmHDoA/qGQuRt8Apxa3D6XQ+ezwcff01FWXVkZbP0Kvv83JC2H4CgYdivE3wCBx8xUWVIIGz+DFa9B4jLnvntf6uzbdiDY2OGmlonISlWN93Qcdak+l9lNwZ70PG55byUb92Vz15mdufvsrnjbsHvGVFlVy+3qNPR9HngN+JOq5h9eqap7ReShU4ixUfq/r7YQ6OvNnWd29nQoVaMKn98J6dvhms8gbiQkrYC1H8KG/8CGTyCgOfS8yEmw24+ov80kSoth/cdOM4+0TdC8HZz3FAy4CnxPMNuYjz/0negs+9dDwuvw82xYMxNa93eahvS+DPxO4WfT0mLI3gtZSc7SoiPEDq7ZPZrjHdzt/CIRHAXNYyEsxnk4NMYA0C4iiP/cdhqPfLaead9uZ3ViJs9NGkCLYD9Ph2ZMo1KlmmoR8QbeVdUp7g+pcvW11mP5LxlMfPUn7ju3G7ePaSBJ9dKX4asH4OxH4fTfHb2ttBh2/g/WfQibvoTiQxDaBvpc6iTYrfpWryZXFQqyjiSZWYmQnQx+IRDmSoaax0Joa/CuxhirRXmw+j348XnI2gPRPZ176fUb8D6FDqIF2bB2Nqx43UnOA8Kg3xQnwY7scsy9JB59P7++T4KcfaBlR5+712/gnL8591ofqULKBtgyD0JbQrvhENG5/tXYl5XC9m+cXxi2zee4keUCwo78N/XrEntkXWgr8PLM0JZWU208afaKPTz82QYig/14/brB9GhtIy8aU5mqltvVaf6xBDhLVYtqGlxN1ccCWlW55KUf2ZeVz+I/jCHQrwGMRb1nGbx1HnQ5FybNPHniVJQHW+fB2jmwfYHT0S+ym5Nc97nUqYUtLYGcvRUnmZmu90U5R5/Xy8c5V3ni5STWxyVE5T4HNIeCTCepWvoK5B2A2KFw+u+hyzm1U5uu6rS5XvEabPwcyoqhzQAoLqj4Xrz9oFlbV23pMfGGtnFq/X941rm/kb+H4XeCb0DN46wNB3fDujmw7iPnQaK8oAgnuT68tO5bvYee2nToAKx+FxLegMw9ENISBl7jPKwU5R7/YJOZ6KwryDz6POLt/FuFxUDcCBhyM4RE1cktWFJtPG19chY3vp3AocISpl8Tz/BOEZ4OyZh6zR1J9TtAD+Bz4NDh9ar6zKkGearqYwE9d90+bpu5in9d2peJgxvAuKC5afDqSKcN8dTFx7c1Ppm8DKcd8ro5sPsHZ11ISziUdnzNbFBExUnx4VrD4CgoKXBqrA8nRIcT8MOfs5Oh9JhnOb9Q0FIoznOS6NN/B+1Pq8lf5ORyU51kbtsC1z3FHp/wB0dVnswf3A3z/wybvoDwOBj3BHQd55ma4EMHnER/3RynPTlA7DDoezn0vNj5d97zE+xZ6rwe/MXZxzcI2g5y/t7thkHMYPc2t1B14lvxmvPfXWmR00xp8A3QfULVEvzCHGcIxWMf9g7ucrWl94cBVzudV8Pd2z3EkmpTH+zNzOfaN5azOz2Ppyf244J+bTwdkjH1ljuS6r9UtF5V/1rN2GqsvhXQRSVlnPPv/+Hn48W8u8+o/x1ASkvg3YudttM3LoRWfU79XFlJTu3mgW3QrM2RRLN5O6cm8FTaIh+rrMxJ2I9KiBKdGu5B19Usfk/ZsQjm3Q8HtjgdQcc9caRpiTsV5sKWuU6b+R3fOg8m0T2dXxx6X3ryhDJ7HyQuPZJk71/nPESJl/Nv0M6VZLcd5Py3UNPmFYU5rmY4b0DqBvBvBv0mQ/z1EN29Zucu78A2+OE5+HmWcz99LoMR90DLnrV3jXIsqTb1RVZeMTe9k8DyXRk8PKEnN5zewdMhGVMv1XpSXZ/UtwL67R938ZfPN/DmdYMZ0z3a0+FUbuFf4ftn4KKXYMCVno6m6SothuXTYfETUJzvjFAy6o+1X+tbUuQk0Os+hM1zoSTfqV3vc5mTTLc8xVFqCnMgcfmRJDspwTk3OM16mrU5wS8UMSfvTJiywWnPvna206SjVV+nVrrP5eAXfGqxVkX2XvjpRUh40+k/0HW800wndkitXsaSalOfFBSXcs+sNXy1Yf//t3fn8VVV5/7HP08GEkICIZCEKUCQGWUmTIoDDogDqKg4IGorWvWn1bbWoXqterUOF7XWa6VqK9UrUgWLCkVxViQhzDIPAZPImDCEKUCyfn/sg4aYkJDkDEm+79frvHL23mvv/bDPOYvnrLP2WkwY1oF7R3QlLNQbhkQCzB8t1YnAPUAP4MeOoM65s6oaZFWFUgVdcPAwpz/9OV1bxPHmLwdioXZDV2mrZ8FbY6HveLj4z8GORsDrWjLnj7D4Da8bzTmPQM8rq94lpLjY66qxbYWXTC+fDgd2QsME6HGJl5ymDKz5UVyKDsPmpbB58bH9mo924XGlZnWLjj82yY5NhvWfeAl6eBScfCkM+KXX8h3Iz9X+fMj4G6T/FQ7keyPenHo3dBxeI3EoqYC4AqYAACAASURBVJZQU1Ts+OP7y5n87SZG927FU2N60SAiREd5EgkCfwyp9ybwNnAhcAswHthetfDqjpe/2ED+vkPcd3630E+o87Ng2s3Qshec/1Swo5GjYpNg9Itet4aZv4XpN3s34p3/FLTqffx99+3wWna3Lve6SGxdAdtXeX3Nwev/3GWkN2RghzMhwo9DaIVHQpt+3qO04iIo2HJs952SN7R+P9cbTaVpKpzzqDcMYkyC/2I9npgEOOP3MOR2WDjZG1Xmzcu8Li6n3uX1Nw/SyCEi/hAeZvzx4h4kN47m6dmr2bH3EC9d25e46CDdkCxSS51IS/UC51w/M1vqnOvpWzffORfwgXdDpdVjy+6DnPHMZ5zXowXPj+0T7HCO7/ABePUc7ybAm7/wbpKT0FNc7I2RPedh2J8H/cbDWQ9542xvX+W1Pm9d8VMCvW/bT/vGNPf6ASf18P4m9/D6S5c3RneoKdzrfQkItXHQjxzybub85jnYscZL/Ife6fXvrsLoLWqpllD2zoIcfv/uUrokx/GPGweQFBciIxSJBJE/WqoP+/5uNrMLgB+AIDUlhYaJH6+muBh+e24tmI585u+8G8uunqqEOpSFhUHfcdDtIvjiKa8LwpIp3ogXR0dWiYiGxK7Q6RwvaU7u4T1ia0F//uOJig12BGWLaODde9DrKlj9IXw1ET74NXz+BIx5DdqfGuwIRWrMmH5taB7bgFvfXMil/zuXyTem0SExRD+bIiHmRJLqx8ysCfAbvNkVGwN3HX+XumvVlj28syCHG4emkpJQAyNc+NPCyd5wcMN+B53PC3Y0UhkN42HE494YzBmToFFzX8tzD0hIVfeDYAgL877sdL0Qsr6Eb/8CzQIwYotIgJ3RJYkpEwZxw9/nc9lLc3n1+gH0bds02GGJhDyN/lFFN/w9gwWbdvLlPWcSHxPCU71uXgKvnAPtBsO105SMiQSZun9IbbFxxz7G/z2DrXsO8uLVfRneLTnYIYkERWXr7Up3XjSzRDO738wmmdlrRx/VC7N2mrtuB5+t3s5tZ3YM7YT6wE54e5zXynnZq0qoRUSk0to3b8S7vxpC5+Q4bpqcyZSM74MdkkhIO5HuH/8GvgLmAEUVlK2ziosdT8xaRev4howf0j7Y4ZSvuBim/8obe/eGWV5iLSIicgKax0bx1k2DuPXNhdw7bRlb9xRyx/COoT/alUgQnEhSHeOc+/2JnsDMRgDPA+HAK865P5Xa/ixw5tFzAEnOuROYMzuw3l/6A8tydzPxil5ER4Zwy+83z8KaWXD+05AS8AFaRCTEVaJuvh54Gsj1rfqLc+4V37bxwB986x9zzr0ekKAlKBpFRfDK+P7c++4ynp2zhk9WbSUlIYakuCgS46JIiosmMS6KxNgokhpHkRDTQBPISL10Ikn1B2Y20jk3s7I7mFk48CJwDpADzDezGc65FUfLOOfuKlH+/wEhOzZd4ZEinp69mu4tGzO6d+tgh1O+DZ/Dp4/ByWMg7aZgRyMiIaYydbPP286520vtmwD8F9AfcMAC3747AxC6BElkeBjPXN6TTsmxfLpqGyt/2MMXBYXsLTzys7LhYUazRg1IauxLtH1Jd8v4aC7q1YrGGv9a6qgTSarvBO43s0K84fUMcM65xsfZJw1Y55zbAGBmU4BRQOmK+6ir8CrrkPTPbzeRs/MAb/yiZ2h+C3fOm0nvnV9A885w0fOBnYlORGqLE62bSzoP+Ng5l+/b92NgBPCWn2KVEGFm3HL6Sdxy+kk/rtt/6Ag7Cg6xreAg2wsK2VZQyHbfY1vBQbbvLWTF5j3s2HuIomLHsx+v5f6RXbmkT2t1IZE6p9JJtXMurgrHbw1kl1jOAQaWVdDM2gGpwKflbJ8ATABo27ZtFUKpnt37D/PCp+sY1jmRUzsFqX/ykUPedM/HTAGdfezy4X3QIBau+GfojvsrIsFW2br5MjMbBqwB7nLOZZez789+ugt2nS2BEdMggrbNImjb7PhDyxYVO5bl7ubhGcu5e+oSpmRk88joHnRtcbx2OZHapcKk2sy6OudWmVnfsrY75xbWUCxjgXecc2XeBOmcmwRMAm94pho6Z6X97+fr2HPwMPeO6Or/kxUd9ib82LH62IS5YAver60lNEqCJm0gsQt0PNt73uEMSOzs/zhFpC57H3jLOVdoZjcDrwNnVXbnYNfZElrCw4zeKfFM+9UQpmZm8+R/VnHBn7/mhiHtufPsTpoSXeqEyrRU343X2vA/HJvRmW/5eJVsLpBSYrkNP930UtpY4LZKxBNwOTv38/e5G7m0Txu6twrAt+qvJsLnj3sz5zVp4z06DocmKT8tN0mBxq2rNE2yiNR7FdbNzrm8EouvAE+V2PeMUvt+XuMRSp0UFmaMTWvLeT1a8NTs1bz6TRYzlvzAAxd04+JerdQlRGq1CpNq59wE39ORwK3AqXjJ9FfASxXsPh/oZGapeBXxWODq0oXMrCvQFPi20pEH0MSP1gDwm3MD0Pq7Yy189Qz0uNSbAlkVjIjUvArrZjNr6Zzb7Fu8GFjpez4beNzMjk6xdy5wn/9DlrqkaaMGPHHpKVw5IIUH3/uOO6cs9rqEjOpBp+Sq9DYVCb5KT/6C99NfN+DPeNOUdwcmH28H59wR4Ha8SnglMNU5t9zMHjGzi0sUHQtMcSE4vePKzXuYvjiXG4em0iq+oX9P5hx8cBdENoTzn1RCLSJ+Ucm6+Q4zW25mS4A7gOt9++YDj+Il5vOBR47etChyonqnxPPebUN5bPTJrNi8h/Of/4onZq1kXxmjioiEukpPU25mK5xz3StaFwiBnPJ24ker+ctn61j44Dn+nz1x0Rvw79u8UTv6Xe/fc4lIUGiacpGy5e0t5Mn/rGJqZg4tm0Tz4IXdOf/kFuoSIkFX49OUAwvNbFCJEwwE6nwtmZ6VT49WTfyfUO/dDrMfgLaDoc91/j2XiIhIiGkWG8VTY3rx7q8GEx/TgFvfXMh1r2WwfvveYIcmUikVJtVmtszMlgL9gLlmttHMsvD6P9fp1paDh4tYlL2LtNQE/59s9v1waJ/XSh12It91RERE6o5+7RJ4//ahPHxRdxZ/v4sRz33J83PWUlwccj1ERY5RmdE/LvR7FCFqac5uDh0pZqC/k+r1n8KyqTDsHm9oPBERkXosIjyM64emMrJnSx77YCXPzlnDprx9PDmmJ5HhaniS0FSZ0T82BSKQUJSR5Y0oNaC9H5PqQ/u9mxObdYTTfuO/84iIiNQySXHRPD+2N52TY3nmozXs2HeIl67pS6OoE5kQWiQw9HXvONKz8umSHEfTRn7sT/3lU7BzI1z4nMacFhERKcXMuP2sTjx52Sl8s24HYyfNY3tBYbDDEvkZJdXlOFxUzIJNO/3bn3rLdzD3Beh9LaSe5r/ziIiI1HJXDmjL367rx9ptBYz561w25e0Ldkgix1BSXY7lP+xh/6EiBnbwU1JdXATv3wnRTeDcR/1zDhERkTrkrK7J/N9Ng9hz4DCXvTSXZTm7gx2SyI+UVJfjaH/qNH/1p858DXIz4bwnICYAo4uIiIjUAX3bNuWdXw0hKiKcKyd9y5drtgc7JBFASXW5MrLySW3eiKTGfujnvOcHmPNH6HAm9Lyi5o8vIiJSh52UGMu0W4fQrlkjbvzHfKYvygl2SCJKqstSVOzIyMr331B6s+6B4sNw4URNRS4iIlIFyY2jefvmQQxon8Bdby9h0pfrqews0SL+oKS6DKu3FLDn4BH/3KS4aiasfB9OvwcSOtT88UVEROqJxtGR/OPGAVzQsyWPz1zFYx+u1CQxEjQa6LEMP/anrumkurAAZv4WkrrDkDtq9tgiIiL1UFREOC+M7UNSXBSvfp3FtoJCnrm8J1ER4cEOTeoZJdVlyNiYT+v4hrRpGlOzB/70Ma8/9eX/gPDImj22iIhIPRUWZjx0YXdaNI7miVmryNtbyMvj+hEXrf9rJXDU/aMU5/zUnzp3AaS/DAN+ASlpNXtsERGRes7MuPn0k5h4RS8ysvK54uV5bNtzMNhhST2ipLqU9dv3sWPvoZrt+lF0xBuTOjYZhj9Uc8cVERGRY1zatw2vXj+ATXn7uPSluXyXq7GsJTCUVJeSkZUP1HB/6nn/C1uWwcinvMleRERExG9O75zIlAmDKDxSzMV/+ZpHP1jBvsIjwQ5L6jgl1aVkZOXRPDaK1OaNauaAOzfB509A5/Oh28U1c0wRERE5rp5t4plz1+mMTWvLq19ncfbEL5i9fEuww5I6TEl1Cc450rPyGdghAauJ8aOdgw/vBgxGPq0xqUVERAKoSUwkj19yCu/+aghNGkZy8z8X8MvXM8nZuT/YoUkdpKS6hJydB9i8+2DN3aT43buwbg6c9QeIT6mZY4qIiMgJ6deuKe//v1O5f2RXvlm3g3MmfsmkL9dzuKg42KFJHaKkuoT0muxPnT0fPrgLWvWBgTdX/3giIiJSZZHhYUwYdhIf3z2MoR2b8fjMVVz0wtcs/H5nsEOTOkJJdQkZWXnEx0TSOSmuegfKng9vXAoxzeDKNyFMA9CLiIiEgjZNY/jbdf15eVw/dh84zGUvzeWB6cvYvf9wsEOTWk5JdQnpWfkMaJ9AWFg1+j6XTKiv/xCatK65AEVERKTazIzzerTg47tP58ahqbyV8T3DJ37Ovxfn4pymOZeqUVLts2X3QTbl7a9ef2ol1CIiIrVGbFQED17YnRm3n0rr+IbcOWUx417NIGvHvmCHJrWQkmqfjI3V7E+thFpERKRWOrl1E6bdOpRHR/VgSfYuznvuS/77wxXMXr6FrB37KCpW67VULCLYAYSK9A15xEZF0L1l4xPfWQm1iIhIrRYeZowb3J7zerTg0Q9X8srXWfztqywAoiLC6JQcS+fkODonx9ElOY7OLeJo1SS6ZobglTpBSbVPRlY+/do1JSL8BBvvlVCLiIjUGUmNo3nhqj786dJTWLdtL6u3FrBmSwGrtxYwd10e0xbm/lg2NiqCTsmxXpKdHEeXFt7fxLioIP4LJFiUVAN5ewtZu20vo/ucYEKshFpERKROahQVQa+UeHqlxB+zfvf+w6zZVsDqLQWs3eol27OXb2HK/Owfy3RMimXkKS25sGdLOidXc0QxqTWUVAPzN3pjVJ7QTYpKqEWkFjOzEcDzQDjwinPuT+WUuwx4BxjgnMs0s/bASmC1r8g859wt/o9YJDQ0iYlkQPsEBrT/KWdwzrFj7yHWbi1gxeY9zFm5lRc+XcufP1lLp6RYLujZkgtOaUknJdh1mpJqID0rj6iIMHq2ia+4MCihFpFazczCgReBc4AcYL6ZzXDOrShVLg64E0gvdYj1zrneAQlWpBYwMxLjokiMi2JIx+b88rQObCs4yOzvtvDB0s08/8lanpuzls7JsVxwSisu6NmCjtWdE0NCjpJqvP7Ufds2pUFEJfpTK6EWkdovDVjnnNsAYGZTgFHAilLlHgWeBH4X2PBEar+kuGjGDW7PuMHt2bbnIP9Z7iXYz32yhmfnrKFLchwX9GzJyFNa0jEpNtjhSg2o90n1noOHWbF5D3ec1aniwkqoRaRuaA1kl1jOAQaWLGBmfYEU59yHZlY6qU41s0XAHuAPzrmv/BqtSC2X1Dia6wa35zpfgj3ruy18uGwzz85Zw8SP19C1RRwjT2nJBT1bclKiEuzaqt4n1Qs27sQ5GNihgv7USqhFpJ4wszBgInB9GZs3A22dc3lm1g94z8x6OOf2lDrGBGACQNu2bf0csUjtkdQ4mvFD2jN+SHu27jnIrGWbmblsy48Jdp+28VzRP4ULe7YkLjoy2OHKCaj3SfW8rDwiw40+KU3LL6SEWkTqllwgpcRyG9+6o+KAk4HPfWPwtgBmmNnFzrlMoBDAObfAzNYDnYHMkidwzk0CJgH0799fM2eIlCG5cTTXD03l+qGpbNl9kPeX/MC/FmRz37Rl/PH95Yw8uSVj+rdhUGozwsI0Hnaoq/dJdUZWPj3bxNOwQXjZBXIWKKEWkbpmPtDJzFLxkumxwNVHNzrndgPNjy6b2efAb32jfyQC+c65IjPrAHQCNgQyeJG6qEWTaG4a1oFfnpbK0pzdTM3MZsaSH5i2KJeUhIaM6ZvCZf1a06ZpTLBDlXLU66R6/6EjLMvZzU3DOpRdYOtyL6Fu2FQJtYjUGc65I2Z2OzAbb0i915xzy83sESDTOTfjOLsPAx4xs8NAMXCLcy7f/1GL1A9m9uP42A9e2J3Zy7cwNTObZ+es4blP1jD0pOZc3r8N5/VoQXRkOQ2CEhT1Oqle9P0ujhS7ssenzlsPk0dDZEMYP0MJtYjUKc65mcDMUuseKqfsGSWevwu869fgRASA6MhwRvVuzajercnO38+7C3N4Z0EOd05ZTFx0BKN6t+Lyfin0bNNE06WHAL8n1ZWZYMDMrgAeBhywxDl3deky/pC+IY8wg37tSvWn3pUNk0eBK4LrPoCm7QMRjoiIiEiZUhJi+PXZnbnjrE7M25DHvxbk8K/MHN6Y9z1dkuO4ckAKl/VrQ5OGurkxWPyaVFdmggEz6wTcBwx1zu00syR/xlRSelY+PVo1Ofbu2r3bvIT64G4Y/z4kdglUOCIiIiLHFRZmDOnYnCEdm/PHUT14f8kPTM3M4ZEPVvD07NWM7tOa6wa3o1vLxsEOtd7xd0t1ZSYYuAl40Tm3E8A5t83PMQFQeKSIRdm7GDeo3U8rD+yEf14CBZth3HRopQnDREREJDQ1jo7kmoHtuGZgO77L3c3kbzcybWEOb2V8z4D2TRk3uD0jerSo3OR2Um3+vsplTTBQunNyZ6CzmX1jZvN83UV+xswmmFmmmWVu37692oEtzdnNoSPFP/WnLiyAN8bAjjUw9k1oO6ja5xAREREJhJNbN+GpMb1Iv384D4zsxraCQu54axFD/vQpEz9azZbdB4MdYp0XCjcqRuANyXQG3lipX5rZKc65XSUL1fSYp+kb8gAY0D4BDh+Et66CHxbBFa/DSWdV9/AiIiIiARcf04CbhnXgF6em8sXa7fzz20288Nk6Xvx8Ped2T2bc4HYM7tBMNzb6gb+T6oomGACv9TrdOXcYyDKzNXhJ9nx/BpaelU+X5DiaRhu8fT1s/AoumQTdLvLnaUVERET8LizMOLNLEmd2SSI7fz9vpG9i6vxsZn23hU5JsYwb3I5L+rTWrI01yN/dP36cYMDMGuBNMFB6/NP38FqpMbPmeN1B/DqRwJGiYhZs2smg1CYw/RZYMwtGPgO9rvTnaUVEREQCLiUhhvvO78a39w3nmct7EdMgnIf+vZxBj3/CH95bxpLsXTiniU+ry68t1ZWcYGA2cK6ZrQCKgN855/L8GdfyH/aw/9ARbtz1Amx8B85+GNJu8ucpRURERIIqOjKcMf3aMKZfG5Zk72Lyt5uY6huWr0NiIy7t442JnZKgWRurwmrjN5P+/fu7zMzMKu8/6Yt18PFDTIj4EE77DQwvc74DEZEaZ2YLnHP9gx1HIFW3zhYR/9l94DCzlm1m2qJcMrK8yVHTUhO4pE9rRp7SUuNeU/l6OxRuVAy4pEUvMDriQ0ibAGc9GOxwRERERIKiScNIxqa1ZWxaW7Lz9/PvxblMW5TLfdOW8V8zlnN2tyQu6dOG0zsnami+CtS7pLp47ouM3vUPFsSPoN+IJ0F3v4qIiIiQkhDD7Wd14rYzO7I0ZzfTF+Xy/pIfmLlsC01jIrmoVytG92lNn5R4jR5ShvqVVC+cTNhH9zOraAAHT32SfmH6xiUiIiJSkpnRKyWeXinxPHBBN75cs53pi3J5e342k7/dRGrzRozu3ZoLerbgpMRYJdg+9Sep/m4azLiD3GZDuDP3Zj49KWCzoYuIiIjUSpHhYQzvlszwbsnsOXiY/yzbwrRFOTw7Zw3PzllD89goBnZIYFBqAoM6NKNjUv1NsutHUn1gF3zwa2g7mKci/0DivkLaNNWdrSIiIiKV1Tg6kisGpHDFgBRydx3gqzXbmbchj/SsfD5cuhmAZo0akOZLsAd2SKBzUhxhYfUjya4fSXXDeBj3Hi6hA9/8z3yGdUoMdkQiIiIitVbr+IY/3uDonCM7/wDzNuQxLyuP9A35zPpuCwBNYyJJS01gYGozBnVoRtcWdTfJrh9JNUDrvqzftpcdew+RlpoQ7GhERERE6gQzo22zGNo2i+GKAd5E2tn5+0nPyifdl2jPXr4V8EYbSUtNYFTvVpzbvUWdGlGk/iTVcMz4iyIiIiLiHykJMaQkxDCmXxsAfth1gPSsPOatz+ertdv5eMVWmsdGcVVaCleltaVVfMMgR1x99SypziMxLorU5o2CHYqIiIhIvdEqviGX9GnDJX3aUFzs+GLtdt74dhN/+WwdL362juHdkrl2UDtO69i81nYPqTdJtXOO9Kx80lIT6u1dqSIiIiLBFhZmnNkliTO7JJGdv5+3Mr5namY2H6/YSrtmMVwzsC2X90uhaaMGwQ71hNSdjiwVyNl5gM27DzJQXT9EREREQkJKQgz3jOjK3HuH8+er+pAcF83jM1cx8IlPuHvqYhZ+vxPnXLDDrJR601Kdrv7UIiIiIiGpQUQYF/dqxcW9WrF6SwFvzNvE9EW5TFuYS49Wjbl2UDtG9W5FTIPQTV1DN7IalpGVR3xMJJ2T4oIdioiIiIiUo0uLOB4dfTK/P78r7y3K5Y15m7hv2jIe/3AlZ3VLomlMA+KiI4iNiiDW99dbjvzxeVx0BI2iIogMD1ynjHqUVOczoH1Cre38LiIiIlKfxEZFcO2gdlwzsC0LNu3kjXmbyMjKp6DwCHsLj1CZXiHRkWHERkUSFx3BDUPbc93g9n6Lt14k1YeLiklLTSAttVmwQxERERGRE2Bm9G+fQP/2P3Xhdc6x/1ARewuPUHDQS7L3HjzC3sLD7Dl49PmRY7Y3j43ya5z1IqmODA/jqTG9gh2GiIiIiNQAM6NRlNfFI7lxsKPx1JvRP0RERERE/EVJtYiIiIhINSmpFhERERGpJiXVIiL1kJmNMLPVZrbOzO49TrnLzMyZWf8S6+7z7bfazM4LTMQiIqGtXtyoKCIiPzGzcOBF4BwgB5hvZjOccytKlYsD7gTSS6zrDowFegCtgDlm1tk5VxSo+EVEQpFaqkVE6p80YJ1zboNz7hAwBRhVRrlHgSeBgyXWjQKmOOcKnXNZwDrf8URE6jUl1SIi9U9rILvEco5v3Y/MrC+Q4pz78ET39e0/wcwyzSxz+/btNRO1iEgIU1ItIiLHMLMwYCLwm6oewzk3yTnX3znXPzExseaCExEJUbWyT/WCBQt2mNmmKuzaHNhR0/FUQ6jFA6EXk+KpWKjFFGrxQGjF1C7YAQC5QEqJ5Ta+dUfFAScDn5sZQAtghpldXIl9f0Z1tl+FWkyhFg+EXkyKp2KhFlOl6m1zlZk4vY4ws0znXP+KSwZGqMUDoReT4qlYqMUUavFAaMYUTGYWAawBhuMlxPOBq51zy8sp/znwW+dcppn1AP4Prx91K+AToJM/blQMtdct1OKB0Isp1OKB0ItJ8VQsFGOqjFrZUi0iIlXnnDtiZrcDs4Fw4DXn3HIzewTIdM7NOM6+y81sKrACOALcppE/RESUVIuI1EvOuZnAzFLrHiqn7Bmllv8b+G+/BSciUgvVtxsVJwU7gFJCLR4IvZgUT8VCLaZQiwdCMyapWKi9bqEWD4ReTKEWD4ReTIqnYqEYU4XqVZ9qERERERF/qG8t1SIiIiIiNU5JtYiIiIhINdXJpNrMRpjZajNbZ2b3lrE9ysze9m1PN7P2fowlxcw+M7MVZrbczO4so8wZZrbbzBb7HmXeLFTDcW00s2W+82WWsd3M7M++a7TUN7uav2LpUuLfvtjM9pjZr0uV8fs1MrPXzGybmX1XYl2CmX1sZmt9f5uWs+94X5m1Zjbej/E8bWarfK/JdDOLL2ff476+NRjPw2aWW+J1GVnOvsf9TNZwTG+XiGejmS0uZ98av0ZSNaqzKxWX6uyfx6E6+8TjUZ3tT865OvXAGx5qPdABaAAsAbqXKnMr8Fff87HA236MpyXQ1/c8Dm9s2NLxnAF8EODrtBFofpztI4FZgAGDgPQAvn5bgHaBvkbAMKAv8F2JdU8B9/qe3ws8WcZ+CcAG39+mvudN/RTPuUCE7/mTZcVTmde3BuN5GG/84ope0+N+JmsyplLb/wd4KFDXSI8qvYaqsysXl+rsn59bdfaJx6M624+PuthSnQasc85tcM4dAqYAo0qVGQW87nv+DjDczJs2rKY55zY75xb6nhcAK4HW/jhXDRsFTHaeeUC8mbUMwHmHA+udc1WZfa1anHNfAvmlVpd8r7wOjC5j1/OAj51z+c65ncDHwAh/xOOc+8g5d8S3OA9vNruAKOf6VEZlPpM1HpPvM30F8FZNnEv8RnV2zVCd7VGdfZx4Kkl1dhXVxaS6NZBdYjmHn1eIP5bxvdl3A838HZjvJ8s+QHoZmweb2RIzm2XejGX+5oCPzGyBmU0oY3tlrqM/jKX8D1SgrxFAsnNus+/5FiC5jDLBulY34rVMlaWi17cm3e77afO1cn5qDdb1OQ3Y6pxbW872QF4jKZ/q7MpRnV05qrMrpjrbT+piUh2SzCwWeBf4tXNuT6nNC/F+OusFvAC8F4CQTnXO9QXOB24zs2EBOOdxmVkD4GLgX2VsDsY1Oobzfn8KiTEozewBvNns3iynSKBe35eAk4DewGa8n+5CxVUcv8Uj5D4DEjpUZ1dMdXblqc6ulFpfZ9fFpDoXSCmx3Ma3rswyZhYBNAHy/BWQmUXiVc5vOuemld7unNvjnNvrez4TiDSz5v6Kx3eeXN/fbcB0vJ97SqrMdaxp5wMLnXNbS28IxjXy2Xr0J1Tf321llAnotTKz64ELgWt8/2n8TCVe3xrhnNvqnCtyzhUDfyvnPAF/L/k+15cCLb2Q0QAAA8dJREFUb5dXJlDXSCqkOrsSVGdXmurs41Cd7V91MameD3Qys1Tft+ixwIxSZWYAR+/2HQN8Wt4bvbp8fYReBVY65yaWU6bF0f6BZpaG97r48z+MRmYWd/Q53o0U35UqNgO4zjyDgN0lflLzl3K/pQb6GpVQ8r0yHvh3GWVmA+eaWVPfT2nn+tbVODMbAdwDXOyc219Omcq8vjUVT8k+m5eUc57KfCZr2tnAKudcTlkbA3mNpEKqsyuOSXV25anOPn48qrP9qbJ3NNamB95d0Gvw7l59wLfuEbw3NUA03s9V64AMoIMfYzkV7+enpcBi32MkcAtwi6/M7cByvDts5wFD/Hx9OvjOtcR33qPXqGRMBrzou4bLgP5+jqkRXoXbpMS6gF4jvP8cNgOH8fqQ/QKv3+YnwFpgDpDgK9sfeKXEvjf63k/rgBv8GM86vL5uR99LR0dEaAXMPN7r66d4/ul7fyzFq3Rblo7Ht/yzz6S/YvKt/8fR906Jsn6/RnpU+XVUnX38mFRnlx2D6uwTj0d1th8fmqZcRERERKSa6mL3DxERERGRgFJSLSIiIiJSTUqqRURERESqSUm1iIiIiEg1KakWEREREakmJdUiVWBmZ5jZB8GOQ0REKqY6WwJBSbWIiIiISDUpqZY6zcyuNbMMM1tsZi+bWbiZ7TWzZ81suZl9YmaJvrK9zWyemS01s+m+mbYws45mNsfMlpjZQjM7yXf4WDN7x8xWmdmbR2cPExGRqlGdLbWZkmqps8ysG3AlMNQ51xsoAq7Bmwks0znXA/gC+C/fLpOB3zvneuLNOHV0/ZvAi865XsAQvNmgAPoAvwa64832NNTv/ygRkTpKdbbUdhHBDkDEj4YD/YD5vgaJhsA2oBh421fmDWCamTUB4p1zX/jWvw78y8zigNbOuekAzrmDAL7jZTjncnzLi4H2wNf+/2eJiNRJqrOlVlNSLXWZAa875+47ZqXZg6XKuSoev7DE8yL0eRIRqQ7V2VKrqfuH1GWfAGPMLAnAzBLMrB3e+36Mr8zVwNfOud3ATjM7zbd+HPCFc64AyDGz0b5jRJlZTED/FSIi9YPqbKnV9C1N6izn3Aoz+wPwkZmFAYeB24B9QJpv2za8PnwA44G/+irgDcANvvXjgJfN7BHfMS4P4D9DRKReUJ0ttZ05V9VfUURqJzPb65yLDXYcIiJSMdXZUluo+4eIiIiISDWppVpEREREpJrUUi0iIiIiUk1KqkVEREREqklJtYiIiIhINSmpFhERERGpJiXVIiIiIiLV9P8Be/Egd/JT9JoAAAAASUVORK5CYII=\n",
       "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAEWCAYAAACJ0YulAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvIxREBQAAIABJREFUeJzt3Xl8VfWd//HXJ/u+kJUQEFRAElYNuFULIhFcsDO2HbfabWo7U7vZ+qu2nS7OUm07HWvHLi50OrVVp3azihoXcGlFQKDs+xp2AgkhJGT7/v44N5cbCBAgJyc39/18PM4j9yz33k+uct/5fr/nfI855xAREQGIC7oAERHpOxQKIiISplAQEZEwhYKIiIQpFEREJEyhICIiYQoFkVMws81mdnXQdYj0BoWCiIiEKRRERCRMoSDSTWaWbGYPmdmO0PKQmSWH9uWb2fNmVmtm+83sLTOLC+37qpltN7N6M1tjZlOD/U1ETiwh6AJEosjXgUuA8YAD/gR8A/gX4MtANVAQOvYSwJnZSOAuYKJzboeZDQXie7dske5TS0Gk+24D7nfO7XHO7QW+A3wktK8FGAic45xrcc695byJxdqAZKDMzBKdc5udcxsCqV6kGxQKIt1XAmyJWN8S2gbwfWA9UGVmG83sXgDn3Hrgi8C3gT1m9rSZlSDSRykURLpvB3BOxPqQ0Dacc/XOuS87584FZgJ3d4wdOOd+45x7X+i5Dniwd8sW6T6Fgkj3PQV8w8wKzCwf+CbwJICZXW9m55uZAXV43UbtZjbSzK4KDUg3AY1Ae0D1i5ySQkGk+/4NWAgsBZYBi0LbAIYDrwKHgHeAnzjn5uCNJzwA7AN2AYXAfb1btkj3mW6yIyIiHdRSEBGRMIWCiIiEKRRERCRMoSAiImFRN81Ffn6+Gzp0aNBliIhElffee2+fc67gVMdFXSgMHTqUhQsXBl2GiEhUMbMtpz5K3UciIhJBoSAiImEKBRERCYu6MQURkTPR0tJCdXU1TU1NQZfiq5SUFEpLS0lMTDyj5ysURCQmVFdXk5mZydChQ/HmLex/nHPU1NRQXV3NsGHDzug11H0kIjGhqamJvLy8fhsIAGZGXl7eWbWGFAoiEjP6cyB0ONvfMWZCYdHWAzz40uqgyxAR6dNiJhRWbK/jp3M3sH7PoaBLEZEYVFtby09+8pPTft61115LbW2tDxV1zddQMLPpZrbGzNZ33LO2i2M+bGYrzWyFmf3Gr1quLisCoGrlLr/eQkTkhE4UCq2trSd93uzZs8nJyfGrrOP4FgpmFg88AswAyoBbzKzsmGOG492F6nLnXDneDc59MTA7lXGl2byycrdfbyEickL33nsvGzZsYPz48UycOJErrriCmTNnUlbmfS1+4AMf4KKLLqK8vJxHH300/LyhQ4eyb98+Nm/ezKhRo/jUpz5FeXk5lZWVNDY29nidfp6SOglY75zbCGBmTwM3AisjjvkU8Ihz7gCAc26Pj/UwrayIH1StZc/BJgqzUvx8KxHpw77z5xWs3HGwR1+zrCSLb91QfsL9DzzwAMuXL2fJkiXMnTuX6667juXLl4dPHZ01axYDBgygsbGRiRMnctNNN5GXl9fpNdatW8dTTz3FY489xoc//GF+97vfcfvtt/fo7+Fn99EgYFvEenVoW6QRwAgz+4uZzTOz6T7WQ2V5MQCvrFJrQUSCNWnSpE7XEjz88MOMGzeOSy65hG3btrFu3brjnjNs2DDGjx8PwEUXXcTmzZt7vK6gL15LwLvh+WSgFHjTzMY45zqNqpjZncCdAEOGDDnjNxtemMHQvDSqVuzmtovPOePXEZHodrK/6HtLenp6+PHcuXN59dVXeeedd0hLS2Py5MldXmuQnJwcfhwfH+9L95GfLYXtwOCI9dLQtkjVwHPOuRbn3CZgLV5IdOKce9Q5V+GcqygoOOV04CdkZlSWF/POhhrqm1rO+HVERE5XZmYm9fX1Xe6rq6sjNzeXtLQ0Vq9ezbx583q5uqP8DIUFwHAzG2ZmScDNwHPHHPNHvFYCZpaP15200ceamFZWRHNbO2+s3evn24iIdJKXl8fll1/O6NGjueeeezrtmz59Oq2trYwaNYp7772XSy65JKAqfew+cs61mtldwMtAPDDLObfCzO4HFjrnngvtqzSzlUAbcI9zrsavmgAuHJJLXnoSVSt2c/3YEj/fSkSkk9/8puuz7pOTk3nxxRe73NcxbpCfn8/y5cvD27/yla/0eH3g85iCc242MPuYbd+MeOyAu0NLr4iPM64eVcTsZTtpbm0nKSFmrt8TETmlmPxGnFZWRP2RVt7d5GujREQk6sRkKLxveD6pifFUrdCpqSIikWIyFFIS43n/iAJeWbkbrwdLREQgRkMBoLK8iF0Hm1i2vS7oUkRE+oyYDYWrLigkPs7UhSQiEiFmQyEnLYlJQwdo1lQR6RVnOnU2wEMPPcThw4d7uKKuxWwogNeFtHb3ITbvawi6FBHp5xQKUWBa6B4Lmk5bRPwWOXX2Pffcw/e//30mTpzI2LFj+da3vgVAQ0MD1113HePGjWP06NE888wzPPzww+zYsYMpU6YwZcoU3+sMekK8QJXmplE2MIuqlbv41JXnBl2OiPSWF++FXct69jWLx8CMB064O3Lq7KqqKp599lnmz5+Pc46ZM2fy5ptvsnfvXkpKSnjhhRcAb06k7OxsfvjDHzJnzhzy8/N7tuYuxHRLAbwupIVbDrDv0JGgSxGRGFFVVUVVVRUTJkzgwgsvZPXq1axbt44xY8bwyiuv8NWvfpW33nqL7OzsXq8tplsKAJVlxTz06jpeW7Wbf5h45tNyi0gUOclf9L3BOcd9993Hpz/96eP2LVq0iNmzZ/ONb3yDqVOn8s1vfrOLV/BPzLcURg3MZFBOqsYVRMRXkVNnX3PNNcyaNYtDhw4BsH37dvbs2cOOHTtIS0vj9ttv55577mHRokXHPddvMd9S8O6xUMSv391Kw5FW0pNj/iMRER9ETp09Y8YMbr31Vi699FIAMjIyePLJJ1m/fj333HMPcXFxJCYm8tOf/hSAO++8k+nTp1NSUsKcOXN8rdOibZqHiooKt3Dhwh59zXc21HDLY/P42e0XMn30wB59bRHpG1atWsWoUaOCLqNXdPW7mtl7zrmKUz03drqP6nfDlnegixCcODSXnLREXd0sIjEvdkJhwWPwi+nwxDRY+SdobwvvSoiP46oLCnlt9R5a29oDLFJEJFixEwrv+xJc+wNo2Av/dwf8+CKY/xg0e1cJVpYVU9fYwvzN+wMuVET8Em3d5WfibH/H2AmFpHSY9Cn43CL40C8hbQDM/go8NBrmfJcrB0FyQpy6kET6qZSUFGpqavp1MDjnqKmpISUl5YxfI3YHmp2Dre/AXx6GtS9CQgpzU6/mp0dm8PR9t2FmZ/8eItJntLS0UF1dTVNTU9Cl+ColJYXS0lISExM7be/uQHPshkKkvWvgnf+mbclTWFsrh4ZdQ9bUL8PgST37PiIiAdHZR6ejYCTM/DF1n17ET9puJKn6r96A9BOVsOp5aNfgs4jEBoVChAFFQ3iz9DPckvEETH8Q6nfCM7fBf1fAwlnQ0hh0iSIivlIoHGNaWRGLd7WwbcQd8LnF8MFZkJwJz38J/ms0zH0QGmqCLlNExBcKhWN0usdCfAKMvgnunAsffR4GXQhz/wP+qxxe+Ars3xhorSIiPU2hcIyh+emMLMrsfJtOMxh2Bdz2W/jneV5QvPc/3rUO/3cHVPfwwLeISEAUCl2oLC9i/qb9HGhoPn5n4Sj4wCPwxWVw+Rdgw1x4fCrMmgFrXtSgtIhENYVCF6aVFdHu4PXVe058UNZAuPrbcPcKuOa7ULcNnroZfnIxvPdLaOnf50KLSP/kayiY2XQzW2Nm683s3i72f8zM9prZktDyj37W011jBmVTnJXSuQvpRJIz4dJ/hs8vhr9/HBKS4c+fh4fGwJvfh8OaNkNEoodvoWBm8cAjwAygDLjFzMq6OPQZ59z40PK4X/Wcjo57LLy5dh9NLW2nfgJAfCKM/RB8+i24408wcCy8/m/eoPTs/wcHNvtas4hIT/CzpTAJWO+c2+icawaeBm708f161LSyIhpb2nh73b7Te6IZnDsZbv8d/NNfoexGWPgEPDwBfvtx2L7Ij3JFRHqEn6EwCNgWsV4d2nasm8xsqZk9a2aDu3ohM7vTzBaa2cK9e/f6UetxLh6WR2ZKQve6kE6kqBz+7mfwhaVw6V2w/lV4bAo8dhXM+S5snQdtLT1XtIjIWQp6oPnPwFDn3FjgFeCXXR3knHvUOVfhnKsoKCjolcKSErx7LLy6ag9t7Wc5P1T2IKj8V/jSCqj8N2/bGw/CrGvgwWHw1K3eNN771nd5EyARkd7i5w2JtwORf/mXhraFOeciLw1+HPiej/WctsqyYv60ZAfvbTnApGEDzv4FU7Lgss95y+H9sOlN2DgHNrwOa17wjskeDOdNgXOneN1QaT3wviIi3eRnKCwAhpvZMLwwuBm4NfIAMxvonNsZWp0JrPKxntP2/pEFJMXH8crKXT0TCpHSBkD5B7zFOe/q6I1zYMMcWPFHWPS/gMHAcXDeVV5QDL7YO7tJRMQnvoWCc67VzO4CXgbigVnOuRVmdj+w0Dn3HPB5M5sJtAL7gY/5Vc+ZyEhO4LLz86hauZuvXTvKv3ssmEHeed4y8R+hrRV2LPICYuMc+MuP4O0fQmIanHP50ZZE4SjvuSIiPUT3UziF37y7la/9YRkvf/FKRhZn9tr7dtJ0EDa/fbQlUbPO255R3LmrKbMomPpEpM/r7v0U/Ow+6heuLivk63+EqhW7gguFlCy44FpvAajddjQg1r4Mf3vK21402guH86bAkMsgKS2YekUkaqml0A1/95O/0NbueO6u9/Xq+3ZLezvsWuoNVm+cEzrNtRnik2HIJUdbEsVjIS7ok81EJChqKfSgyrJiHnxpNTtqGynJSQ26nM7i4qBkvLdccTc0H4Ytfz3aknj128C3IS3Pa0WcO8ULiuzSQMsWkb5JodANleVFPPjSal5dtZs7Lh0adDknl5QGw6/2FoD6XbBx7tFB6+W/87bnj4CSCV44ZA8OLaXeNRXJAXWTiUjgFArdcF5BBucWpFO1IgpC4ViZxTDuZm9xDvasOtqK2PoOHNwB7a2dn5OSExESkUtoW2YxxMUH8/uIiK8UCt1UWVbM429tpK6xhezUxKDLOTNmUFTmLZd+1tvW3ua1Juqqvem/66o7L1vfgabazq8TlwCZJV5A5Aw+PjSyS9XaEIlSCoVuqiwv4mdvbGDumj3cOL6rKZyiVFy812WUPQi4uOtjjtRD3fZQaGw7PjS6bG1kd9HaiFjPKPZudyoifYr+VXbT+NIcCjKTqVqxu3+FQnckZ0LhBd7SlfY2OLT7aGuj9tjgmHd8a8PiISsURlkl3pJZEvF4oNdNFR+lrTKRKKVQ6Ka4OOPqUUU8t2Q7R1rbSE5Qn3pYXPzRL/PBk7o+JtzaiOymCv3c/h6seh7ajhzzJIOMQi8gsgZ5d7vr9Dj0nskZvv+KIrFCoXAaKsuLeGr+Vv66oYYpIwuDLie6nKq14Rw0HoCD2+HgTu9n/U6va+rgDjiwCbb85fgWB0ByVigsjmlpRLZA0vJ0nYZINygUTsNl5+WRnhRP1YrdCoWeZuZNEpg2AIrHnPi45sOdw6J+R+cQ2bAGDu0C1975eXGJEa2LUGsjc+DRxxlFkJjqDaIft8RrjimJGQqF05CcEM/kkYW8umo3/94+mrg4fVH0uqS0o5MHnkhbKzTs6brFUb8Tdv4N1rwErY3df99jQyIuwQuaTusJ3hhI5PqJQiY+sevXS0gKjadEdJNlFHvbRXqBQuE0VZYX8cKynSypruXCIblBlyNdiU842nXERV0f45zXFXUw1NI4tAtaj3iD5u2tJ1navLvlRa63t0J7yzHrraHj2kKv29C912tp7GJsBUgvPKaFE9lNFgoPnQYsPUChcJomjywkIc6oWrFboRDNzCA111uKyoOu5qiOsZX6nce0dEJjLQe2eKcBNx44/rkaW5EeoFA4TdmpiVx6Xh5VK3dx74wTDJqKnKnIsZWThVVL49HusMiusY7w2DCn67GV+CTvVN+TtTjUXdW72lrhyEEv6JtqobHW+9lUd/Rxx8+LPubddMtHCoUzMK2siG/+aQXr9xzi/EKdDikBSEw99dhKexsc2hMxIL+ji7GVF7sYWzHv4sP4RG+cIz403tHlesIx20+2rzuv0TEmE3ocn+jN+BufFHqc5N19sONxeHtoW1AnBLQe6fpLvDvbmutP/trxSd7UM6k5XbcQe5hC4QxcPcoLhVdW7lYoSN8VFx8ahxhIt8dWOsLjcE1orKPF+0u2veXoGEn4cav3Zdh86Oh6l8+J2H7sle89/jt3BEdS16HRse1097c0nfyL/VQnLSSme1/qKdneF3zOYEgZ03lbao73MyX76OPUHO8PgF6kUDgDJTmpjC3NpmrlLv5p8kn+UhPp63p7bMW5k4RHFwHU1hxaWkI/j0Q8bobW5mOO6eb+lkbvi72txQu2Tu/R8dwjQMT9ZpKzITXiCzz//C6+zHOP35aSHVXdcQqFM1RZVsQPqtay52AThVkpQZcjEh3MjnYLRYOOs8cSkmNmZmCdhnCGppUVA/DKqt0BVyIivomL966NiZFAAIXCGRtRlME5eWm8slKhICL9h0LhDJkZlWVF/HV9DfVNLUGXIyLSIxQKZ2FaWTHNbe28sXZv0KWIiPQIhcJZuOicXAakJ6kLSUT6DYXCWYiPM64eVcjrq/fQ3Np+6ieIiPRxCoWzVFlWTH1TK+9uqgm6FBGRs+ZrKJjZdDNbY2brzezekxx3k5k5M6vwsx4/vG94PqmJ3j0WRESinW+hYGbxwCPADKAMuMXMyro4LhP4AvCuX7X4KSUxnitH5PPKyt045079BBGRPszPlsIkYL1zbqNzrhl4Grixi+P+FXgQaPKxFl9VlhWz62ATy7bXBV2KiMhZ8TMUBgHbItarQ9vCzOxCYLBz7oWTvZCZ3WlmC81s4d69fe/0z6suKCQ+dI8FEZFoFthAs5nFAT8EvnyqY51zjzrnKpxzFQUFBf4Xd5py05OYODSXqpW7gi5FROSs+BkK24HBEeuloW0dMoHRwFwz2wxcAjwXjYPN4HUhrd19iM37GoIuRUTkjPkZCguA4WY2zMySgJuB5zp2OufqnHP5zrmhzrmhwDxgpnNuoY81+WZaWRGALmQTkajmWyg451qBu4CXgVXA/znnVpjZ/WY206/3DcrgAWmMGpilLiQRiWq+3k/BOTcbmH3Mtm+e4NjJftbSGyrLivjx6+vYd+gI+RnJQZcjInLadEVzD6osL6Ldweur9gRdiojIGVEo9KCygVkMyklVF5KIRC2FQg8yM6aVFfHWun0cbvb5BuUiIj5QKPSwyvIijrS28+bafUGXIiJy2hQKPWzS0AFkpyaqC0lEopJCoYclxMcxdVQhr63aQ2ub7rEgItFFoeCDyrIi6hpbmL95f9CliIicFoWCD64cUUByQpyubhaRqKNQ8EFaUgJXDM+naoXusSAi0UWh4JNpZUVsr21k5c6DQZciItJtCgWfTB1VhBm6x4KIRBWFgk/yM5KpOCdX4woiElW6FQpm9gUzyzLPE2a2yMwq/S4u2lWWFbNy50G27T8cdCkiIt3S3ZbCJ5xzB4FKIBf4CPCAb1X1E7rHgohEm+6GgoV+Xgv8yjm3ImKbnMDQ/HRGFGUoFEQkanQ3FN4zsyq8UHjZzDIBXa7bDZVlxczfvJ8DDc1BlyIickrdDYVPAvcCE51zh4FE4OO+VdWPTCsroq3d8fpq3WNBRPq+7obCpcAa51ytmd0OfAOo86+s/mPMoGyKs1I0QZ6IRIXuhsJPgcNmNg74MrAB+F/fqupH4uK8eyy8uXYfTS1tQZcjInJS3Q2FVufN13Aj8N/OuUeATP/K6l8qy4tobGnj7XW6x4KI9G3dDYV6M7sP71TUF8wsDm9cQbrh4mF5ZCYnqAtJRPq87obCPwBH8K5X2AWUAt/3rap+JikhjikXePdYaGvXBHki0nd1KxRCQfBrINvMrgeanHMaUzgNleVF1DQ0s2jrgaBLERE5oe5Oc/FhYD7wIeDDwLtm9kE/C+tv3j+igKT4OKpWqAtJRPqu7nYffR3vGoWPOufuACYB/+JfWf1PZkoil56XR9VK3WNBRPqu7oZCnHMu8uqrmtN4roRUlhexpeYwa3cfCroUEZEudfeL/SUze9nMPmZmHwNeAGb7V1b/NG1UxwR56kISkb6puwPN9wCPAmNDy6POua+e6nlmNt3M1pjZejO7t4v9nzGzZWa2xMzeNrOy0/0FoklhVgrjB+fw+8XbaTjSGnQ5IiLH6XYXkHPud865u0PLH051vJnFA48AM4Ay4JYuvvR/45wb45wbD3wP+OFp1B6VvjB1OFtqDvPpX73HkVZd4SwifctJQ8HM6s3sYBdLvZmd6ubDk4D1zrmNzrlm4Gm8K6LDQvdo6JAO9PsR2CkXFPLgTWN5e/0+vvDUElrbNNmsiPQdCSfb6Zw7m6ksBgHbItargYuPPcjMPgvcDSQBV3X1QmZ2J3AnwJAhQ86ipL7hgxeVcrCxhfufX8nX/7CcB24ag5luTyEiwQv8DCLn3CPOufOAr+LNvtrVMY865yqccxUFBQW9W6BPPvG+YXz+qvN5ZuE2vvviap2mKiJ9wklbCmdpOzA4Yr00tO1EnsabjTVmfGnaCGobW3j0zY3kpCXyz5PPD7okEYlxfobCAmC4mQ3DC4ObgVsjDzCz4c65daHV64B1xBAz49s3lFPX2ML3XlpDdmoit118TtBliUgM8y0UnHOtZnYX8DIQD8xyzq0ws/uBhc6554C7zOxqoAU4AHzUr3r6qrg44wcfGkd9Uyvf+ONyslISuWFcSdBliUiMsmjry66oqHALFy4Muowe19jcxkdnzWfxtgM8dkcFk0cWBl2SiPQjZvaec67iVMcFPtAsntSkeB7/WAXDCzP5zJPv8d6W/UGXJCIxSKHQh2SlJPK/n5zEwOxUPv6LBazaeapLQUREepZCoY/Jz0jmV5+cRFpSAh95Yj6b9zUEXZKIxBCFQh9UmpvGk/84ibb2dm5/4l12H2wKuiQRiREKhT7q/MJMfvmJSRxoaOYjT7xL7eHmoEsSkRigUOjDxpbm8NhHK9hcc5iP/WKBZlYVEd8pFPq4y87L579vmcCy7XWaWVVEfKdQiAKV5cXhmVW/+PQS2tqj69oSEYkeCoUo8cGLSvmX68t4cfkuvvb7ZZpAT0R84efcR9LDPvm+YdQdbubh19eTk5bIfdeOCrokEelnFApRpmNm1Z+/uZGctCT+afJ5QZckIv2IQiHKRM6s+uBLq8lOTeTWi6P/xkMi0jcoFKJQ5MyqX//jMrJSE7h+rGZWFZGzp4HmKJUYH8cjt15IxTm5fOmZJbyxdm/QJYlIP6BQiGKpSfE8/tGJ3syqv9LMqiJy9hQKUS47NZFffmISxdkpmllVRM6aQqEfKMg8OrPqHbPms6VGM6uKyJlRKPQTpblp/OqTk2ht08yqInLmFAr9yPCiTP7n45PYf0gzq4rImVEo9DPjBufw2B0VbN53mI//j2ZWFZHTo1Dohy47P58f3zqBv22r5TNPamZVEek+hUI/dU1oZtW31u3jS89oZlUR6R5d0dyPfahiMHWNLfzbC6vISlnGd/9+DGYWdFki0ocpFPq5f7ziXOoaW/jx6+vJTkvkvhmaWVVETkyhEAPunjaC2sMt/PyNjeSkamZVETkxhUIMMDO+M/PozKo5aYncMkkzq4rI8XwdaDaz6Wa2xszWm9m9Xey/28xWmtlSM3vNzM7xs55YFhdn/OeHxzFlZAFf+8Mynl+6I+iSRKQP8i0UzCweeASYAZQBt5hZ2TGHLQYqnHNjgWeB7/lVj3gzq/7ktovCM6u+tHxn0CWJSB/jZ0thErDeObfROdcMPA3cGHmAc26Oc+5waHUeUOpjPcLRmVVHFmfymScX8Yn/WcDGvYeCLktE+gg/Q2EQsC1ivTq07UQ+CbzY1Q4zu9PMFprZwr17dd+As5Wdmsjv/+lyvnbtBczftJ9rHnqT/5i9ioNNLUGXJiIB6xMXr5nZ7UAF8P2u9jvnHnXOVTjnKgoKCnq3uH4qKSGOO688jzlfmczfTRjEY29t5KofzOWZBVt1oZtIDPMzFLYDgyPWS0PbOjGzq4GvAzOdc0d8rEe6UJCZzPc+OI4/ffZyzslL56u/W8aNj7zNgs26YY9ILPIzFBYAw81smJklATcDz0UeYGYTgJ/jBcIeH2uRUxhbmsOzn7mUH908nppDzXzoZ+/w+acWs6O2MejSRKQX+RYKzrlW4C7gZWAV8H/OuRVmdr+ZzQwd9n0gA/itmS0xs+dO8HLSC8yMG8cP4rUvv5/PTx3Oyyt2cdV/zuVHr66jqUWT6onEAnMuuvqPKyoq3MKFC4MuIyZs23+YB15czQvLdjIoJ5WvXTuKa8cUa/4kkShkZu855ypOdVyfGGiWvmnwgDQeue1Cnr7zErJSE/nsbxbxD4/OY8WOuqBLExGfKBTklC45N4/nP/c+/v3vRrNudz3X//ht7vv9MmoO6bwAkf5GoSDdEh9n3HbxOcz9yhQ+ftkwfrtwG5N/MJcn3t5ES1t70OWJSA9RKMhpyU5L5Js3lPHSF69gwpBc/vX5lUx/6E3mrtHJYyL9gUJBzsj5hZn88uMTeeKjFbS1Oz72iwWaMkOkH1AoyBkzM6aOKqLqS+/XlBki/YRCQc6apswQ6T8UCtJjNGWGSPRTKEiP05QZItFLoSC+0JQZItFJoSC+SktK4O5pI3j17vcz9YIi/uvVtUz9zzd4YelOom2KFZFYoFCQXqEpM0SigybEk17X1u54esFWfvDyGmobW5gyspDrxw5kWlkRmSmJQZcn0i91d0K8hN4oRiRSx5QZ148p4dG3NvDHxTt4ffUekhLimDyigBvGlTB1VCFpSfrfU6S3qaUggXPOsWhrLc8v3cELS3eyp/4IqYnxXDVH0xLCAAAMXUlEQVSqkBvGDmTyyEJSEuODLlMkqnW3paBQkD6lrd2xYPN+nl+6gxeX7aKmoZn0pHgqy4u5fuxArhheQFKChsJETpdCQaJea1s78zaGAmL5LuoaW8hKSeCa8mKuH1fCZeflkRivgBDpDoWC9CvNre38Zf0+/rx0B6+s2E39kVZy0xKZMWYg148dyMXD8oiP0x3hRE5EoSD9VlNLG2+u3cufl+7ktVW7OdzcRkFmMteOLuaGcSVcOCSXOAWESCcKBYkJjc1tvL56D88v9c5gOtLazsDsFK4bM5Drx5UwrjRb95QWQaEgMejQkVZeW7WbP/9tB2+s3UtLm2PwgFSuG1PC9WMHUl6SpYCQmKVQkJhW19hC1YpdPL90J2+v30dbu+Pc/HSuH+u1IEYUZQZdokivUiiIhOxvaOal5bt4fukO5m2sod3BiKIMbhhbwvXjShiWnx50iSK+UyiIdGFPfRMvLd/Fn/+2gwWbDwBQXpLFdWMHcum5eZSVZJGcoAvlpP9RKIicws66Rl5YupPnl+5kybZaAJLi4ygflMX4wTlMGJLLhME5lOamaixCop5CQeQ07D7YxKItB1iyrZbFW2tZur2WppZ2APIzkkMh4S1jS3PISNa8TBJd+sSEeGY2HfgREA887px74Jj9VwIPAWOBm51zz/pZj8iJFGWlMGPMQGaMGQhAS1s7a3bVs3hbLYu3HmDJ1lpeXbUbgDiDEUWZTBiSE25RnF+QoWsjpF/wraVgZvHAWmAaUA0sAG5xzq2MOGYokAV8BXiuO6GgloIEpfZwc7glsSQUFgebWgHITE5g3OCccIti/OAc8jKSA65Y5Ki+0FKYBKx3zm0MFfQ0cCMQDgXn3ObQvnYf6xDpETlpSUweWcjkkYUAtLc7NtU0sGRrLYu3HWDx1lp++sYG2tq9P7SGDEjzupwG5zB+SC5lA7M0mZ/0eX6GwiBgW8R6NXCxj+8n0qvi4ozzCjI4ryCDmy4qBbwrrJdtr2PxVi8k5m2s4U9LdgCQlBDH6JIsJgzJDbcoBuVoEFv6lqgYLTOzO4E7AYYMGRJwNSInlpoUz6RhA5g0bEB42866xk5dTk/O28ITb28CoCAzYhB7cC5jS7NJ1yC2BMjP//u2A4Mj1ktD206bc+5R4FHwxhTOvjSR3jMwO5WBY1K5NmIQe/XOepaEupwWb6vllZW7I45PYVh+OkPz0zk3P52heekMK0hncG6aup/Ed36GwgJguJkNwwuDm4FbfXw/kaiQGB/HmNJsxpRm85FLvW0HGppZUl3L8uo6Nu1rYFNNA7OX7aT2cEv4efFxRmluqhcYeemcWxAKjPx0SnJSNXW49AjfQsE512pmdwEv452SOss5t8LM7gcWOueeM7OJwB+AXOAGM/uOc67cr5pE+qrc9CSmjCxkSmgQu8OBhmY21TSweV+DFxahZf6m/Rxubgsfl5QQxzkD0hiWnx5eOloaBZnJGreQbtPFayJRyDnH3vojbNx3fGBs2X+Y5tajJ/SlJ8UzNCIsIgMjJy0pwN9CelNfOCVVRHxiZhRmpVCYlcIl5+Z12tfW7thR28imfQ1srmlg417v57Ltdby4fFf4lFmAnLTEo2ERGrsYmueFhq7ajk36ry7Sz8THGYMHpDF4QBpXUtBpX3NrO9sOHD6udTFvQw2/X9T5PJDs1ERKclIZlJPKoJwU73FuKiU5qZTmpJKfkayruPshhYJIDElKiAtfW3GsxuY2tuxvYNNerwtqR20j2w80Un3gMPM31YSv3u6QGG8MzPZCoyMwwuER2paSqBlno41CQUQA7xqLC4qzuKA4q8v99U0t7KhtYnvtYbbXNoVDY0dtI3/dsI/dB5toP2aIMj8jiZKcVEqyj7YyBuWkMCgnjZKcFAakJ2kQvI9RKIhIt2SmJDKyOJGRxV3fta6lrZ3dB5u8oKjzAqMjPNbvPcQba/fS2NLW6TkpiXERXVSpnVoZg3JSKcxKVmujlykURKRHJMbHUZqbRmluWpf7nXPUHm5he63Xuoj8ub22idWr97C3/shxz0tKiCM7NbHTkpOaSNYx27JTE8lO67yuQDl9CgUR6RVmRm56ErnpSYwelN3lMU0tbeyqa/KC4kAj+xqOUNfYwsHGFmoPt1DX2MLug02s3V1PXWML9ceMcxxLgXL6FAoi0mekJHrXVAzt5n2z29od9U1eWEQuHQFy8JjtZxooA9KTyM9IIj8jmbz0ZPIzk8hLT6Yg9DM/M5n0pPh+MT6iUBCRqBUfZ+SkJZ3RRXiRgdIRIpFLZKDUNDSzZlc9fzlUQ11jS5evl5IY5wVER3iEfx7dlh96nJOW1GenJVEoiEhMigyUc/JOfXyH5tZ29jc0s+/QkdDSTE3occ2hZvYeOsLOuiaWba+jpqG508WCHeIMBhwTIB0tkPyIlkh+ZjJ56Um92pWlUBAROQ1JCXEUZ6dQnJ1yymPb212opXGEvfXN1DQcYV/9EWrCoeL93Lr1MPsOHek0n1WkzOQE8jKSuLtyJDPHlfT0r9SJQkFExCdxcUcH188vPPXxh5tbqTnUfFwLpCM8ctMSfa9ZoSAi0kekJSWQNiCBwQO6Pq23N+iOHSIiEqZQEBGRMIWCiIiEKRRERCRMoSAiImEKBRERCVMoiIhImEJBRETCzLnj5+Xoy8xsL7DlDJ+eD+zrwXKinT6PzvR5HKXPorP+8Hmc45wrONVBURcKZ8PMFjrnKoKuo6/Q59GZPo+j9Fl0Fkufh7qPREQkTKEgIiJhsRYKjwZdQB+jz6MzfR5H6bPoLGY+j5gaUxARkZOLtZaCiIichEJBRETCYiYUzGy6ma0xs/Vmdm/Q9QTFzAab2RwzW2lmK8zsC0HX1BeYWbyZLTaz54OuJWhmlmNmz5rZajNbZWaXBl1TUMzsS6F/J8vN7CkzO/U9OKNcTISCmcUDjwAzgDLgFjMrC7aqwLQCX3bOlQGXAJ+N4c8i0heAVUEX0Uf8CHjJOXcBMI4Y/VzMbBDweaDCOTcaiAduDrYq/8VEKACTgPXOuY3OuWbgaeDGgGsKhHNup3NuUehxPd4/+EHBVhUsMysFrgMeD7qWoJlZNnAl8ASAc67ZOVcbbFWBSgBSzSwBSAN2BFyP72IlFAYB2yLWq4nxL0IAMxsKTADeDbaSwD0E/D+gPehC+oBhwF7gF6HutMfNLD3oooLgnNsO/ADYCuwE6pxzVcFW5b9YCQU5hpllAL8DvuicOxh0PUExs+uBPc6594KupY9IAC4EfuqcmwA0ADE5BmdmuXg9CsOAEiDdzG4Ptir/xUoobAcGR6yXhrbFJDNLxAuEXzvnfh90PQG7HJhpZpvxuhWvMrMngy0pUNVAtXOuo/X4LF5IxKKrgU3Oub3OuRbg98BlAdfku1gJhQXAcDMbZmZJeINFzwVcUyDMzPD6i1c5534YdD1Bc87d55wrdc4Nxfv/4nXnXL//a/BEnHO7gG1mNjK0aSqwMsCSgrQVuMTM0kL/bqYSA4PuCUEX0Bucc61mdhfwMt4ZBLOccysCLisolwMfAZaZ2ZLQtq8552YHWJP0LZ8Dfh36A2oj8PGA6wmEc+5dM3sWWIR31t5iYmC6C01zISIiYbHSfSQiIt2gUBARkTCFgoiIhCkUREQkTKEgIiJhCgWRXmRmkzUTq/RlCgUREQlTKIh0wcxuN7P5ZrbEzH4eut/CITP7r9D8+q+ZWUHo2PFmNs/MlprZH0Jz5mBm55vZq2b2NzNbZGbnhV4+I+J+Bb8OXS0r0icoFESOYWajgH8ALnfOjQfagNuAdGChc64ceAP4Vugp/wt81Tk3FlgWsf3XwCPOuXF4c+bsDG2fAHwR794e5+JdZS7SJ8TENBcip2kqcBGwIPRHfCqwB29q7WdCxzwJ/D50/4Ec59wboe2/BH5rZpnAIOfcHwCcc00Aodeb75yrDq0vAYYCb/v/a4mcmkJB5HgG/NI5d1+njWb/csxxZzpHzJGIx23o36H0Ieo+Ejnea8AHzawQwMwGmNk5eP9ePhg65lbgbedcHXDAzK4Ibf8I8EbornbVZvaB0Gskm1lar/4WImdAf6GIHMM5t9LMvgFUmVkc0AJ8Fu+GM5NC+/bgjTsAfBT4WehLP3JW0Y8APzez+0Ov8aFe/DVEzohmSRXpJjM75JzLCLoOET+p+0hERMLUUhARkTC1FEREJEyhICIiYQoFEREJUyiIiEiYQkFERML+P9e3fPqCDm+zAAAAAElFTkSuQmCC\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
+       "<Figure size 864x288 with 2 Axes>"
       ]
      },
      "metadata": {},
@@ -634,7 +680,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 120,
    "metadata": {},
    "outputs": [
     {
@@ -643,12 +689,12 @@
      "text": [
       "\n",
       "Train Set Metrics of the trained model:\n",
-      "\tloss: 0.0497\n",
+      "\tloss: 0.3663\n",
       "\tbinary_accuracy: 1.0000\n",
       "\n",
       "Test Set Metrics of the trained model:\n",
-      "\tloss: 0.4263\n",
-      "\tbinary_accuracy: 0.8106\n"
+      "\tloss: 0.5801\n",
+      "\tbinary_accuracy: 0.7159\n"
      ]
     }
    ],
@@ -664,13 +710,20 @@
     "for name, val in zip(model.metrics_names, test_metrics):\n",
     "    print(\"\\t{}: {:0.4f}\".format(name, val))"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Stellar ML [3]",
    "language": "python",
-   "name": "python3"
+   "name": "stellarml"
   },
   "language_info": {
    "codemirror_mode": {
@@ -682,7 +735,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,8 +14,12 @@
 #
 import os
 import sys
+import re
 sys.path.insert(0, os.path.abspath('..'))
 
+version = {}
+with open(os.path.abspath("../stellargraph/version.py"), "r") as fh:
+    exec(fh.read(), version)
 
 # -- Project information -----------------------------------------------------
 
@@ -24,9 +28,13 @@ copyright = '2018, Data61, CSIRO'
 author = 'Data61, CSIRO'
 
 # The short X.Y version
-version = '0.4'
+m = re.match('^(\d+.\d+)', version['__version__'])
+if m is None:
+    raise RuntimeError("Couldn't parse version")
+version = m.group()
+
 # The full version, including alpha/beta/rc tags
-release = '0.4.0b'
+release = version['__version__']
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ import setuptools
 
 DESCRIPTION = "Python library for machine learning on graphs"
 URL = "https://github.com/stellargraph/stellargraph"
-VERSION = "0.5.0b"
 
 # Required packages
 REQUIRES = [
@@ -37,6 +36,13 @@ EXTRAS_REQURES = {"demos": ["numba"], "test": ["pytest", "pandas", "pytest-bench
 # Long description
 with open("README.md", "r") as fh:
     LONG_DESCRIPTION = fh.read()
+
+# Get global version
+# see: https://packaging.python.org/guides/single-sourcing-package-version/
+version = {}
+with open("stellargraph/version.py", "r") as fh:
+    exec(fh.read(), version)
+VERSION = version['__version__']
 
 setuptools.setup(
     name="stellargraph",

--- a/stellargraph/__init__.py
+++ b/stellargraph/__init__.py
@@ -3,8 +3,10 @@ Stellar Machine Learning Library
 
 """
 
-__all__ = ["data", "layer", "mapper", "StellarDiGraph", "StellarGraph"]
+__all__ = ["data", "layer", "mapper", "StellarDiGraph", "StellarGraph", "__version__"]
 
+# Version
+from .version import __version__
 
 # Top-level imports
 from stellargraph.core.graph import StellarGraph, StellarDiGraph

--- a/stellargraph/layer/graphsage.py
+++ b/stellargraph/layer/graphsage.py
@@ -523,8 +523,6 @@ class GraphSAGE:
             for layer in range(self.n_layers)
         ]
 
-        self._normalization = Lambda(lambda x: K.l2_normalize(x, 2))
-
     def __call__(self, x: List):
         """
         Apply aggregator layers

--- a/stellargraph/layer/link_inference.py
+++ b/stellargraph/layer/link_inference.py
@@ -20,7 +20,7 @@ link attribute inference (regression)
 """
 
 from typing import AnyStr, Optional, List, Tuple
-from keras.layers import Layer, Concatenate, Dense, Lambda, Multiply, Average, Reshape
+from keras.layers import (Layer, Concatenate, Dense, Lambda, Multiply, Average, Reshape, Activation)
 from keras import backend as K
 
 
@@ -101,6 +101,7 @@ def link_inference(
             out = Lambda(lambda x: K.sum(x[0] * x[1], axis=-1, keepdims=False))(
                 [x0, x1]
             )
+            out = Activation(output_act)(out)
 
         elif edge_feature_method == "l1":
             # l1(u,v)_i = |u_i - v_i| - vector of the same size as u,v

--- a/stellargraph/layer/link_inference.py
+++ b/stellargraph/layer/link_inference.py
@@ -20,7 +20,16 @@ link attribute inference (regression)
 """
 
 from typing import AnyStr, Optional, List, Tuple
-from keras.layers import (Layer, Concatenate, Dense, Lambda, Multiply, Average, Reshape, Activation)
+from keras.layers import (
+    Layer,
+    Concatenate,
+    Dense,
+    Lambda,
+    Multiply,
+    Average,
+    Reshape,
+    Activation,
+)
 from keras import backend as K
 
 

--- a/stellargraph/version.py
+++ b/stellargraph/version.py
@@ -1,0 +1,2 @@
+# Global version information
+__version__ = "0.5.0b"

--- a/tests/layer/test_link_inference.py
+++ b/tests/layer/test_link_inference.py
@@ -49,7 +49,7 @@ class Test_Link_Inference(object):
         x_src = tf.constant(x_src, shape=(1, self.d), dtype="float64")
         x_dst = tf.constant(x_dst, shape=(1, self.d), dtype="float64")
 
-        li = link_inference(edge_feature_method="ip")([x_src, x_dst])
+        li = link_inference(edge_feature_method="ip", output_act='linear')([x_src, x_dst])
         print(
             "link inference with 'ip' operator on orthonormal vectors: {}, expected: {}".format(
                 li.eval(), expected
@@ -58,9 +58,16 @@ class Test_Link_Inference(object):
         assert li.eval() == pytest.approx(expected)
         assert li.eval() == pytest.approx(0)
 
-        li = link_inference(edge_feature_method="ip")([x_src, x_src])
+        li = link_inference(edge_feature_method="ip", output_act='linear')([x_src, x_src])
         print("link inference with 'ip' operator on unit vector: ", li.eval())
         assert li.eval() == pytest.approx(1)
+
+        # Test sigmoid activation
+        li = link_classification(edge_feature_method="ip", output_act='sigmoid')([x_src, x_dst])
+        assert li.eval() == pytest.approx(0.5)
+
+        li = link_classification(edge_feature_method="ip", output_act='sigmoid')([x_src, x_src])
+        assert li.eval() == pytest.approx(0.7310586)
 
         sess.close()
 
@@ -116,17 +123,19 @@ class Test_Link_Classification(object):
         x_src = tf.constant(x_src, shape=(1, self.d), dtype="float64")
         x_dst = tf.constant(x_dst, shape=(1, self.d), dtype="float64")
 
-        li = link_classification(edge_feature_method="ip")([x_src, x_dst])
-        print(
-            "link classification with 'ip' operator on orthonormal vectors: {}, expected: {}".format(
-                li.eval(), expected
-            )
-        )
+        # Test linear activation
+        li = link_classification(edge_feature_method="ip", output_act='linear')([x_src, x_dst])
         assert li.eval() == pytest.approx(0)
 
-        li = link_classification(edge_feature_method="ip")([x_src, x_src])
-        print("link classification with 'ip' operator on unit vector: ", li.eval())
+        li = link_classification(edge_feature_method="ip", output_act='linear')([x_src, x_src])
         assert li.eval() == pytest.approx(1)
+
+        # Test sigmoid activation
+        li = link_classification(edge_feature_method="ip", output_act='sigmoid')([x_src, x_dst])
+        assert li.eval() == pytest.approx(0.5)
+
+        li = link_classification(edge_feature_method="ip", output_act='sigmoid')([x_src, x_src])
+        assert li.eval() == pytest.approx(0.7310586)
 
         sess.close()
 

--- a/tests/layer/test_link_inference.py
+++ b/tests/layer/test_link_inference.py
@@ -49,7 +49,9 @@ class Test_Link_Inference(object):
         x_src = tf.constant(x_src, shape=(1, self.d), dtype="float64")
         x_dst = tf.constant(x_dst, shape=(1, self.d), dtype="float64")
 
-        li = link_inference(edge_feature_method="ip", output_act='linear')([x_src, x_dst])
+        li = link_inference(edge_feature_method="ip", output_act="linear")(
+            [x_src, x_dst]
+        )
         print(
             "link inference with 'ip' operator on orthonormal vectors: {}, expected: {}".format(
                 li.eval(), expected
@@ -58,15 +60,21 @@ class Test_Link_Inference(object):
         assert li.eval() == pytest.approx(expected)
         assert li.eval() == pytest.approx(0)
 
-        li = link_inference(edge_feature_method="ip", output_act='linear')([x_src, x_src])
+        li = link_inference(edge_feature_method="ip", output_act="linear")(
+            [x_src, x_src]
+        )
         print("link inference with 'ip' operator on unit vector: ", li.eval())
         assert li.eval() == pytest.approx(1)
 
         # Test sigmoid activation
-        li = link_classification(edge_feature_method="ip", output_act='sigmoid')([x_src, x_dst])
+        li = link_classification(edge_feature_method="ip", output_act="sigmoid")(
+            [x_src, x_dst]
+        )
         assert li.eval() == pytest.approx(0.5)
 
-        li = link_classification(edge_feature_method="ip", output_act='sigmoid')([x_src, x_src])
+        li = link_classification(edge_feature_method="ip", output_act="sigmoid")(
+            [x_src, x_src]
+        )
         assert li.eval() == pytest.approx(0.7310586)
 
         sess.close()
@@ -124,17 +132,25 @@ class Test_Link_Classification(object):
         x_dst = tf.constant(x_dst, shape=(1, self.d), dtype="float64")
 
         # Test linear activation
-        li = link_classification(edge_feature_method="ip", output_act='linear')([x_src, x_dst])
+        li = link_classification(edge_feature_method="ip", output_act="linear")(
+            [x_src, x_dst]
+        )
         assert li.eval() == pytest.approx(0)
 
-        li = link_classification(edge_feature_method="ip", output_act='linear')([x_src, x_src])
+        li = link_classification(edge_feature_method="ip", output_act="linear")(
+            [x_src, x_src]
+        )
         assert li.eval() == pytest.approx(1)
 
         # Test sigmoid activation
-        li = link_classification(edge_feature_method="ip", output_act='sigmoid')([x_src, x_dst])
+        li = link_classification(edge_feature_method="ip", output_act="sigmoid")(
+            [x_src, x_dst]
+        )
         assert li.eval() == pytest.approx(0.5)
 
-        li = link_classification(edge_feature_method="ip", output_act='sigmoid')([x_src, x_src])
+        li = link_classification(edge_feature_method="ip", output_act="sigmoid")(
+            [x_src, x_src]
+        )
         assert li.eval() == pytest.approx(0.7310586)
 
         sess.close()


### PR DESCRIPTION
This bugfix applied the specified activation function when using the `edge_feature_method='ip'` option in the `link_inference` function.

This is particularly important as our example notebook uses the 'ip' method and specifies a 'sigmoid' activation.  The 'ip' method also produces the best generalization performance currently (perhaps because it has no trainable parameters).

The unit tests are also modified to test for 'linear' and 'sigmoid' activation functions.