### PR TITLE
updated requirements and setup to use tensorflow>=1.12.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 networkx==2.2
 setuptools>=39.1.0
 Keras>=2.2.3
-tensorflow>=1.10.0
+tensorflow>=1.12.1
 numba>=0.39.0
 numpy>=1.14.5
 scikit_learn>=0.19.2

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ URL = "https://github.com/stellargraph/stellargraph"
 # Required packages
 REQUIRES = [
     "keras>=2.2.3",
-    "tensorflow>=1.8",
+    "tensorflow>=1.12.1",
     "numpy>=1.14",
     "networkx>=2.2",
     "scikit_learn>=0.18",


### PR DESCRIPTION
This PR addresses security issue https://github.com/stellargraph/stellargraph/network/alert/demos/link-prediction/requirements.txt/tensorflow/open 