### PR TITLE
update docker plugin to 2.1.0

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,6 +10,7 @@ steps:
         environment:
           - PYTHONDONTWRITEBYTECODE=1
           - COVERALLS_REPO_TOKEN=$COVERALLS_REPO_TOKEN
+          - GIT_BRANCH=$BUILDKITE_BRANCH
 
   - label: "style"
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,7 +5,7 @@ steps:
         && py.test -ra --cov=stellargraph tests/ --doctest-modules --doctest-modules --cov-report=term-missing -p no:cacheprovider
         && coveralls
     plugins:
-      docker#v1.3.0:
+      docker#v2.1.0:
         image: "python:3.6"
         workdir: /app
         environment:
@@ -16,7 +16,7 @@ steps:
     command:
       - --check stellargraph tests
     plugins:
-      docker#v1.3.0:
+      docker#v2.1.0:
         image: "stellargraph/black"
         workdir: /app
         entrypoint: /usr/bin/black

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,19 +7,15 @@ steps:
     plugins:
       docker#v2.1.0:
         image: "python:3.6"
-        workdir: /app
         environment:
           - PYTHONDONTWRITEBYTECODE=1
           - COVERALLS_REPO_TOKEN=$COVERALLS_REPO_TOKEN
 
   - label: "style"
-    command:
-      - --check stellargraph tests
     plugins:
       docker#v2.1.0:
         image: "stellargraph/black"
-        workdir: /app
-        entrypoint: /usr/bin/black
+        command: ["--check", "stellargraph", "tests"]
         environment:
           - PYTHONDONTWRITEBYTECODE=1
 


### PR DESCRIPTION
PR to update the buildkite docker plugin version, and fix the issue with coveralls.io only detecting the `HEAD`

Going by https://coveralls-python.readthedocs.io/en/latest/usage/vcsconfig.html it seems that `coveralls` uses the internal `git` commands to collect information (but somehow fails). Adding the `GIT_BRANCH` env var seems to fix the branch detection issue.

![image](https://user-images.githubusercontent.com/856001/50671940-32977100-1029-11e9-9caf-cc686d80dbb0.png)
