### PR TITLE
add shfmt to CI + format

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -26,6 +26,12 @@ steps:
         environment:
           - PYTHONDONTWRITEBYTECODE=1
 
+  - label: ":shell: format"
+    plugins:
+      docker#v3.2.0:
+        image: "mvdan/shfmt:v2.6.4"
+        command: ["-d", "-i", "2", "-ci", "-sr", "."]
+
   - label: ":docker: :hadolint: lint Dockerfiles"
     command: "find -name 'Dockerfile*' -print0 | xargs -0 hadolint"
     plugins:

--- a/.buildkite/steps/manage-images.sh
+++ b/.buildkite/steps/manage-images.sh
@@ -5,7 +5,7 @@ build_push() {
   local image="$1"
   local tag="$2"
 
-  echo "Building ${image}";
+  echo "Building ${image}"
   docker/"${image}"/build.sh
   docker tag stellargraph/"${image}" stellargraph/"${image}":"${tag}"
   docker push stellargraph/"${image}":"${tag}"
@@ -51,9 +51,8 @@ delete_numbered() {
       else
         echo "failed to delete 'stellargraph/${image_name}:${version}' (probably never uploaded)"
       fi
-      fi
-      #done
-    done
+    fi
+  done
 }
 
 images=(
@@ -87,4 +86,5 @@ case "${action}" in
   *)
     echo "[ERROR] unknown argument '${action}'" >&2
     exit 1
+    ;;
 esac

--- a/.buildkite/steps/script.sh
+++ b/.buildkite/steps/script.sh
@@ -10,6 +10,6 @@ pip install -q --no-cache-dir -r requirements.txt -e .
 py.test -ra --cov=stellargraph tests/ --doctest-modules --doctest-modules --cov-report=term-missing -p no:cacheprovider --junitxml=./${BUILDKITE_BUILD_NUMBER}.xml
 coveralls
 
-if [ "${BUILDKITE_BRANCH}" = "develop"  ] || [ "${BUILDKITE_BRANCH}" = "master" ] ; then
+if [ "${BUILDKITE_BRANCH}" = "develop" ] || [ "${BUILDKITE_BRANCH}" = "master" ]; then
   upload_tests
 fi

--- a/.buildkite/utils/checkstatus.sh
+++ b/.buildkite/utils/checkstatus.sh
@@ -3,7 +3,7 @@
 BUILDKITE_BUILD_STATE="$(curl -s --show-error --fail -X GET -H "Authorization: Bearer ${BUILDKITE_API_TOKEN}" "https://api.buildkite.com/v2/organizations/${BUILDKITE_ORGANIZATION_SLUG}/pipelines/${BUILDKITE_PIPELINE_SLUG}/builds/${BUILDKITE_BUILD_NUMBER}" | jq -r ".jobs[].state" | sort -u | grep "failed\|canceled")"
 
 case "${BUILDKITE_BUILD_STATE}" in
-  failed|canceled)
+  failed | canceled)
     echo "build ${BUILDKITE_BUILD_STATE}: not running $*"
     ;;
   *)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@
   <a href="https://github.com/ambv/black" alt="Code style">
     <img src="https://img.shields.io/badge/code%20style-black-000000.svg"/>
   </a>
+  <a href="https://github.com/mvdan/sh/" alt="Shellcode style">
+    <img src="https://img.shields.io/badge/shell%20style-shfmt-black.svg"/>
+  </a>
   <a href="https://stellargraph.readthedocs.io/" alt="Docs">
     <img src="https://readthedocs.org/projects/stellargraph/badge/?version=latest"/>
   </a>


### PR DESCRIPTION
PR:

* Adds [shfmt](https://github.com/mvdan/sh/) to the CI
* All shell scripts will be formatted with the flags:
  * `-i 2`: 2 spaces 
  * `sr`: redirect operators will be followed by a space
  * `ci`: switch cases will be indented
* Rolled out for repos, so we have a unified style for shellscripts
* PR also formatted the scripts with the flags so that it passes
* Added `shfmt` badge to the readme