### PR TITLE
buildkite: pass through environment variables for coveralls-python

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,6 +11,10 @@ steps:
           - BUILDKITE_BUILD_NUMBER
           - BUILDKITE_BRANCH
           - AWS_LOGS_BUCKET
+          # for coveralls-python, to send more metadata to coveralls.io
+          - BUILDKITE
+          - BUILDKITE_PULL_REQUEST
+          - BUILDKITE_JOB_ID
     agents:
       queue: 't2medium'
 


### PR DESCRIPTION
The coverage-uploader `coveralls-python` understands buildkite
natively, as long as it has access to the required environment
variables from outside the docker container.

This change means that:

- coveralls has more metadata, like a connection to the pull request (see "Build Type > PR 363" on  https://coveralls.io/jobs/46962445)
- coveralls can do a comment like below (this can be turned off under https://coveralls.io/github/stellargraph/stellargraph/settings "Leave Comments?" if not desired)
- (slight downside) the build identifiers on coveralls are UUIDs referring back to the specific Buildkite step and thus are longer