### PR TITLE
Bug/read the docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,9 @@
+# .readthedocs.yml
+
+version: 2
+
+python:
+  version: 3.6
+  install:
+     - method: pip
+       path: .

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,5 +5,6 @@ version: 2
 python:
   version: 3.6
   install:
+     - requirements: requirements.txt
      - method: pip
        path: .

--- a/docs/api.txt
+++ b/docs/api.txt
@@ -15,14 +15,36 @@ Data
   :members: UniformRandomWalk, BiasedRandomWalk, UniformRandomMetaPathWalk, SampledBreadthFirstWalk, SampledHeterogeneousBreadthFirstWalk, EdgeSplitter, NodeSplitter, from_epgm, load_dataset_BlogCatalog3
 
 
-Layers
-------------
-
-.. automodule:: stellargraph.layer
-  :members: GraphSAGE, MeanAggregator, MeanPoolingAggregator, MaxPoolingAggregator, AttentionalAggregator, HinSAGE, MeanHinAggregator, link_inference, link_classification, link_regression
-
 Generators
 -----------
 
 .. automodule:: stellargraph.mapper
-  :members: NodeSequence, LinkSequence, GraphSAGENodeGenerator, GraphSAGELinkGenerator, HinSAGENodeGenerator
+  :members: FullBatchNodeGenerator, GraphSAGENodeGenerator, GraphSAGELinkGenerator, HinSAGENodeGenerator, HinSAGELinkGenerator
+
+
+GraphSAGE model
+----------------
+
+.. automodule:: stellargraph.layer.graphsage
+  :members: GraphSAGE, MeanAggregator, MeanPoolingAggregator, MaxPoolingAggregator, AttentionalAggregator
+
+
+HinSAGE model
+----------------
+
+.. automodule:: stellargraph.layer.hinsage
+  :members: HinSAGE, MeanHinAggregator
+
+
+GCN model
+-------------
+
+.. automodule:: stellargraph.layer.gcn
+  :members: GraphConvolution, GCN
+
+
+Link prediction layers
+------------------------
+
+.. automodule:: stellargraph.layer.link_inference
+  :members: link_classification, link_regression, link_inference

--- a/stellargraph/layer/gcn.py
+++ b/stellargraph/layer/gcn.py
@@ -231,9 +231,10 @@ class GCN:
     def node_model(self):
         """
         Builds a GCN model for node prediction
+
         Returns:
-            tuple: (x_inp, x_out) where ``x_inp`` is a Keras input tensor
-            for the specified GCN model and ``x_out`` is a Keras tensor for the GCN model output.
+            tuple: (x_inp, x_out) where `x_inp` is a Keras input tensor
+                for the specified GCN model and `x_out` is a Keras tensor for the GCN model output.
         """
 
         x_in = Input(shape=(self.generator.features.shape[1],))

--- a/stellargraph/mapper/link_mappers.py
+++ b/stellargraph/mapper/link_mappers.py
@@ -317,19 +317,19 @@ class HinSAGELinkGenerator:
     Use the :meth:`flow` method supplying the nodes and (optionally) targets
     to get an object that can be used as a Keras data generator.
 
-    Example:
+    Note that you don't need to pass link_type (target link type) to the link mapper, considering that:
 
-    ```
+    * The mapper actually only cares about (src,dst) node types, and these can be inferred from the passed
+      link ids (although this might be expensive, as it requires parsing the links ids passed - yet only once)
+
+    * It's possible to do link prediction on a graph where that link type is completely removed from the graph
+      (e.g., "same_as" links in ER)
+
+
+    Example::
+
         G_generator = HinSAGELinkGenerator(G, 50, [10,10])
         data_gen = G_generator.flow(edge_ids)
-    ```
-
-    Notes:
-         We don't need to pass link_type (target link type) to the link mapper, considering that:
-            1. The mapper actually only cares about (src,dst) node types, and these can be inferred from the passed
-                link ids (although this might be expensive, as it requires parsing the links ids passed - yet only once)
-            2. It's possible to do link prediction on a graph where that link type is completely removed from the graph
-                (e.g., "same_as" links in ER)
 
     Args:
         g (StellarGraph): A machine-learning ready graph.

--- a/stellargraph/mapper/node_mappers.py
+++ b/stellargraph/mapper/node_mappers.py
@@ -332,7 +332,7 @@ class GraphSAGENodeGenerator:
 
 
 class HinSAGENodeGenerator:
