### PR TITLE
Tests/schema tests

### DIFF
--- a/demos/node-classification-graphsage/graphsage-cora-example.py
+++ b/demos/node-classification-graphsage/graphsage-cora-example.py
@@ -101,7 +101,7 @@ def train(
 
     # Create graph schema
     sample_edges = [e for ii,e in enumerate(G.edges(keys=True)) if ii < 5]
-    schema = G.create_graph_schema(nodes=node_ids[:1], edges=sample_edges)
+    schema = G.create_graph_schema(create_type_maps=False, nodes=node_ids[:1], edges=sample_edges)
 
     # Create mappers for GraphSAGE that input data from the graph to the model
     generator = GraphSAGENodeGenerator(G, batch_size, num_samples, schema=schema, seed=42)

--- a/demos/node-classification-graphsage/graphsage-cora-example.py
+++ b/demos/node-classification-graphsage/graphsage-cora-example.py
@@ -99,8 +99,12 @@ def train(
         test_nodes, test_targets, train_size=500, test_size=None, random_state=523214
     )
 
+    # Create graph schema
+    sample_edges = [e for ii,e in enumerate(G.edges(keys=True)) if ii < 5]
+    schema = G.create_graph_schema(nodes=node_ids[:1], edges=sample_edges)
+
     # Create mappers for GraphSAGE that input data from the graph to the model
-    generator = GraphSAGENodeGenerator(G, batch_size, num_samples, seed=42)
+    generator = GraphSAGENodeGenerator(G, batch_size, num_samples, schema=schema, seed=42)
     train_gen = generator.flow(train_nodes, train_targets)
     val_gen = generator.flow(val_nodes, val_targets)
 

--- a/demos/node-classification-graphsage/graphsage-cora-example.py
+++ b/demos/node-classification-graphsage/graphsage-cora-example.py
@@ -99,12 +99,8 @@ def train(
         test_nodes, test_targets, train_size=500, test_size=None, random_state=523214
     )
 
-    # Create graph schema
-    sample_edges = [e for ii,e in enumerate(G.edges(keys=True)) if ii < 5]
-    schema = G.create_graph_schema(create_type_maps=False, nodes=node_ids[:1], edges=sample_edges)
-
     # Create mappers for GraphSAGE that input data from the graph to the model
-    generator = GraphSAGENodeGenerator(G, batch_size, num_samples, schema=schema, seed=42)
+    generator = GraphSAGENodeGenerator(G, batch_size, num_samples, seed=42)
     train_gen = generator.flow(train_nodes, train_targets)
     val_gen = generator.flow(val_nodes, val_targets)
 

--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -459,8 +459,11 @@ class StellarGraphBase:
         node_indices = [nt_id_to_index.get(n) for n in nodes]
 
         if None in node_indices:
+            problem_nodes = [
+                node for node, index in zip(nodes, node_indices) if index is None
+            ]
             raise ValueError(
-                "Incorrect node specified or nodes of multiple types found."
+                "Could not find features for nodes with IDs {}.".format(problem_nodes)
             )
 
         features = self._node_attribute_arrays[node_type][node_indices]
@@ -607,7 +610,7 @@ class StellarGraphBase:
 
         return s
 
-    def create_graph_schema(self, create_type_maps=False, nodes=None, edges=None):
+    def create_graph_schema(self, create_type_maps=True, nodes=None, edges=None):
         """
         Create graph schema in dict of dict format from current graph.
 

--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -506,6 +506,19 @@ class StellarGraphBase:
                 if ndata.get(self._node_type_attr) == node_type
             ]
 
+    def type_for_node(self, node):
+        """
+        Get the type of the node
+
+        Args:
+            node: Node ID
+
+        Returns:
+            Node type
+        """
+        ndata = self.node[node]
+        return ndata.get(self._node_type_attr)
+
     @property
     def node_types(self):
         """
@@ -594,7 +607,7 @@ class StellarGraphBase:
 
         return s
 
-    def create_graph_schema(self, create_type_maps=True, nodes=None, edges=None):
+    def create_graph_schema(self, create_type_maps=False, nodes=None, edges=None):
         """
         Create graph schema in dict of dict format from current graph.
 
@@ -610,15 +623,11 @@ class StellarGraphBase:
         if nodes is None:
             nodes = self.nodes()
         elif create_type_maps is True:
-            raise ValueError(
-                "Creating type mapes for subsampled nodes is not supported"
-            )
+            raise ValueError("Creating type maps for subsampled nodes is not supported")
         if edges is None:
             edges = self.edges(keys=True)
         elif create_type_maps is True:
-            raise ValueError(
-                "Creating type mapes for subsampled edges is not supported"
-            )
+            raise ValueError("Creating type maps for subsampled edges is not supported")
 
         # Create node type index list
         node_types = sorted(

--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -390,8 +390,6 @@ class StellarGraphBase:
         An error will be raised if the graph is not correctly setup.
         """
         # TODO: This are simple tests and miss many problems that could arise, improve!
-        # TODO: At this point perhaps we should generate features rather than in fit_attribute_spec
-        # TODO: but if so how do we know whether to fit the attribute specs or not?
         # Check features on the nodes:
         if features and len(self._node_attribute_arrays) == 0:
             raise RuntimeError(
@@ -399,7 +397,9 @@ class StellarGraphBase:
                 "Node features are required for machine learning"
             )
 
-        # How about checking the schema?
+        # TODO: check the schema
+
+        # TODO: check the feature node_ids against the graph node ids?
 
     def get_feature_for_nodes(self, nodes, node_type=None):
         """
@@ -419,8 +419,7 @@ class StellarGraphBase:
         if not is_real_iterable(nodes):
             nodes = [nodes]
 
-        # Get the node type
-        # TODO: This is slow, refactor so that self._node_index_maps gives the node type
+        # Get the node type if not specified.
         if node_type is None:
             node_types = {
                 self.node[n].get(self._node_type_attr) for n in nodes if n is not None

--- a/stellargraph/layer/graphsage.py
+++ b/stellargraph/layer/graphsage.py
@@ -474,6 +474,9 @@ class GraphSAGE:
         elif normalize is None or normalize == "none":
             self._normalization = Lambda(lambda x: x)
 
+        else:
+            raise ValueError("Normalization should be either 'l2' or 'none'")
+
         # Get the input_dim and num_samples from the mapper if it is given
         # Use both the schema and head node type from the mapper
         # TODO: Refactor the horror of generator.generator.graph...

--- a/stellargraph/mapper/node_mappers.py
+++ b/stellargraph/mapper/node_mappers.py
@@ -31,7 +31,7 @@ from ..data.explorer import (
     SampledBreadthFirstWalk,
     SampledHeterogeneousBreadthFirstWalk,
 )
-from ..core.graph import StellarGraphBase
+from ..core.graph import StellarGraphBase, GraphSchema
 from ..core.utils import is_real_iterable
 
 
@@ -77,7 +77,10 @@ class NodeSequence(Sequence):
 
         # Infer head_node_type
         # TODO: Generalize to multiple head node target types?
-        head_node_types = set([generator.schema.get_node_type(n) for n in ids])
+        if generator.schema.node_type_map is None:
+            head_node_types = {generator.graph.type_for_node(n) for n in ids}
+        else:
+            head_node_types = {generator.schema.get_node_type(n) for n in ids}
         if len(head_node_types) > 1:
             raise ValueError(
                 "Only a single head node type is currently supported for HinSAGE models"
@@ -157,11 +160,12 @@ class GraphSAGENodeGenerator:
         G (StellarGraph): The machine-learning ready graph.
         batch_size (int): Size of batch to return.
         num_samples (list): The number of samples per layer (hop) to take.
+        schema (GraphSchema): [Optional] Graph schema for G.
         seed (int): [Optional] Random seed for the node sampler.
         name (str or None): Name of the generator (optional)
     """
 
-    def __init__(self, G, batch_size, num_samples, seed=None, name=None):
+    def __init__(self, G, batch_size, num_samples, schema=None, seed=None, name=None):
         if not isinstance(G, StellarGraphBase):
             raise TypeError("Graph must be a StellarGraph object.")
 
@@ -177,7 +181,12 @@ class GraphSAGENodeGenerator:
         self.sampler = SampledBreadthFirstWalk(G, seed=seed)
 
         # We need a schema for compatibility with HinSAGE
-        self.schema = G.create_graph_schema(create_type_maps=True)
+        if schema is None:
+            self.schema = G.create_graph_schema(create_type_maps=True)
+        elif isinstance(schema, GraphSchema):
+            self.schema = schema
+        else:
+            raise TypeError("Schema must be a GraphSchema object")
 
         # Check that there is only a single node type for GraphSAGE
         if len(self.schema.node_types) > 1:
@@ -298,11 +307,12 @@ class HinSAGENodeGenerator:
         G (StellarGraph): The machine-learning ready graph
         batch_size (int): Size of batch to return
         num_samples (list): The number of samples per layer (hop) to take
+        schema (GraphSchema): [Optional] Graph schema for G.
         seed (int), Optional: Random seed for the node sampler
         name (str), optional: Name of the generator.
      """
 
-    def __init__(self, G, batch_size, num_samples, seed=None, name=None):
+    def __init__(self, G, batch_size, num_samples, schema=None, seed=None, name=None):
 
         self.graph = G
         self.num_samples = num_samples
@@ -319,7 +329,13 @@ class HinSAGENodeGenerator:
         self.sampler = SampledHeterogeneousBreadthFirstWalk(G, seed=seed)
 
         # Generate schema
-        self.schema = G.create_graph_schema(create_type_maps=True)
+        # We need a schema for compatibility with HinSAGE
+        if schema is None:
+            self.schema = G.create_graph_schema(create_type_maps=True)
+        elif isinstance(schema, GraphSchema):
+            self.schema = schema
+        else:
+            raise TypeError("Schema must be a GraphSchema object")
 
     def sample_features(self, head_nodes, sampling_schema):
         """

--- a/stellargraph/mapper/node_mappers.py
+++ b/stellargraph/mapper/node_mappers.py
@@ -75,6 +75,12 @@ class NodeSequence(Sequence):
                     "The length of the targets must be the same as the length of the ids"
                 )
 
