### PR TITLE
use python:3.6-slim docker image

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,7 +3,7 @@ steps:
     command: ".buildkite/steps/script.sh"
     plugins:
       docker#v3.2.0:
-        image: "python:3.6"
+        image: "python:3.6-slim"
         environment:
           - PYTHONDONTWRITEBYTECODE=1
           - GIT_BRANCH=$BUILDKITE_BRANCH


### PR DESCRIPTION
PR:

* Updates the docker image that's used for the tests to `python:3.6-slim` from `python:3.6`
* `python:3.6` is 354MBs compressed
* `python:3.6-slim` is 50MBs compressed
* This means that the buildkite agents will pull down the image faster since it's significantly smaller
* Since the `stellargraph/stellargraph` docker image uses `python:3.6-slim`, the agent only needs to pull down one image

The CI passes with the slim image, however I'm now hesitant to use it given the recommendation from https://hub.docker.com/_/python?tab=description

>This image does not contain the common packages contained in the default tag and only contains the minimal packages needed to run python. Unless you are working in an environment where only the python image will be deployed and you have space constraints, we highly recommend using the default image of this repository.

What are your thoughts?