-    """Keras-compatible data mapper for Heterogeneour GraphSAGE (HinSAGE)
+    """Keras-compatible data mapper for Heterogeneous GraphSAGE (HinSAGE)
 
      At minimum, supply the StellarGraph, the batch size, and the number of
      node samples for each layer of the HinSAGE model.
@@ -534,23 +534,27 @@ class FullBatchNodeSequence(Sequence):
 
 
 class FullBatchNodeGenerator:
+    """
+    A data generator for node prediction with Homogeneous full-batch models, e.g., GCN, GAT
+    The supplied graph G should be a StellarGraph object that is ready for
+    machine learning. Currently the model requires node features for all
+    nodes in the graph.
+    Use the :meth:`flow` method supplying the nodes and (optionally) targets
+    to get an object that can be used as a Keras data generator.
+
+    Example::
+
+        G_generator = FullBatchNodeGenerator(G)
+        train_data_gen = G_generator.flow(node_ids, node_targets)
+
+    Args:
+        G (StellarGraphBase): a machine-learning StellarGraph-type graph
+        name (str): an optional name of the generator
+        func_opt: an optional function to apply on features and adjacency matrix (declared func_opt(features, Aadj, **kwargs))
+        kwargs: additional parameters for func_opt function
+    """
+
     def __init__(self, G, name=None, func_opt=None, **kwargs):
-        """
-        A data generator for node prediction with Homogeneous full-batch models, e.g., GCN, GAT
-        The supplied graph G should be a StellarGraph object that is ready for
-        machine learning. Currently the model requires node features for all
-        nodes in the graph.
-        Use the :meth:`flow` method supplying the nodes and (optionally) targets
-        to get an object that can be used as a Keras data generator.
-        Example::
-            G_generator = FullBatchNodeGenerator(G)
-            train_data_gen = G_generator.flow(node_ids, node_targets)
-        Args:
-            G (StellarGraphBase): a machine-learning StellarGraph-type graph
-            name (str): an optional name of the generator
-            func_opt: an optional function to apply on features and adjacency matrix (declared func_opt(features, Aadj, **kwargs))
-            kwargs: additional parameters for func_opt function
-        """
         if not isinstance(G, StellarGraphBase):
             raise TypeError("Graph must be a StellarGraph object.")
 

--- a/stellargraph/mapper/node_mappers.py
+++ b/stellargraph/mapper/node_mappers.py
@@ -166,7 +166,8 @@ class NodeSequence(Sequence):
 
 
 class GraphSAGENodeGenerator:
-    """A data generator for node prediction with Homogeneous GraphSAGE models
+    """
+    A data generator for node prediction with Homogeneous GraphSAGE models
 
     At minimum, supply the StellarGraph, the batch size, and the number of
     node samples for each layer of the GraphSAGE model.
@@ -334,18 +335,18 @@ class GraphSAGENodeGenerator:
 class HinSAGENodeGenerator:
     """Keras-compatible data mapper for Heterogeneous GraphSAGE (HinSAGE)
 
-     At minimum, supply the StellarGraph, the batch size, and the number of
-     node samples for each layer of the HinSAGE model.
+    At minimum, supply the StellarGraph, the batch size, and the number of
+    node samples for each layer of the HinSAGE model.
 
-     The supplied graph should be a StellarGraph object that is ready for
-     machine learning. Currently the model requires node features for all
-     nodes in the graph.
+    The supplied graph should be a StellarGraph object that is ready for
+    machine learning. Currently the model requires node features for all
+    nodes in the graph.
 
-     Use the :meth:`flow` method supplying the nodes and (optionally) targets
-     to get an object that can be used as a Keras data generator.
+    Use the :meth:`flow` method supplying the nodes and (optionally) targets
+    to get an object that can be used as a Keras data generator.
 
-     Note that the shuffle argument should be True for training and
-     False for prediction.
+    Note that the shuffle argument should be True for training and
+    False for prediction.
 
      Example::
 


### PR DESCRIPTION
This fixes the failure of building the docs on readthedocs.org. This was because rtd.org has updated to python3.7 and tensorflow is not available.

I've added a `.readthedocs.yaml` config file specifying the python version (3.6).

Also updated the `api.txt` file to pull in GCN and split the layers into different models. Some docstrings were updated to fix formatting issues.