+        # Check all IDs are actually in the graph
+        if any(n not in generator.graph for n in ids):
+            raise KeyError(
+                "Head nodes supplied to generator contain IDs not found in graph"
+            )
+
         # Infer head_node_type
         if generator.schema.node_type_map is None:
             head_node_types = {generator.graph.type_for_node(n) for n in ids}

--- a/tests/core/test_schema.py
+++ b/tests/core/test_schema.py
@@ -8,19 +8,14 @@
 #
 # http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing, softwarware
+# Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
 import pytest
-import pandas as pd
-import networkx as nx
-
-import stellargraph as sg
 from stellargraph.core.schema import *
-from stellargraph.data.converter import *
 import itertools as it
 
 

--- a/tests/core/test_schema.py
+++ b/tests/core/test_schema.py
@@ -1,0 +1,189 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2017-2018 Data61, CSIRO
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, softwarware
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import pandas as pd
+import networkx as nx
+
+import stellargraph as sg
+from stellargraph.core.schema import *
+from stellargraph.data.converter import *
+import itertools as it
+
+
+@pytest.fixture
+def example_graph_schema():
+    def create_schema(aa=1, ab=1, ba=1, bb=1):
+        # graph schema
+        schema = {"A": [], "B": []}
+        for ii in range(aa):
+            schema["A"].append(EdgeType("A", "a%d" % ii, "A"))
+        for ii in range(ab):
+            schema["A"].append(EdgeType("A", "ab%d" % ii, "B"))
+        for ii in range(ba):
+            schema["B"].append(EdgeType("B", "ab%d" % ii, "A"))
+        for ii in range(bb):
+            schema["B"].append(EdgeType("B", "b%d" % ii, "B"))
+
+        # Create schema object
+        gs = GraphSchema()
+        gs.node_types = sorted(schema.keys())
+        gs.edge_types = sorted(set(it.chain(*schema.values())))
+        gs.schema = schema
+        return gs
+
+    return create_schema
+
+
+def test_homogeneous_graph_schema(example_graph_schema):
+    # Create dummy graph schema
+    gs = example_graph_schema(bb=0)
+
+    assert gs.node_index("A") == 0
+    assert gs.node_index("B") == 1
+
+    assert gs.edge_index(EdgeType("A", "a0", "A")) == 0
+    assert gs.edge_index(EdgeType("A", "ab0", "B")) == 1
+    assert gs.edge_index(EdgeType("B", "ab0", "A")) == 2
+
+    # Directed schema
+    gs = example_graph_schema(ba=0, bb=0)
+
+    assert gs.edge_index(EdgeType("A", "a0", "A")) == 0
+    assert gs.edge_index(EdgeType("A", "ab0", "B")) == 1
+
+    with pytest.raises(ValueError):
+        gs.edge_index(EdgeType("B", "ab0", "A"))
+
+
+def test_graph_schema_sampling(example_graph_schema):
+    # Create dummy graph schema
+    schema = example_graph_schema(bb=0)
+
+    # Only accepts lists & tuples
+    with pytest.raises(TypeError):
+        schema.type_adjacency_list("A", 2)
+
+    # Only accepts int for n_hops
+    with pytest.raises(TypeError):
+        schema.type_adjacency_list("A", None)
+
+    type_list = schema.type_adjacency_list(["A", "B"], n_hops=2)
+
+    assert type_list[0][0] == "A"
+    assert type_list[1][0] == "B"
+
+    for lt in type_list:
+        adj_types = [t.n2 for t in schema.schema[lt[0]]]
+        list_types = [type_list[adj_n][0] for adj_n in lt[1]]
+
+        if len(list_types) > 0:
+            assert set(adj_types) == set(list_types)
+
+
+def test_graph_schema_sampling_layout_1(example_graph_schema):
+    # Create dummy graph schema
+    schema = example_graph_schema(aa=0, bb=0)
+
+    sampling_layout = schema.sampling_layout(["A"], [2, 2])
+
+    assert len(sampling_layout) == 1
+
+    assert sampling_layout[0][2] == ("A", [2, 3])
+    assert sampling_layout[0][1] == ("B", [1])
+    assert sampling_layout[0][0] == ("A", [0])
+
+    # Check error handling
+    schema = example_graph_schema(ab=2, ba=2, bb=0)
+
+    # Only accepts lists & tuples
+    with pytest.raises(TypeError):
+        schema.sampling_layout("A", [1, 2])
+
+    # Multiple edge types
+    schema = example_graph_schema(ab=2, ba=2, bb=0)
+    sampling_layout = schema.sampling_layout(("A",), [1, 2])
+
+    assert len(sampling_layout) == 1
+
+    assert sampling_layout[0] == [
+        ("A", [0]),
+        ("A", [1]),
+        ("B", [2]),
+        ("B", [3]),
+        ("A", [4]),
+        ("B", [5]),
+        ("B", [6]),
+        ("A", [7]),
+        ("A", [8]),
+        ("A", [9]),
+        ("A", [10]),
+    ]
+
+
+def test_graph_schema_sampling_tree(example_graph_schema):
+    # Create dummy graph schema
+    schema = example_graph_schema(bb=0)
+    type_list = schema.type_adjacency_list(["A", "B"], 3)
+    _, type_tree = schema.sampling_tree(["A", "B"], 3)
+
+    # Check that the tree corresponds to the adjacency list
+    def check_tree(tree):
+        items = []
+        for x in tree:
+            chd = check_tree(x[2])
+            assert x[1] == type_list[x[0]][0]
+            assert chd == type_list[x[0]][1]
+            items.append(x[0])
+        return items
+
+    check_tree(type_tree)
+
+
+def test_graph_schema_sampling_layout_multiple(example_graph_schema):
+    # Create dummy graph schema
+    schema = example_graph_schema(bb=0)
+    sampling_layout = schema.sampling_layout(["A", "B"], [2, 2])
+
+    assert len(sampling_layout) == 2
+    assert all((x1[0] == x2[0]) for x1, x2 in zip(*sampling_layout))
+
+    print(sampling_layout[0])
+
+    assert sampling_layout[0] == [
+        ("A", [0]),
+        ("B", []),
+        ("A", [1]),
+        ("B", [2]),
+        ("A", []),
+        ("A", [3, 5]),
+        ("B", [4, 6]),
+        ("A", [7, 8]),
+        ("A", []),
+        ("B", []),
+    ]
+    assert sampling_layout[1] == [
+        ("A", []),
+        ("B", [0]),
+        ("A", []),
+        ("B", []),
+        ("A", [1]),
+        ("A", []),
+        ("B", []),
+        ("A", []),
+        ("A", [2, 4]),
+        ("B", [3, 5]),
+    ]

