### PR TITLE
Added GraphSAGE attention aggregator

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,8 @@ The StellarGraph library currently includes the following algorithms for graph m
 
 * GraphSAGE [1]
   - Supports representation learning, node classification/regression, and link prediction for homogeneous networks.
-  The current implementation supports mean aggregation of neighbour nodes only.
+  The current implementation supports multiple aggregation methods, including mean, maxpool, meanpool, and
+  attentional aggregators.
 
 * HinSAGE
   - Extension of GraphSAGE algorithm to heterogeneous networks.

--- a/docs/api.txt
+++ b/docs/api.txt
@@ -19,7 +19,7 @@ Layers
 ------------
 
 .. automodule:: stellargraph.layer
-  :members: GraphSAGE, MeanAggregator, HinSAGE, MeanHinAggregator, link_inference, link_classification, link_regression
+  :members: GraphSAGE, MeanAggregator, MeanPoolingAggregator, MaxPoolingAggregator, AttentionalAggregator, HinSAGE, MeanHinAggregator, link_inference, link_classification, link_regression
 
 Generators
 -----------

--- a/stellargraph/layer/__init__.py
+++ b/stellargraph/layer/__init__.py
@@ -6,7 +6,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,7 +17,6 @@
 
 """
 The layer package contains implementations of popular neural network layers for graph ML as Keras layers
-
 """
 
 # __all__ = ["graphsage", "hinsage", "link_inference"]

