### PR TITLE
Issue/isolated nodes

### DIFF
--- a/demos/node-classification-graphsage/graphsage-cora-example.py
+++ b/demos/node-classification-graphsage/graphsage-cora-example.py
@@ -101,7 +101,7 @@ def train(
 
     # Create graph schema
     sample_edges = [e for ii,e in enumerate(G.edges(keys=True)) if ii < 5]
-    schema = G.create_graph_schema(nodes=node_ids[:1], edges=sample_edges)
+    schema = G.create_graph_schema(create_type_maps=False, nodes=node_ids[:1], edges=sample_edges)
 
     # Create mappers for GraphSAGE that input data from the graph to the model
     generator = GraphSAGENodeGenerator(G, batch_size, num_samples, schema=schema, seed=42)

--- a/demos/node-classification-graphsage/graphsage-cora-example.py
+++ b/demos/node-classification-graphsage/graphsage-cora-example.py
@@ -99,8 +99,12 @@ def train(
         test_nodes, test_targets, train_size=500, test_size=None, random_state=523214
     )
 
+    # Create graph schema
+    sample_edges = [e for ii,e in enumerate(G.edges(keys=True)) if ii < 5]
+    schema = G.create_graph_schema(nodes=node_ids[:1], edges=sample_edges)
+
     # Create mappers for GraphSAGE that input data from the graph to the model
-    generator = GraphSAGENodeGenerator(G, batch_size, num_samples, seed=42)
+    generator = GraphSAGENodeGenerator(G, batch_size, num_samples, schema=schema, seed=42)
     train_gen = generator.flow(train_nodes, train_targets)
     val_gen = generator.flow(val_nodes, val_targets)
 

--- a/demos/node-classification-graphsage/graphsage-cora-example.py
+++ b/demos/node-classification-graphsage/graphsage-cora-example.py
@@ -99,12 +99,8 @@ def train(
         test_nodes, test_targets, train_size=500, test_size=None, random_state=523214
     )
 
-    # Create graph schema
-    sample_edges = [e for ii,e in enumerate(G.edges(keys=True)) if ii < 5]
-    schema = G.create_graph_schema(create_type_maps=False, nodes=node_ids[:1], edges=sample_edges)
-
     # Create mappers for GraphSAGE that input data from the graph to the model
-    generator = GraphSAGENodeGenerator(G, batch_size, num_samples, schema=schema, seed=42)
+    generator = GraphSAGENodeGenerator(G, batch_size, num_samples, seed=42)
     train_gen = generator.flow(train_nodes, train_targets)
     val_gen = generator.flow(val_nodes, val_targets)
 

--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -459,8 +459,11 @@ class StellarGraphBase:
         node_indices = [nt_id_to_index.get(n) for n in nodes]
 
         if None in node_indices:
+            problem_nodes = [
+                node for node, index in zip(nodes, node_indices) if index is None
+            ]
             raise ValueError(
-                "Incorrect node specified or nodes of multiple types found."
+                "Could not find features for nodes with IDs {}.".format(problem_nodes)
             )
 
         features = self._node_attribute_arrays[node_type][node_indices]
@@ -607,7 +610,7 @@ class StellarGraphBase:
 
         return s
 
-    def create_graph_schema(self, create_type_maps=False, nodes=None, edges=None):
+    def create_graph_schema(self, create_type_maps=True, nodes=None, edges=None):
         """
         Create graph schema in dict of dict format from current graph.
 

--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -506,6 +506,19 @@ class StellarGraphBase:
                 if ndata.get(self._node_type_attr) == node_type
             ]
 
+    def type_for_node(self, node):
+        """
+        Get the type of the node
+
+        Args:
+            node: Node ID
+
+        Returns:
+            Node type
+        """
+        ndata = self.node[node]
+        return ndata.get(self._node_type_attr)
+
     @property
     def node_types(self):
         """
@@ -594,7 +607,7 @@ class StellarGraphBase:
 
         return s
 
-    def create_graph_schema(self, create_type_maps=True, nodes=None, edges=None):
+    def create_graph_schema(self, create_type_maps=False, nodes=None, edges=None):
         """
         Create graph schema in dict of dict format from current graph.
 
@@ -610,15 +623,11 @@ class StellarGraphBase:
         if nodes is None:
             nodes = self.nodes()
         elif create_type_maps is True:
-            raise ValueError(
-                "Creating type mapes for subsampled nodes is not supported"
-            )
+            raise ValueError("Creating type maps for subsampled nodes is not supported")
         if edges is None:
             edges = self.edges(keys=True)
         elif create_type_maps is True:
-            raise ValueError(
-                "Creating type mapes for subsampled edges is not supported"
-            )
+            raise ValueError("Creating type maps for subsampled edges is not supported")
 
         # Create node type index list
         node_types = sorted(

--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -390,8 +390,6 @@ class StellarGraphBase:
         An error will be raised if the graph is not correctly setup.
         """
         # TODO: This are simple tests and miss many problems that could arise, improve!
-        # TODO: At this point perhaps we should generate features rather than in fit_attribute_spec
-        # TODO: but if so how do we know whether to fit the attribute specs or not?
         # Check features on the nodes:
         if features and len(self._node_attribute_arrays) == 0:
             raise RuntimeError(
@@ -399,7 +397,9 @@ class StellarGraphBase:
                 "Node features are required for machine learning"
             )
 
-        # How about checking the schema?
+        # TODO: check the schema
+
+        # TODO: check the feature node_ids against the graph node ids?
 
     def get_feature_for_nodes(self, nodes, node_type=None):
         """
@@ -419,8 +419,7 @@ class StellarGraphBase:
         if not is_real_iterable(nodes):
             nodes = [nodes]
 
-        # Get the node type
-        # TODO: This is slow, refactor so that self._node_index_maps gives the node type
+        # Get the node type if not specified.
         if node_type is None:
             node_types = {
                 self.node[n].get(self._node_type_attr) for n in nodes if n is not None

--- a/stellargraph/layer/graphsage.py
+++ b/stellargraph/layer/graphsage.py
@@ -474,6 +474,9 @@ class GraphSAGE:
         elif normalize is None or normalize == "none":
             self._normalization = Lambda(lambda x: x)
 
+        else:
+            raise ValueError("Normalization should be either 'l2' or 'none'")
+
         # Get the input_dim and num_samples from the mapper if it is given
         # Use both the schema and head node type from the mapper
         # TODO: Refactor the horror of generator.generator.graph...

--- a/stellargraph/mapper/node_mappers.py
+++ b/stellargraph/mapper/node_mappers.py
@@ -31,7 +31,7 @@ from ..data.explorer import (
     SampledBreadthFirstWalk,
     SampledHeterogeneousBreadthFirstWalk,
 )
-from ..core.graph import StellarGraphBase
+from ..core.graph import StellarGraphBase, GraphSchema
 from ..core.utils import is_real_iterable
 
 
@@ -77,7 +77,10 @@ class NodeSequence(Sequence):
 
         # Infer head_node_type
         # TODO: Generalize to multiple head node target types?
-        head_node_types = set([generator.schema.get_node_type(n) for n in ids])
+        if generator.schema.node_type_map is None:
+            head_node_types = {generator.graph.type_for_node(n) for n in ids}
+        else:
+            head_node_types = {generator.schema.get_node_type(n) for n in ids}
         if len(head_node_types) > 1:
             raise ValueError(
                 "Only a single head node type is currently supported for HinSAGE models"
@@ -157,11 +160,12 @@ class GraphSAGENodeGenerator:
         G (StellarGraph): The machine-learning ready graph.
         batch_size (int): Size of batch to return.
         num_samples (list): The number of samples per layer (hop) to take.
+        schema (GraphSchema): [Optional] Graph schema for G.
         seed (int): [Optional] Random seed for the node sampler.
         name (str or None): Name of the generator (optional)
     """
 
-    def __init__(self, G, batch_size, num_samples, seed=None, name=None):
+    def __init__(self, G, batch_size, num_samples, schema=None, seed=None, name=None):
         if not isinstance(G, StellarGraphBase):
             raise TypeError("Graph must be a StellarGraph object.")
 
@@ -177,7 +181,12 @@ class GraphSAGENodeGenerator:
         self.sampler = SampledBreadthFirstWalk(G, seed=seed)
 
         # We need a schema for compatibility with HinSAGE
-        self.schema = G.create_graph_schema(create_type_maps=True)
+        if schema is None:
+            self.schema = G.create_graph_schema(create_type_maps=True)
+        elif isinstance(schema, GraphSchema):
+            self.schema = schema
+        else:
+            raise TypeError("Schema must be a GraphSchema object")
 
         # Check that there is only a single node type for GraphSAGE
         if len(self.schema.node_types) > 1:
@@ -298,11 +307,12 @@ class HinSAGENodeGenerator:
         G (StellarGraph): The machine-learning ready graph
         batch_size (int): Size of batch to return
         num_samples (list): The number of samples per layer (hop) to take
+        schema (GraphSchema): [Optional] Graph schema for G.
         seed (int), Optional: Random seed for the node sampler
         name (str), optional: Name of the generator.
      """
 
-    def __init__(self, G, batch_size, num_samples, seed=None, name=None):
+    def __init__(self, G, batch_size, num_samples, schema=None, seed=None, name=None):
 
         self.graph = G
         self.num_samples = num_samples
@@ -319,7 +329,13 @@ class HinSAGENodeGenerator:
         self.sampler = SampledHeterogeneousBreadthFirstWalk(G, seed=seed)
 
         # Generate schema
-        self.schema = G.create_graph_schema(create_type_maps=True)
+        # We need a schema for compatibility with HinSAGE
+        if schema is None:
+            self.schema = G.create_graph_schema(create_type_maps=True)
+        elif isinstance(schema, GraphSchema):
+            self.schema = schema
+        else:
+            raise TypeError("Schema must be a GraphSchema object")
 
     def sample_features(self, head_nodes, sampling_schema):
         """

--- a/tests/mapper/test_benchmark_generators.py
+++ b/tests/mapper/test_benchmark_generators.py
@@ -1,0 +1,165 @@
+import random
+
+from stellargraph.mapper.link_mappers import *
+from stellargraph.mapper.node_mappers import *
+from stellargraph.core.graph import *
+
+import numpy as np
+import networkx as nx
+import pytest
+
+
+def example_Graph_2(feature_size=None, n_nodes=100, n_edges=200):
+    G = nx.Graph()
+
+    edges = [
+        (random.randint(0, n_nodes - 1), random.randint(0, n_nodes - 1))
+        for _ in range(n_edges)
+    ]
+    G.add_edges_from(edges)
+
+    # Add example features
+    if feature_size is not None:
+        for v in G.nodes():
+            G.node[v]["feature"] = np.ones(feature_size)
+
+    G = StellarGraph(G, node_features="feature")
+    return G
+
+
+@pytest.mark.benchmark(group="generator")
+def test_benchmark_setup_generator_small(benchmark):
+    n_feat = 1024
+    n_edges = 100
+    batch_size = 10
+    num_samples = [20, 10]
+
+    G = example_Graph_2(n_feat)
+    nodes = list(G.nodes())
+    edges_to_sample = np.reshape(random.choices(nodes, k=2 * n_edges), (n_edges, 2))
+
+    def setup_generator():
+        generator = GraphSAGELinkGenerator(
+            G, batch_size=batch_size, num_samples=num_samples
+        )
+
+    benchmark(setup_generator)
+
+
+@pytest.mark.benchmark(group="generator")
+def test_benchmark_setup_generator_large(benchmark):
+    n_feat = 1024
+    n_edges = 100
+    batch_size = 10
+    num_samples = [20, 10]
+
+    G = example_Graph_2(n_feat, 5000, 20000)
+    nodes = list(G.nodes())
+    edges_to_sample = np.reshape(random.choices(nodes, k=2 * n_edges), (n_edges, 2))
+
+    def setup_generator():
+        generator = GraphSAGELinkGenerator(
+            G, batch_size=batch_size, num_samples=num_samples
+        )
+
+    benchmark(setup_generator)
+
+
+@pytest.mark.benchmark(group="generator")
+def test_benchmark_link_generator_small(benchmark):
+    n_feat = 1024
+    n_edges = 100
+    batch_size = 10
+    num_samples = [20, 10]
+
+    G = example_Graph_2(n_feat)
+    nodes = list(G.nodes())
+    edges_to_sample = np.reshape(random.choices(nodes, k=2 * n_edges), (n_edges, 2))
+
+    generator = GraphSAGELinkGenerator(
+        G, batch_size=batch_size, num_samples=num_samples
+    )
+
+    def read_generator():
+        gen = generator.flow(edges_to_sample)
+
+        for ii in range(len(gen)):
+            xf, xl = gen[ii]
+        return xf, xl
+
+    benchmark(read_generator)
+
+
+@pytest.mark.benchmark(group="generator")
+def test_benchmark_link_generator_large(benchmark):
+    n_feat = 1024
+    n_edges = 100
+    batch_size = 10
+    num_samples = [20, 10]
+
+    G = example_Graph_2(n_feat, 5000, 20000)
+    nodes = list(G.nodes())
+    edges_to_sample = np.reshape(random.choices(nodes, k=2 * n_edges), (n_edges, 2))
+
+    generator = GraphSAGELinkGenerator(
+        G, batch_size=batch_size, num_samples=num_samples
+    )
+
+    def read_generator():
+        gen = generator.flow(edges_to_sample)
+
+        for ii in range(len(gen)):
+            xf, xl = gen[ii]
+        return xf, xl
+
+    benchmark(read_generator)
+
+
+@pytest.mark.benchmark(group="generator")
+def test_benchmark_node_generator_small(benchmark):
+    n_feat = 1024
+    n_nodes = 200
+    batch_size = 10
+    num_samples = [20, 10]
+
+    G = example_Graph_2(n_feat)
+    nodes = list(G.nodes())
+    nodes_to_sample = random.choices(nodes, k=n_nodes)
+
+    generator = GraphSAGENodeGenerator(
+        G, batch_size=batch_size, num_samples=num_samples
+    )
+
+    def read_generator():
+        gen = generator.flow(nodes_to_sample)
+
+        for ii in range(len(gen)):
+            xf, xl = gen[ii]
+        return xf, xl
+
+    benchmark(read_generator)
+
+
+@pytest.mark.benchmark(group="generator")
+def test_benchmark_node_generator_large(benchmark):
+    n_feat = 1024
+    n_nodes = 200
+    batch_size = 10
+    num_samples = [20, 10]
+
+    G = example_Graph_2(n_feat, 5000, 20000)
+    nodes = list(G.nodes())
+    nodes_to_sample = random.choices(nodes, k=n_nodes)
+
+    generator = GraphSAGENodeGenerator(
+        G, batch_size=batch_size, num_samples=num_samples
+    )
+
+    def read_generator():
+        gen = generator.flow(nodes_to_sample)
+
+        for ii in range(len(gen)):
+            xf, xl = gen[ii]
+        return xf, xl
+
+    benchmark(read_generator)

--- a/tests/mapper/test_node_mappers.py
+++ b/tests/mapper/test_node_mappers.py
@@ -150,6 +150,7 @@ def example_hin_3(feature_size_by_type=None):
 
     # Node 2 has no edges of type 1
     # Node 1 has no edges of type 2
+    # Node 6 has no edges
 
     # Add example features
     if feature_size_by_type is not None:


### PR DESCRIPTION
Fixed the handling of isolated nodes in GraphSAGE node and link generators.

Isolated nodes were already handled by the HinSAGE generators, so this PR gives GraphSAGE generators the same behavior. Now, when an isolated node is a head node for a generator the random samples of neighbors will be filled with the null-node ID. This is currently the Python `None`. Next the `StellarGraph.get_features_for_nodes` method will get the null-node features (currently all zeros) and put these in the batch features.  In future, the null-node features could be configurable, and even trainable.

Also introduced are unit tests to test for isolated head nodes in node and link generators for both GraphSAGE and HinSAGE generators.

Now, running the graphsage link prediction demo using the `EdgeSplitter` with `keep_connected=False` works and gives similar error to the `keep_connected=True` setting.