--- a/tests/core/test_stellargraph.py
+++ b/tests/core/test_stellargraph.py
@@ -28,15 +28,6 @@ def create_graph_1(sg=StellarGraph()):
     return sg
 
 
-def create_graph_2(sg=StellarGraph()):
-    sg.add_nodes_from([0, 1, 2, 3], label="movie")
-    sg.add_nodes_from([4, 5], label="user")
-    sg.add_edges_from([(4, 0), (4, 1), (5, 1), (4, 2), (5, 3)], label="rating")
-    sg.add_edges_from([(0, 4), (1, 4), (1, 5), (2, 4), (3, 5)], label="another")
-    sg.add_edges_from([(4, 5)], label="friend")
-    return sg
-
-
 def example_stellar_graph_1(feature_name=None):
     G = nx.Graph()
     elist = [(1, 2), (2, 3), (1, 4), (3, 2)]
@@ -122,7 +113,7 @@ def test_digraph_constructor():
 
 
 def test_info():
-    sg = create_graph_2()
+    sg = create_graph_1()
     info_str = sg.info()
     info_str = sg.info(show_attributes=False)
     # How can we check this?
@@ -200,135 +191,8 @@ def test_digraph_schema():
         )
 
     assert schema.get_edge_type((4, 0, 0)) == ("user", "rating", "movie")