--- a/stellargraph/layer/graphsage.py
+++ b/stellargraph/layer/graphsage.py
@@ -492,7 +492,16 @@ class AttentionalAggregator(GraphSAGEAggregator):
 
 class GraphSAGE:
     """
-    Implementation of the GraphSAGE algorithm with Keras layers.
+    Implementation of the GraphSAGE algorithm of Hamilton et al. with Keras layers.
+    see: http://snap.stanford.edu/graphsage/
+
+    The model minimally requires specification of the layer sizes as a list of ints
+    corresponding to the feature dimensions for each hidden layer and a generator object.
+
+    Different aggregators can also be specified with the `aggregator` argument, which
+    should be the aggregator class, either :class:`MeanAggregator`,
+    :class:`MeanPoolingAggregator`, :class:`MaxPoolingAggregator`,
+    or :class:`AttentionalAggregator`.
 
     Args:
         layer_sizes (list): Hidden feature dimensions for each layer

--- a/stellargraph/layer/hinsage.py
+++ b/stellargraph/layer/hinsage.py
@@ -46,7 +46,7 @@ class MeanHinAggregator(Layer):
         output_dim: int = 0,
         bias: bool = False,
         act: Union[Callable, AnyStr] = "relu",
-        **kwargs,
+        **kwargs
     ):
         self.output_dim = output_dim
         assert output_dim % 2 == 0
@@ -122,9 +122,9 @@ class MeanHinAggregator(Layer):
 
         Args:
           x: List of Keras Tensors
-             x[0] = tensor of self features shape (n_batch, n_head, n_feat)
-             x[1+r] = tensors of neighbour features each of shape
-                (n_batch, n_head, n_neighbour[r], n_feat[r])
+            x[0] = tensor of self features shape (n_batch, n_head, n_feat)
+            x[1+r] = tensors of neighbour features each of shape
+            (n_batch, n_head, n_neighbour[r], n_feat[r])
 
         Returns:
             Keras Tensor representing the aggregated embeddings in the input.

--- a/stellargraph/layer/link_inference.py
+++ b/stellargraph/layer/link_inference.py
@@ -86,7 +86,7 @@ def link_inference(
         output_act (str), optional: activation function applied to the output, one of "softmax", "sigmoid", etc.,
             or any activation function supported by Keras, see https://keras.io/activations/ for more information.
         edge_feature_method (str), optional: Name of the method of combining (src,dst) node features into edge features.
-            One of
+            One of:
              * 'concat' -- concatenation,
              * 'ip' or 'dot' -- inner product, :math:`ip(u,v) = sum_{i=1..d}{u_i*v_i}`,
              * 'mul' or 'hadamard' -- element-wise multiplication, :math:`h(u,v)_i = u_i*v_i`,

--- a/tests/layer/test_graphsage.py
+++ b/tests/layer/test_graphsage.py
@@ -119,7 +119,7 @@ def test_maxpool_agg_zero_neighbours():
     x2 = np.zeros((1, 1, 0, 2))
 
     actual = model.predict([x1, x2])
-    expected = np.array([[[2, 2, 0, 0]]])
+    expected = np.array([[[2, 2, 2, 2]]])
     assert expected == pytest.approx(actual)
 
 
@@ -195,7 +195,7 @@ def test_meanpool_agg_zero_neighbours():
     x2 = np.zeros((1, 1, 0, 2))
 
     actual = model.predict([x1, x2])
-    expected = np.array([[[2, 2, 0, 0]]])
+    expected = np.array([[[2, 2, 2, 2]]])
     assert expected == pytest.approx(actual)
 
 
@@ -253,7 +253,7 @@ def test_mean_agg_zero_neighbours():
     x2 = np.zeros((1, 1, 0, 2))
 
     actual = model.predict([x1, x2])
-    expected = np.array([[[2, 2, 0, 0]]])
+    expected = np.array([[[2, 2, 2, 2]]])
     assert expected == pytest.approx(actual)
 
 
@@ -474,5 +474,5 @@ def test_graphsage_zero_neighbours():
     x = [np.array([[[1.5, 1]]]), np.zeros((1, 0, 2)), np.zeros((1, 0, 2))]
 
     actual = model.predict(x)
-    expected = np.array([[[2.5, 0]]])
+    expected = np.array([[[5, 5]]])
     assert actual == pytest.approx(expected)

--- a/tests/layer/test_graphsage.py
+++ b/tests/layer/test_graphsage.py
@@ -28,6 +28,8 @@ import numpy as np
 import networkx as nx
 import pytest
 
+from keras.engine import saving
+
 
 def example_graph_1(feature_size=None):
     G = nx.Graph()
@@ -43,6 +45,9 @@ def example_graph_1(feature_size=None):
 
     else:
         return StellarGraph(G)
+
+
+# MaxPooling aggregator tests
 
 
 def test_maxpool_agg_constructor():
@@ -68,6 +73,10 @@ def test_maxpool_agg_constructor_1():
     assert agg.hidden_dim == 4
     assert agg.has_bias
     assert agg.act(2) == 3
+
+    # Test for output dim not divisible by 2
+    with pytest.raises(ValueError):
+        MaxPoolingAggregator(output_dim=3)
 
 
 def test_maxpool_agg_apply():
@@ -114,6 +123,9 @@ def test_maxpool_agg_zero_neighbours():
     assert expected == pytest.approx(actual)
 
 
+# MeanPooling aggregator tests
+
+
 def test_meanpool_agg_constructor():
     agg = MeanPoolingAggregator(2, bias=False)
     assert agg.output_dim == 2
@@ -137,6 +149,10 @@ def test_meanpool_agg_constructor_1():
     assert agg.hidden_dim == 4
     assert agg.has_bias
     assert agg.act(2) == 3
+
+    # Test for output dim not divisible by 2
+    with pytest.raises(ValueError):
+        MeanPoolingAggregator(output_dim=3)
 
 
 def test_meanpool_agg_apply():
@@ -183,6 +199,7 @@ def test_meanpool_agg_zero_neighbours():
     assert expected == pytest.approx(actual)
 
 
+# Mean aggregator tests
 def test_mean_agg_constructor():
     agg = MeanAggregator(2)
     assert agg.output_dim == 2
@@ -202,6 +219,10 @@ def test_mean_agg_constructor_1():
     assert agg.half_output_dim == 2
     assert agg.has_bias
     assert agg.act(2) == 3
+
+    # Test for output dim not divisible by 2
+    with pytest.raises(ValueError):
+        MeanAggregator(output_dim=3)
 
 
 def test_mean_agg_apply():
@@ -233,6 +254,75 @@ def test_mean_agg_zero_neighbours():
 
     actual = model.predict([x1, x2])
     expected = np.array([[[2, 2, 0, 0]]])
+    assert expected == pytest.approx(actual)
+
+
+# Attentional aggregator tests
+def test_attn_agg_constructor():
+    agg = AttentionalAggregator(2, bias=False)
+    assert agg.output_dim == 2
+    assert not agg.has_bias
+    assert agg.act.__name__ == "relu"
+    # assert agg.attn_act.__name__ == "relu"
+
+    # Check config
+    config = agg.get_config()
+    assert config["output_dim"] == 2
+    assert config["bias"] == False
+    assert config["act"] == "relu"
+
+
+def test_attn_agg_constructor_1():
+    agg = AttentionalAggregator(output_dim=4, bias=True, act=lambda x: x + 1)
+    assert agg.output_dim == 4
+    assert agg.has_bias
+    assert agg.act(2) == 3
+
+
+def test_attn_agg_apply():
+    agg = AttentionalAggregator(2, bias=True, act="linear")
+    agg._initializer = "ones"
+    agg.attn_act = keras.activations.get("relu")
+
+    # Self features
+    inp1 = keras.Input(shape=(1, 2))
+    # Neighbour features
+    inp2 = keras.Input(shape=(1, 2, 2))
+
+    # Numerical test values
+    x1 = np.array([[[1, 1]]])
+    x2 = np.array([[[[2, 2], [3, 3]]]])
+
+    # Agg output:
+    # hs = relu(x1 · ones(2x2)) = [2,2]
+    # hn = relu(x2 · ones(2x2)) =  [[2,2], [4,4],[6,6]]
+    # attn_u = ones(2) · hs +  ones(2) · hn = [8, 12, 16]
+    # attn = softmax(attn_u) = [3.3e-4, 1.8e-4, 9.81e-1]
+    # hout =  attn · hn = [5.96, 5.96]
+
+    out = agg([inp1, inp2])
+    model = keras.Model(inputs=[inp1, inp2], outputs=out)
+    actual = model.predict([x1, x2])
+    expected = np.array([[[5.963, 5.963]]])
+
+    assert expected == pytest.approx(actual, rel=1e-4)
+
+
+def test_attn_agg_zero_neighbours():
+    agg = AttentionalAggregator(4, bias=False, act="linear")
+    agg._initializer = "ones"
+
+    inp1 = keras.Input(shape=(1, 2))
+    inp2 = keras.Input(shape=(1, 0, 2))
+
+    out = agg([inp1, inp2])
+    model = keras.Model(inputs=[inp1, inp2], outputs=out)
+
+    x1 = np.array([[[1, 1]]])
+    x2 = np.zeros((1, 1, 0, 2))
+
+    actual = model.predict([x1, x2])
+    expected = np.array([[[2, 2, 2, 2]]])
     assert expected == pytest.approx(actual)
 
 


### PR DESCRIPTION
Added n GAT-style attention aggregator for GraphSAGE. This performs the same attention computation as GAT on a batch of input nodes. Dropout is handled externally in the same way as the default GraphSAGE code (different to GAT which would require dropout within the aggregator).

Currently the aggregator is single-headed only. We can extend this to multi-headed in a more general way by adding the multi-head support in the GraphSAGE model class, enabling multiple-head models with different aggregators than just the attention aggregator.

Additional changes are to build a more flexible MLP model when there are zero samples in all aggregators (required as the attention aggregator wasn't compatible with how I did this previously).