### PR TITLE
refactored link inference classes to use `edge_embedding_method` instead of `edge_feature_method`

### DIFF
--- a/demos/link-prediction-graphsage/cora-links-example.ipynb
+++ b/demos/link-prediction-graphsage/cora-links-example.ipynb
@@ -448,7 +448,7 @@
    ],
    "source": [
     "prediction = link_classification(\n",
-    "        output_dim=1, output_act=\"relu\", edge_feature_method='ip'\n",
+    "        output_dim=1, output_act=\"relu\", edge_embedding_method='ip'\n",
     "    )(x_out)"
    ]
   },
@@ -700,7 +700,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.6"
   }
  },
  "nbformat": 4,

--- a/demos/link-prediction-graphsage/cora-links-example.py
+++ b/demos/link-prediction-graphsage/cora-links-example.py
@@ -166,7 +166,7 @@ def train(
 
     # Final estimator layer
     prediction = link_classification(
-        output_dim=1, output_act="sigmoid", edge_feature_method=args.edge_feature_method
+        output_dim=1, output_act="sigmoid", edge_embedding_method=args.edge_feature_method
     )(x_out)
 
     # Stack the GraphSAGE and prediction layers into a Keras model, and specify the loss

--- a/demos/link-prediction-graphsage/cora-links-example.py
+++ b/demos/link-prediction-graphsage/cora-links-example.py
@@ -166,7 +166,7 @@ def train(
 
     # Final estimator layer
     prediction = link_classification(
-        output_dim=1, output_act="sigmoid", edge_embedding_method=args.edge_feature_method
+        output_dim=1, output_act="sigmoid", edge_embedding_method=args.edge_embedding_method
     )(x_out)
 
     # Stack the GraphSAGE and prediction layers into a Keras model, and specify the loss
@@ -343,7 +343,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "-m",
-        "--edge_feature_method",
+        "--edge_embedding_method",
         type=str,
         default="ip",
         help="The method for combining node embeddings into edge embeddings: 'concat', 'mul', 'ip', 'l1', 'l2', or 'avg'",

--- a/demos/link-prediction-hinsage/movielens-recommender.ipynb
+++ b/demos/link-prediction-hinsage/movielens-recommender.ipynb
@@ -672,7 +672,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Add the final estimator layer for predicting the ratings. The edge_feature_method argument specifies the way in which node representations (node embeddings) are combined into link representations (recall that links represent user-movie ratings, and are thus pairs of (user, movie) nodes). In this example, we will use 'concat', i.e., node embeddings are concatenated to get link embeddings."
+    "Add the final estimator layer for predicting the ratings. The edge_embedding_method argument specifies the way in which node representations (node embeddings) are combined into link representations (recall that links represent user-movie ratings, and are thus pairs of (user, movie) nodes). In this example, we will use 'concat', i.e., node embeddings are concatenated to get link embeddings."
    ]
   },
   {
@@ -690,7 +690,7 @@
    ],
    "source": [
     "# Final estimator layer\n",
-    "score_prediction = link_regression(edge_feature_method='concat')(x_out)"
+    "score_prediction = link_regression(edge_embedding_method='concat')(x_out)"
    ]
   },
   {
@@ -1136,9 +1136,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Stellar ML [3]",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "stellarml"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1150,7 +1150,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.6"
   }
  },
  "nbformat": 4,

--- a/demos/link-prediction-hinsage/movielens-recommender.py
+++ b/demos/link-prediction-hinsage/movielens-recommender.py
@@ -168,7 +168,7 @@ class LinkInference(object):
 
         # Final estimator layer
         score_prediction = link_regression(
-            edge_embedding_method=args.edge_feature_method
+            edge_embedding_method=args.edge_embedding_method
         )(x_out)
 
         # Create Keras model for training
@@ -234,7 +234,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "-m",
-        "--edge_feature_method",
+        "--edge_embedding_method",
         type=str,
         default="concat",
         help="The method for combining node embeddings into edge embeddings: 'concat', 'mul', 'ip', 'l1', 'l2', or 'avg'",

--- a/demos/link-prediction-hinsage/movielens-recommender.py
+++ b/demos/link-prediction-hinsage/movielens-recommender.py
@@ -168,7 +168,7 @@ class LinkInference(object):
 
         # Final estimator layer
         score_prediction = link_regression(
-            edge_feature_method=args.edge_feature_method
+            edge_embedding_method=args.edge_feature_method
         )(x_out)
 
         # Create Keras model for training

--- a/tests/layer/test_link_inference.py
+++ b/tests/layer/test_link_inference.py
@@ -49,7 +49,7 @@ class Test_Link_Inference(object):
         x_src = tf.constant(x_src, shape=(1, self.d), dtype="float64")
         x_dst = tf.constant(x_dst, shape=(1, self.d), dtype="float64")
 