-    assert schema.get_edge_type((0, 4, 0)) == None
-
-
-def test_graph_schema_node_types():
-    for sg in [
-        create_graph_1(),
-        create_graph_2(),
-        create_graph_1(StellarDiGraph()),
-        create_graph_2(StellarDiGraph()),
-    ]:
-        schema = sg.create_graph_schema(create_type_maps=True)
-
-        for n, ndata in sg.nodes(data=True):
-            assert schema.get_node_type(n) == ndata["label"]
-
-
-def test_graph_schema_edge_types():
-    for sg in [create_graph_1(), create_graph_2()]:
-        schema = sg.create_graph_schema(create_type_maps=True)
-
-        for n1, n2, k in sg.edges(keys=True):
-            et = (
-                sg.node[n1]["label"],
-                sg.adj[n1][n2][k]["label"],
-                sg.node[n2]["label"],
-            )
-            assert schema.get_edge_type((n1, n2, k)) == et
-
-            # Check the is_of_edge_type function: it should work either way round for undirected
-            # graphs
-            assert schema.is_of_edge_type((n1, n2, k), et)
-            assert schema.is_of_edge_type((n1, n2, k), (et[2], et[1], et[0]))
-
-    for sg in [create_graph_1(StellarDiGraph()), create_graph_2(StellarDiGraph())]:
-        schema = sg.create_graph_schema(create_type_maps=True)
-
-        for n1, n2, k in sg.edges(keys=True):
-            et = (
-                sg.node[n1]["label"],
-                sg.adj[n1][n2][k]["label"],
-                sg.node[n2]["label"],
-            )
-            assert schema.get_edge_type((n1, n2, k)) == et
-
-            # Check the is_of_edge_type function: it should only work one way for directed graphs
-            assert schema.is_of_edge_type((n1, n2, k), et)
-            assert ~schema.is_of_edge_type((n1, n2, k), (et[2], et[1], et[0]))
-
-
-def test_graph_schema_sampling():
-    for sg in [
-        create_graph_1(),
-        create_graph_2(),
-        create_graph_1(StellarDiGraph()),
-        create_graph_2(StellarDiGraph()),
-    ]:
-        schema = sg.create_graph_schema()
-        type_list = schema.type_adjacency_list(["user", "movie"], n_hops=2)
-
-        assert type_list[0][0] == "user"
-        assert type_list[1][0] == "movie"
-
-        for lt in type_list:
-            adj_types = [t.n2 for t in schema.schema[lt[0]]]
-            list_types = [type_list[adj_n][0] for adj_n in lt[1]]
-
-            if len(list_types) > 0:
-                assert set(adj_types) == set(list_types)
-
-
-def test_graph_schema_sampling_layout_1():
-    sg = create_graph_1()
-    schema = sg.create_graph_schema(create_type_maps=True)
-    sampling_layout = schema.sampling_layout(["user"], [2, 2])
-
-    assert len(sampling_layout) == 1
-
-    assert sampling_layout[0][2] == ("user", [2, 3])
-    assert sampling_layout[0][1] == ("movie", [1])
-    assert sampling_layout[0][0] == ("user", [0])
-
-    sg = create_graph_2()
-    schema = sg.create_graph_schema(create_type_maps=True)
-    sampling_layout = schema.sampling_layout(["user"], [1, 2])
-
-    assert len(sampling_layout) == 1
-
-    assert sampling_layout[0] == [
-        ("user", [0]),
-        ("movie", [1]),
-        ("user", [2]),
-        ("movie", [3]),
-        ("user", [4]),
-        ("user", [5]),
-        ("movie", [6]),
-        ("user", [7]),
-        ("movie", [8]),
-        ("user", [9]),
-        ("user", [10]),
-    ]
-
-
-def test_graph_schema_sampling_layout_multiple():
-    sg = create_graph_1()
-    schema = sg.create_graph_schema(create_type_maps=True)
-    sampling_layout = schema.sampling_layout(["user", "movie"], [1, 2, 2])
-
-    assert len(sampling_layout) == 2
-
-    assert sampling_layout[0] == [
-        ("user", [0]),
-        ("movie", []),
-        ("movie", [1]),
-        ("user", []),
-        ("user", [2]),
-        ("movie", []),
-        ("movie", [3, 4]),
-        ("user", []),
-    ]
-    assert sampling_layout[1] == [
-        ("user", []),
-        ("movie", [0]),
-        ("movie", []),
-        ("user", [1]),
-        ("user", []),
-        ("movie", [2]),
-        ("movie", []),
-        ("user", [3, 4]),
-    ]
+    with pytest.raises(IndexError):
+        schema.get_edge_type((0, 4, 0))
 
 
 def test_feature_conversion_from_nodes():

