### PR TITLE
Hotfix/saliency maps

### DIFF
--- a/stellargraph/utils/saliency_maps/__init__.py
+++ b/stellargraph/utils/saliency_maps/__init__.py
@@ -13,5 +13,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-

--- a/stellargraph/utils/saliency_maps/__init__.py
+++ b/stellargraph/utils/saliency_maps/__init__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2018-2019 Data61, CSIRO
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+


### PR DESCRIPTION
Found a bug when I tried to install stellargraph develop branch in pyGraphER. 
The error is that "__init__.py" is missed in saliency_maps folder which will cause ModuleNotFound when calling stellargraph lib.