### PR TITLE
upload junit to xml + move commands to script

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,6 +9,7 @@ steps:
           - COVERALLS_REPO_TOKEN=$COVERALLS_REPO_TOKEN
           - GIT_BRANCH=$BUILDKITE_BRANCH
           - BUILDKITE_BUILD_NUMBER=${BUILDKITE_BUILD_NUMBER?}
+          - BUILDKITE_BRANCH=${BUILDKITE_BRANCH?}
 
   - label: "style"
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,6 +10,7 @@ steps:
           - GIT_BRANCH=$BUILDKITE_BRANCH
           - BUILDKITE_BUILD_NUMBER=${BUILDKITE_BUILD_NUMBER?}
           - BUILDKITE_BRANCH=${BUILDKITE_BRANCH?}
+          - AWS_LOGS_BUCKET=${AWS_LOGS_BUCKET}
 
   - label: "style"
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,9 +1,6 @@
 steps:
   - label: ":python:"
-    command:
-      - pip install -q --no-cache-dir -r requirements.txt -e .
-        && py.test -ra --cov=stellargraph tests/ --doctest-modules --doctest-modules --cov-report=term-missing -p no:cacheprovider
-        && coveralls
+    command: ".buildkite/script.sh"
     plugins:
       docker#v2.1.0:
         image: "python:3.6"
@@ -11,6 +8,7 @@ steps:
           - PYTHONDONTWRITEBYTECODE=1
           - COVERALLS_REPO_TOKEN=$COVERALLS_REPO_TOKEN
           - GIT_BRANCH=$BUILDKITE_BRANCH
+          - BUILDKITE_BUILD_NUMBER=${BUILDKITE_BUILD_NUMBER?}
 
   - label: "style"
     plugins:

--- a/.buildkite/script.sh
+++ b/.buildkite/script.sh
@@ -10,6 +10,6 @@ pip install -q --no-cache-dir -r requirements.txt -e .
 py.test -ra --cov=stellargraph tests/ --doctest-modules --doctest-modules --cov-report=term-missing -p no:cacheprovider --junitxml=./${BUILDKITE_BUILD_NUMBER}.xml
 coveralls
 
-if [ "${BUILDKITE_BRANCH}" = "develop"  ] || [ "${BUILDKITE_BRANCH}" = "master" ] ; then
+if [ "${BUILDKITE_BRANCH}" = "develop"  ] || [ "${BUILDKITE_BRANCH}" = "master" ]  [ "${BUILDKITE_BRANCH}" = "feature/upload-junitxml-to-s3" ]; then
 	upload_tests
 fi

--- a/.buildkite/script.sh
+++ b/.buildkite/script.sh
@@ -3,7 +3,7 @@
 set -xeo pipefail
 
 upload_tests() {
-  buildkite-agent artifact upload "${BUILDKITE_BUILD_NUMBER}.xml" s3://stellargraph-logs-hosted/pytest/${BUILDKITE_BRANCH}/${BUILDKITE_BUILD_NUMBER}
+  buildkite-agent artifact upload "${BUILDKITE_BUILD_NUMBER}.xml" s3://${AWS_LOGS_BUCKET}/pytest/${BUILDKITE_BRANCH}/${BUILDKITE_BUILD_NUMBER}
 }
 
 pip install -q --no-cache-dir -r requirements.txt -e .

--- a/.buildkite/script.sh
+++ b/.buildkite/script.sh
@@ -10,6 +10,6 @@ pip install -q --no-cache-dir -r requirements.txt -e .
 py.test -ra --cov=stellargraph tests/ --doctest-modules --doctest-modules --cov-report=term-missing -p no:cacheprovider --junitxml=./${BUILDKITE_BUILD_NUMBER}.xml
 coveralls
 
-if [ "${BUILDKITE_BRANCH}" = "develop"  ] || [ "${BUILDKITE_BRANCH}" = "master" ]  [ "${BUILDKITE_BRANCH}" = "feature/upload-junitxml-to-s3" ]; then
+if [ "${BUILDKITE_BRANCH}" = "develop"  ] || [ "${BUILDKITE_BRANCH}" = "master" ] || [ "${BUILDKITE_BRANCH}" = "feature/upload-junitxml-to-s3" ]; then
 	upload_tests
 fi

--- a/.buildkite/script.sh
+++ b/.buildkite/script.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -xeo pipefail
+
+pip install -q --no-cache-dir -r requirements.txt -e .
+py.test -ra --cov=stellargraph tests/ --doctest-modules --doctest-modules --cov-report=term-missing -p no:cacheprovider --junitxml=./${BUILDKITE_BUILD_NUMBER}.xml
+coveralls
+
+# Upload junitxml to s3
+buildkite-agent artifact upload "${BUILDKITE_BUILD_NUMBER}.xml" s3://stellargraph-logs-hosted/pytest/${BUILDKITE_BUILD_NUMBER}

--- a/.buildkite/script.sh
+++ b/.buildkite/script.sh
@@ -10,6 +10,6 @@ pip install -q --no-cache-dir -r requirements.txt -e .
 py.test -ra --cov=stellargraph tests/ --doctest-modules --doctest-modules --cov-report=term-missing -p no:cacheprovider --junitxml=./${BUILDKITE_BUILD_NUMBER}.xml
 coveralls
 
-if [ "${BUILDKITE_BRANCH}" = "develop"  ] || [ "${BUILDKITE_BRANCH}" = "master" ] || [ "${BUILDKITE_BRANCH}" = "feature/upload-junitxml-to-s3" ]; then
+if [ "${BUILDKITE_BRANCH}" = "develop"  ] || [ "${BUILDKITE_BRANCH}" = "master" ] ; then
 	upload_tests
 fi

--- a/.buildkite/script.sh
+++ b/.buildkite/script.sh
@@ -2,9 +2,14 @@
 
 set -xeo pipefail
 
+upload_tests() {
+  buildkite-agent artifact upload "${BUILDKITE_BUILD_NUMBER}.xml" s3://stellargraph-logs-hosted/pytest/${BUILDKITE_BRANCH}/${BUILDKITE_BUILD_NUMBER}
+}
+
 pip install -q --no-cache-dir -r requirements.txt -e .
 py.test -ra --cov=stellargraph tests/ --doctest-modules --doctest-modules --cov-report=term-missing -p no:cacheprovider --junitxml=./${BUILDKITE_BUILD_NUMBER}.xml
 coveralls
 
-# Upload junitxml to s3
-buildkite-agent artifact upload "${BUILDKITE_BUILD_NUMBER}.xml" s3://stellargraph-logs-hosted/pytest/${BUILDKITE_BUILD_NUMBER}
+if [ "${BUILDKITE_BRANCH}" = "develop"  ] || [ "${BUILDKITE_BRANCH}" = "master" ] ; then
+	upload_tests
+fi


### PR DESCRIPTION
This PR:

* Move the command to a script—`script.sh`
* Records the `pytest` results to a junit xml file named after the build number
* Uploads junit xml files to s3 for parsing later (or to dashboard)
* Limit uploads only to `develop` and `master` branches