--- a/tests/core/test_stellargraph.py
+++ b/tests/core/test_stellargraph.py
@@ -8,7 +8,7 @@
 #
 # http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing, softwarware
+# Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and

--- a/tests/layer/test_graphsage.py
+++ b/tests/layer/test_graphsage.py
@@ -19,12 +19,30 @@
 GraphSAGE tests
 
 """
-
-
+from stellargraph.core.graph import StellarGraph
+from stellargraph.mapper.node_mappers import GraphSAGENodeGenerator
 from stellargraph.layer.graphsage import *
+
 import keras
 import numpy as np
+import networkx as nx
 import pytest
+
+
+def example_graph_1(feature_size=None):
+    G = nx.Graph()
+    elist = [(1, 2), (2, 3), (1, 4), (3, 2)]
+    G.add_nodes_from([1, 2, 3, 4], label="default")
+    G.add_edges_from(elist, label="default")
+
+    # Add example features
+    if feature_size is not None:
+        for v in G.nodes():
+            G.node[v]["feature"] = np.ones(feature_size)
+        return StellarGraph(G, node_features="feature")
+
+    else:
+        return StellarGraph(G)
 
 
 def test_maxpool_agg_constructor():
@@ -35,6 +53,12 @@ def test_maxpool_agg_constructor():
     assert not agg.has_bias
     assert agg.act.__name__ == "relu"
     assert agg.hidden_act.__name__ == "relu"
+
+    # Check config
+    config = agg.get_config()
+    assert config["output_dim"] == 2
+    assert config["bias"] == False
+    assert config["act"] == "relu"
 
 
 def test_maxpool_agg_constructor_1():
@@ -47,7 +71,7 @@ def test_maxpool_agg_constructor_1():
 
 
 def test_maxpool_agg_apply():
-    agg = MaxPoolingAggregator(2, bias=False, act="linear")
+    agg = MaxPoolingAggregator(2, bias=True, act="linear")
     agg._initializer = "ones"
 
     # Self features
@@ -81,6 +105,12 @@ def test_meanpool_agg_constructor():
     assert agg.act.__name__ == "relu"
     assert agg.hidden_act.__name__ == "relu"
 
+    # Check config
+    config = agg.get_config()
+    assert config["output_dim"] == 2
+    assert config["bias"] == False
+    assert config["act"] == "relu"
+
 
 def test_meanpool_agg_constructor_1():
     agg = MeanPoolingAggregator(output_dim=4, bias=True, act=lambda x: x + 1)
@@ -92,7 +122,7 @@ def test_meanpool_agg_constructor_1():
 
 
 def test_meanpool_agg_apply():
-    agg = MeanPoolingAggregator(2, bias=False, act="linear")
+    agg = MeanPoolingAggregator(2, bias=True, act="linear")
     agg._initializer = "ones"
 
     # Self features
@@ -122,7 +152,12 @@ def test_mean_agg_constructor():
     assert agg.output_dim == 2
     assert agg.half_output_dim == 1
     assert not agg.has_bias
-    assert agg.act.__name__ == "relu"
+
+    # Check config
+    config = agg.get_config()
+    assert config["output_dim"] == 2
+    assert config["bias"] == False
+    assert config["act"] == "relu"
 
 
 def test_mean_agg_constructor_1():
@@ -134,7 +169,7 @@ def test_mean_agg_constructor_1():
 
 
 def test_mean_agg_apply():
-    agg = MeanAggregator(4, act=lambda x: x)
+    agg = MeanAggregator(4, bias=True, act=lambda x: x)
     agg._initializer = "ones"
     inp1 = keras.Input(shape=(1, 2))
     inp2 = keras.Input(shape=(1, 2, 2))
@@ -148,12 +183,31 @@ def test_mean_agg_apply():
 
 
 def test_graphsage_constructor():
-    gs = GraphSAGE(layer_sizes=[4], n_samples=[2], input_dim=2)
+    gs = GraphSAGE(layer_sizes=[4], n_samples=[2], input_dim=2, normalize="l2")
     assert gs.dims == [2, 4]
     assert gs.n_samples == [2]
     assert gs.n_layers == 1
     assert gs.bias
     assert len(gs._aggs) == 1
+
+    # Check incorrect normalization flag
+    with pytest.raises(ValueError):
+        GraphSAGE(layer_sizes=[4], n_samples=[2], input_dim=2, normalize=lambda x: x)
+
+    # Check requirement for generator or n_samples
+    with pytest.raises(RuntimeError):
+        GraphSAGE(layer_sizes=[4])
+
+    # Construction from generator
+    G = example_graph_1(feature_size=3)
+    gen = GraphSAGENodeGenerator(G, batch_size=2, num_samples=[2, 2]).flow([1, 2])
+    gs = GraphSAGE(layer_sizes=[4, 8], generator=gen, bias=True)
+
+    assert gs.dims == [3, 4, 8]
+    assert gs.n_samples == [2, 2]
+    assert gs.n_layers == 2
+    assert gs.bias
+    assert len(gs._aggs) == 2
 
 
 def test_graphsage_constructor_passing_aggregator():
@@ -165,6 +219,9 @@ def test_graphsage_constructor_passing_aggregator():
     assert gs.n_layers == 1
     assert gs.bias
     assert len(gs._aggs) == 1
+
+    with pytest.raises(TypeError):
+        GraphSAGE(layer_sizes=[4], n_samples=[2], input_dim=2, aggregator=1)
 
 
 def test_graphsage_constructor_1():
@@ -179,8 +236,9 @@ def test_graphsage_constructor_1():
 
 
 def test_graphsage_apply():
-    gs = GraphSAGE(layer_sizes=[4], n_samples=[2], bias=False, input_dim=2)
-    gs._normalization = lambda x: x
+    gs = GraphSAGE(
+        layer_sizes=[4], n_samples=[2], bias=False, input_dim=2, normalize="none"
+    )
     for agg in gs._aggs:
         agg._initializer = "ones"
 
@@ -198,8 +256,13 @@ def test_graphsage_apply():
 
 
 def test_graphsage_apply_1():
-    gs = GraphSAGE(layer_sizes=[2, 2, 2], n_samples=[2, 2, 2], bias=False, input_dim=2)
-    gs._normalization = lambda z: z
+    gs = GraphSAGE(
+        layer_sizes=[2, 2, 2],
+        n_samples=[2, 2, 2],
+        bias=False,
+        input_dim=2,
+        normalize=None,
+    )
     for agg in gs._aggs:
         agg._initializer = "ones"
 
@@ -217,3 +280,10 @@ def test_graphsage_apply_1():
     actual = model.predict(x)
     expected = np.array([[[16, 25]]])
     assert expected == pytest.approx(actual)
+
+    # Use the default model:
+    xinp, xout = gs.default_model()
+    model2 = keras.Model(inputs=xinp, outputs=xout)
+
+    expected = np.array([[[16, 25]]])
+    assert pytest.approx(expected) == model2.predict(x)

--- a/tests/layer/test_hinsage.py
+++ b/tests/layer/test_hinsage.py
@@ -42,6 +42,23 @@ def test_mean_hin_agg_constructor_1():
     assert agg.has_bias
     assert agg.act(2) == 3
 
+    # Check config
+    config = agg.get_config()
+    assert config["output_dim"] == 2
+    assert config["bias"] == True
+    assert config["act"] == "<lambda>"
+
+    agg = MeanHinAggregator(output_dim=2, bias=True, act="relu")
+    assert agg.output_dim == 2
+    assert agg.half_output_dim == 1
+    assert agg.has_bias
+
+    # Check config
+    config = agg.get_config()
+    assert config["output_dim"] == 2
+    assert config["bias"] == True
+    assert config["act"] == "relu"
+
 
 def test_mean_hin_agg_apply():
     agg = MeanHinAggregator(2, act=lambda z: z)
@@ -111,6 +128,61 @@ def test_hinsage_constructor():
     assert hs.n_samples == [2, 2]
     assert hs.bias
 
+    hs = HinSAGE(
+        layer_sizes=[2, 2],
+        n_samples=[2, 2],
+        input_neighbor_tree=[
+            ("1", [1, 2]),
+            ("1", [3, 4]),
+            ("2", [5]),
+            ("1", []),
+            ("2", []),
+            ("2", []),
+        ],
+        input_dim={"1": 2, "2": 2},
+    )
+    assert hs.n_layers == 2
+    assert hs.n_samples == [2, 2]
+    assert hs.bias
+
+
+def test_hinsage_constructor_with_agg():
+    hs = HinSAGE(
+        layer_sizes=[{"1": 2, "2": 2}, {"1": 2}],
+        n_samples=[2, 2],
+        input_neighbor_tree=[
+            ("1", [1, 2]),
+            ("1", [3, 4]),
+            ("2", [5]),
+            ("1", []),
+            ("2", []),
+            ("2", []),
+        ],
+        input_dim={"1": 2, "2": 2},
+        aggregator=MeanHinAggregator,
+    )
+    assert hs.n_layers == 2
+    assert hs.n_samples == [2, 2]
+    assert hs.bias
+
+
+def test_hinsage_input_shapes():
+    hs = HinSAGE(
+        layer_sizes=[{"1": 2, "2": 2}, 2],
+        n_samples=[2, 2],
+        input_neighbor_tree=[
+            ("1", [1, 2]),
+            ("1", [3, 4]),
+            ("2", [5]),
+            ("1", []),
+            ("2", []),
+            ("2", []),
+        ],
+        input_dim={"1": 2, "2": 4},
+    )
+    print(hs._input_shapes())
+    assert hs._input_shapes() == [(1, 2), (2, 2), (2, 4), (4, 2), (4, 4), (4, 4)]
+
 
 def test_hinsage_apply():
     hs = HinSAGE(
@@ -142,6 +214,81 @@ def test_hinsage_apply():
 
     out = hs(inp)
     model = keras.Model(inputs=inp, outputs=out)
+
+    x = [
+        np.array([[[1, 1]]]),
+        np.array([[[2, 2], [2, 2]]]),
+        np.array([[[4, 4, 4, 4], [4, 4, 4, 4]]]),
+        np.array([[[3, 3], [3, 3], [3, 3], [3, 3]]]),
+        np.array([[[6, 6, 6, 6], [6, 6, 6, 6], [6, 6, 6, 6], [6, 6, 6, 6]]]),
+        np.array([[[9, 9, 9, 9], [9, 9, 9, 9], [9, 9, 9, 9], [9, 9, 9, 9]]]),
+    ]
+
+    actual = model.predict(x)
+    expected = np.array([[[12, 35.5]]])
+    assert actual == pytest.approx(expected)
+
+
+def test_hinsage_default_model():
+    hs = HinSAGE(
+        layer_sizes=[2, 2],
+        n_samples=[2, 2],
+        input_neighbor_tree=[
+            ("1", [1, 2]),
+            ("1", [3, 4]),
+            ("2", [5]),
+            ("1", []),
+            ("2", []),
+            ("2", []),
+        ],
+        input_dim={"1": 2, "2": 4},
+        normalize="none",
+    )
+
+    for aggs in hs._aggs:
+        for _, agg in aggs.items():
+            agg._initializer = "ones"
+
+    xin, xout = hs.default_model()
+    model = keras.Model(inputs=xin, outputs=xout)
+
+    x = [
+        np.array([[[1, 1]]]),
+        np.array([[[2, 2], [2, 2]]]),
+        np.array([[[4, 4, 4, 4], [4, 4, 4, 4]]]),
+        np.array([[[3, 3], [3, 3], [3, 3], [3, 3]]]),
+        np.array([[[6, 6, 6, 6], [6, 6, 6, 6], [6, 6, 6, 6], [6, 6, 6, 6]]]),
+        np.array([[[9, 9, 9, 9], [9, 9, 9, 9], [9, 9, 9, 9], [9, 9, 9, 9]]]),
+    ]
+
+    actual = model.predict(x)
+    expected = np.array([[[12, 35.5]]])
+    assert actual == pytest.approx(expected)
+
+
+def test_hinsage_aggregators():
+    hs = HinSAGE(
+        layer_sizes=[2, 2],
+        n_samples=[2, 2],
+        input_neighbor_tree=[
+            ("1", [1, 2]),
+            ("1", [3, 4]),
+            ("2", [5]),
+            ("1", []),
+            ("2", []),
+            ("2", []),
+        ],
+        input_dim={"1": 2, "2": 4},
+        aggregator=MeanHinAggregator,
+        normalize="none",
+    )
+
+    for aggs in hs._aggs:
+        for _, agg in aggs.items():
+            agg._initializer = "ones"
+
+    xin, xout = hs.default_model()
+    model = keras.Model(inputs=xin, outputs=xout)
 
     x = [
         np.array([[[1, 1]]]),

--- a/tests/mapper/test_benchmark_generators.py
+++ b/tests/mapper/test_benchmark_generators.py
@@ -1,3 +1,19 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2018 Data61, CSIRO
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import random
 
 from stellargraph.mapper.link_mappers import *

--- a/tests/mapper/test_benchmark_generators.py
+++ b/tests/mapper/test_benchmark_generators.py
@@ -1,0 +1,165 @@
+import random
+
+from stellargraph.mapper.link_mappers import *
+from stellargraph.mapper.node_mappers import *
+from stellargraph.core.graph import *
+
+import numpy as np
+import networkx as nx
+import pytest
+
+
+def example_Graph_2(feature_size=None, n_nodes=100, n_edges=200):
+    G = nx.Graph()
+
+    edges = [
+        (random.randint(0, n_nodes - 1), random.randint(0, n_nodes - 1))
+        for _ in range(n_edges)
+    ]
+    G.add_edges_from(edges)
+
+    # Add example features
+    if feature_size is not None:
+        for v in G.nodes():
+            G.node[v]["feature"] = np.ones(feature_size)
+
+    G = StellarGraph(G, node_features="feature")
+    return G
+
+
+@pytest.mark.benchmark(group="generator")
+def test_benchmark_setup_generator_small(benchmark):
+    n_feat = 1024
+    n_edges = 100
+    batch_size = 10
+    num_samples = [20, 10]
+
+    G = example_Graph_2(n_feat)
+    nodes = list(G.nodes())
+    edges_to_sample = np.reshape(random.choices(nodes, k=2 * n_edges), (n_edges, 2))
+
+    def setup_generator():
+        generator = GraphSAGELinkGenerator(
+            G, batch_size=batch_size, num_samples=num_samples
+        )
+
+    benchmark(setup_generator)
+
+
+@pytest.mark.benchmark(group="generator")
+def test_benchmark_setup_generator_large(benchmark):
+    n_feat = 1024
+    n_edges = 100
+    batch_size = 10
+    num_samples = [20, 10]
+
+    G = example_Graph_2(n_feat, 5000, 20000)
+    nodes = list(G.nodes())
+    edges_to_sample = np.reshape(random.choices(nodes, k=2 * n_edges), (n_edges, 2))
+
+    def setup_generator():
+        generator = GraphSAGELinkGenerator(
+            G, batch_size=batch_size, num_samples=num_samples
+        )
+
+    benchmark(setup_generator)
+
+
+@pytest.mark.benchmark(group="generator")
+def test_benchmark_link_generator_small(benchmark):
+    n_feat = 1024
+    n_edges = 100
+    batch_size = 10
+    num_samples = [20, 10]
+
+    G = example_Graph_2(n_feat)
+    nodes = list(G.nodes())
+    edges_to_sample = np.reshape(random.choices(nodes, k=2 * n_edges), (n_edges, 2))
+
+    generator = GraphSAGELinkGenerator(
+        G, batch_size=batch_size, num_samples=num_samples
+    )
+
+    def read_generator():
+        gen = generator.flow(edges_to_sample)
+
+        for ii in range(len(gen)):
+            xf, xl = gen[ii]
+        return xf, xl
+
+    benchmark(read_generator)
+
+
+@pytest.mark.benchmark(group="generator")
+def test_benchmark_link_generator_large(benchmark):
+    n_feat = 1024
+    n_edges = 100
+    batch_size = 10
+    num_samples = [20, 10]
+
+    G = example_Graph_2(n_feat, 5000, 20000)
+    nodes = list(G.nodes())
+    edges_to_sample = np.reshape(random.choices(nodes, k=2 * n_edges), (n_edges, 2))
+
+    generator = GraphSAGELinkGenerator(
+        G, batch_size=batch_size, num_samples=num_samples
+    )
+
+    def read_generator():
+        gen = generator.flow(edges_to_sample)
+
+        for ii in range(len(gen)):
+            xf, xl = gen[ii]
+        return xf, xl
+
+    benchmark(read_generator)
+
+
+@pytest.mark.benchmark(group="generator")
+def test_benchmark_node_generator_small(benchmark):
+    n_feat = 1024
+    n_nodes = 200
+    batch_size = 10
+    num_samples = [20, 10]
+
+    G = example_Graph_2(n_feat)
+    nodes = list(G.nodes())
+    nodes_to_sample = random.choices(nodes, k=n_nodes)
+
+    generator = GraphSAGENodeGenerator(
+        G, batch_size=batch_size, num_samples=num_samples
+    )
+
+    def read_generator():
+        gen = generator.flow(nodes_to_sample)
+
+        for ii in range(len(gen)):
+            xf, xl = gen[ii]
+        return xf, xl
+
+    benchmark(read_generator)
+
+
+@pytest.mark.benchmark(group="generator")
+def test_benchmark_node_generator_large(benchmark):
+    n_feat = 1024
+    n_nodes = 200
+    batch_size = 10
+    num_samples = [20, 10]
+
+    G = example_Graph_2(n_feat, 5000, 20000)
+    nodes = list(G.nodes())
+    nodes_to_sample = random.choices(nodes, k=n_nodes)
+
+    generator = GraphSAGENodeGenerator(
+        G, batch_size=batch_size, num_samples=num_samples
+    )
+
+    def read_generator():
+        gen = generator.flow(nodes_to_sample)
+
+        for ii in range(len(gen)):
+            xf, xl = gen[ii]
+        return xf, xl
+
+    benchmark(read_generator)

--- a/tests/mapper/test_node_mappers.py
+++ b/tests/mapper/test_node_mappers.py
@@ -242,6 +242,10 @@ def test_nodemapper_1():
     assert nf[1].shape == (1, 2, n_feat)
     assert nf[2].shape == (1, 2 * 2, n_feat)
 
+    # This will fail as the nodes are not in the graph
+    with pytest.raises(KeyError):
+        GraphSAGENodeGenerator(G1, batch_size=2, num_samples=[2, 2]).flow(["A", "B"])
+
 
 def test_nodemapper_with_labels():
     n_feat = 4

--- a/tests/mapper/test_node_mappers.py
+++ b/tests/mapper/test_node_mappers.py
@@ -150,6 +150,7 @@ def example_hin_3(feature_size_by_type=None):
 
     # Node 2 has no edges of type 1
     # Node 1 has no edges of type 2
+    # Node 6 has no edges
 
     # Add example features
     if feature_size_by_type is not None:

--- a/tests/mapper/test_node_mappers.py
+++ b/tests/mapper/test_node_mappers.py
@@ -333,6 +333,29 @@ def test_nodemapper_isolated_nodes():
     assert pytest.approx(nf[2][2:]) == 0
 
 
+def test_nodemapper_manual_schema():
+    """
+    Tests checks on head nodes
+    """
+    n_feat = 4
+    n_batch = 2
+
+    # test graph
+    G = example_graph_1(feature_size=n_feat)
+
+    # Create manual schema
+    schema = G.create_graph_schema(create_type_maps=True)
+    GraphSAGENodeGenerator(G, schema=schema, batch_size=n_batch, num_samples=[1]).flow(
+        list(G)
+    )
+
+    # Create manual schema without type maps
+    schema = G.create_graph_schema(create_type_maps=False)
+    GraphSAGENodeGenerator(G, schema=schema, batch_size=n_batch, num_samples=[1]).flow(
+        list(G)
+    )
+
+
 def test_nodemapper_incorrect_targets():
     """
     Tests checks on target shape
