### PR TITLE
Python igraph

### DIFF
--- a/demos/community_detection/requirements.txt
+++ b/demos/community_detection/requirements.txt
@@ -1,3 +1,3 @@
-python-igraph==0.7.1
+python-igraph
 mplleaflet==0.0.5
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,4 @@ pytest==3.9.3
 pytest-benchmark>=3.1
 pytest-cov>=2.6.0
 coveralls>=1.5.1
-seaborn>=0.9.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,5 @@ pytest==3.9.3
 pytest-benchmark>=3.1
 pytest-cov>=2.6.0
 coveralls>=1.5.1
+seaborn>=0.9.0
+


### PR DESCRIPTION
The python-igraph package required for the community detection demo is no longer available in v0.7.1  on PyPl. As only required in this demonstration, I've removed the version number from this package in the requirements.txt of the community-detection folder. 