### PR TITLE
Refer to the GAT paper, not the GaAN one

### DIFF
--- a/demos/node-classification/gat/gat-cora-node-classification-example.ipynb
+++ b/demos/node-classification/gat/gat-cora-node-classification-example.ipynb
@@ -359,7 +359,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To follow the GAT model architecture used for Cora dataset in the original paper [Graph Attention Networks. P. Velickovic et al. ICLR 2018 https://arxiv.org/abs/1803.07294], let's build a 2-layer GAT model, with the 2nd layer being the classifier that predicts paper subject: it thus should have the output size of `train_targets.shape[1]` (7 subjects) and a softmax activation."
+    "To follow the GAT model architecture used for Cora dataset in the original paper [Graph Attention Networks. P. Velickovic et al. ICLR 2018 https://arxiv.org/abs/1710.10903], let's build a 2-layer GAT model, with the 2nd layer being the classifier that predicts paper subject: it thus should have the output size of `train_targets.shape[1]` (7 subjects) and a softmax activation."
    ]
   },
   {

--- a/stellargraph/layer/graph_attention.py
+++ b/stellargraph/layer/graph_attention.py
@@ -35,7 +35,7 @@ class GraphAttention(Layer):
     Graph Attention (GAT) layer, base implementation taken from https://github.com/danielegrattarola/keras-gat,
     some modifications added for ease of use.
 
-    Based on the original paper: Graph Attention Networks. P. Velickovic et al. ICLR 2018 https://arxiv.org/abs/1803.07294
+    Based on the original paper: Graph Attention Networks. P. Velickovic et al. ICLR 2018 https://arxiv.org/abs/1710.10903
 
     Args:
             F_out (int): dimensionality of output feature vectors
@@ -307,7 +307,7 @@ class GraphAttention(Layer):
 
 class GAT:
     """
-    A stack of Graph Attention (GAT) layers with aggregation of multiple attention heads, Eqs 5-6 of the GAT paper https://arxiv.org/abs/1803.07294
+    A stack of Graph Attention (GAT) layers with aggregation of multiple attention heads, Eqs 5-6 of the GAT paper https://arxiv.org/abs/1710.10903
 
     Args:
             layer_sizes (list of int): list of output sizes of GAT layers in the stack. The length of this list defines


### PR DESCRIPTION
The GAT paper is https://arxiv.org/abs/1710.10903, while
https://arxiv.org/abs/1803.07294 is Zhang, Jiani, et al. "GaAN: Gated
attention networks for learning on large and spatiotemporal graphs."