@@ -385,6 +408,15 @@ def test_hinnodemapper_constructor_no_features():
         mapper = HinSAGENodeGenerator(G, batch_size=2, num_samples=[2, 2]).flow(
             G.nodes()
         )
+
+
+def test_hinnodemapper_constructor_nx_graph():
+    G = nx.Graph()
+    with pytest.raises(TypeError):
+        HinSAGENodeGenerator(G, batch_size=2, num_samples=[2, 2])
+
+    with pytest.raises(TypeError):
+        HinSAGENodeGenerator(None, batch_size=2, num_samples=[2, 2])
 
 
 def test_hinnodemapper_level_1():
@@ -470,6 +502,27 @@ def test_hinnodemapper_with_labels():
     # Check beyond the graph lengh
     with pytest.raises(IndexError):
         nf, nl = gen[len(gen)]
+
+
+def test_hinnodemapper_manual_schema():
+    """
+    Tests checks on head nodes
+    """
+    n_batch = 2
+    feature_sizes = {"t1": 1, "t2": 2}
+    G, nodes_type_1, nodes_type_2 = example_hin_2(feature_sizes)
+
+    # Create manual schema
+    schema = G.create_graph_schema(create_type_maps=True)
+    HinSAGENodeGenerator(G, schema=schema, batch_size=n_batch, num_samples=[1]).flow(
+        nodes_type_1
+    )
+
+    # Create manual schema without type maps
+    schema = G.create_graph_schema(create_type_maps=False)
+    HinSAGENodeGenerator(G, schema=schema, batch_size=n_batch, num_samples=[1]).flow(
+        nodes_type_1
+    )
 
 
 def test_hinnodemapper_no_neighbors():


### PR DESCRIPTION
* Added more unit tests for`core/schema.py` and moved tests to `core` subdirectory.
* Added mode unit tests for `layers/hinsage.py` and `layers/graphsage.py`.
* Removed unused schema methods `node_index_to_type` and `edge_index_to_type`
* Removed `edges` option for method `StellarGraph.create_graph_schema` and using edges connected to the specified nodes.