-        li = link_inference(edge_feature_method="ip", output_act="linear")(
+        li = link_inference(edge_embedding_method="ip", output_act="linear")(
             [x_src, x_dst]
         )
         print(
@@ -60,19 +60,19 @@ class Test_Link_Inference(object):
         assert li.eval() == pytest.approx(expected)
         assert li.eval() == pytest.approx(0)
 
-        li = link_inference(edge_feature_method="ip", output_act="linear")(
+        li = link_inference(edge_embedding_method="ip", output_act="linear")(
             [x_src, x_src]
         )
         print("link inference with 'ip' operator on unit vector: ", li.eval())
         assert li.eval() == pytest.approx(1)
 
         # Test sigmoid activation
-        li = link_classification(edge_feature_method="ip", output_act="sigmoid")(
+        li = link_classification(edge_embedding_method="ip", output_act="sigmoid")(
             [x_src, x_dst]
         )
         assert li.eval() == pytest.approx(0.5)
 
-        li = link_classification(edge_feature_method="ip", output_act="sigmoid")(
+        li = link_classification(edge_embedding_method="ip", output_act="sigmoid")(
             [x_src, x_src]
         )
         assert li.eval() == pytest.approx(0.7310586)
@@ -95,7 +95,7 @@ class Test_Link_Inference(object):
         inp_dst = keras.Input(shape=(1, self.d))
 
         for op in ["mul", "l1", "l2", "avg"]:
-            out = link_inference(output_dim=self.d_out, edge_feature_method=op)(
+            out = link_inference(output_dim=self.d_out, edge_embedding_method=op)(
                 [inp_src, inp_dst]
             )
             li = keras.Model(inputs=[inp_src, inp_dst], outputs=out)
@@ -132,23 +132,23 @@ class Test_Link_Classification(object):
         x_dst = tf.constant(x_dst, shape=(1, self.d), dtype="float64")
 
         # Test linear activation
-        li = link_classification(edge_feature_method="ip", output_act="linear")(
+        li = link_classification(edge_embedding_method="ip", output_act="linear")(
             [x_src, x_dst]
         )
         assert li.eval() == pytest.approx(0)
 
-        li = link_classification(edge_feature_method="ip", output_act="linear")(
+        li = link_classification(edge_embedding_method="ip", output_act="linear")(
             [x_src, x_src]
         )
         assert li.eval() == pytest.approx(1)
 
         # Test sigmoid activation
-        li = link_classification(edge_feature_method="ip", output_act="sigmoid")(
+        li = link_classification(edge_embedding_method="ip", output_act="sigmoid")(
             [x_src, x_dst]
         )
         assert li.eval() == pytest.approx(0.5)
 
-        li = link_classification(edge_feature_method="ip", output_act="sigmoid")(
+        li = link_classification(edge_embedding_method="ip", output_act="sigmoid")(
             [x_src, x_src]
         )
         assert li.eval() == pytest.approx(0.7310586)
@@ -171,7 +171,7 @@ class Test_Link_Classification(object):
         inp_dst = keras.Input(shape=(1, self.d))
 
         for op in ["mul", "l1", "l2", "avg"]:
-            out = link_classification(output_dim=self.d_out, edge_feature_method=op)(
+            out = link_classification(output_dim=self.d_out, edge_embedding_method=op)(
                 [inp_src, inp_dst]
             )
             li = keras.Model(inputs=[inp_src, inp_dst], outputs=out)
@@ -212,7 +212,7 @@ class Test_Link_Regression(object):
         x_src = tf.constant(x_src, shape=(1, self.d), dtype="float64")
         x_dst = tf.constant(x_dst, shape=(1, self.d), dtype="float64")
 
-        li = link_regression(edge_feature_method="ip")([x_src, x_dst])
+        li = link_regression(edge_embedding_method="ip")([x_src, x_dst])
         print(
             "link regression with 'ip' operator on orthonormal vectors: {}, expected: {}".format(
                 li.eval(), expected
@@ -220,7 +220,7 @@ class Test_Link_Regression(object):
         )
         assert li.eval() == pytest.approx(0)
 
-        li = link_regression(edge_feature_method="ip")([x_src, x_src])
+        li = link_regression(edge_embedding_method="ip")([x_src, x_src])
         print("link regression with 'ip' operator on unit vector: ", li.eval())
         assert li.eval() == pytest.approx(1)
 
@@ -242,7 +242,7 @@ class Test_Link_Regression(object):
         inp_dst = keras.Input(shape=(1, self.d))
 
         for op in ["mul", "l1", "l2", "avg"]:
-            out = link_regression(output_dim=self.d_out, edge_feature_method=op)(
+            out = link_regression(output_dim=self.d_out, edge_embedding_method=op)(
                 [inp_src, inp_dst]
             )
             li = keras.Model(inputs=[inp_src, inp_dst], outputs=out)
@@ -276,7 +276,7 @@ class Test_Link_Regression(object):
         for op in ["mul", "l1", "l2", "avg"]:
             out = link_regression(
                 output_dim=self.d_out,
-                edge_feature_method=op,
+                edge_embedding_method=op,
                 clip_limits=self.clip_limits,
             )([inp_src, inp_dst])
             li = keras.Model(inputs=[inp_src, inp_dst], outputs=out)


### PR DESCRIPTION
This PR renames `edge_feature_method` to `edge_embedding_method` and updates the doc strings and all the demos and tests.