### PR TITLE
use python 3.7-slim docker image

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -18,7 +18,7 @@ steps:
     agents:
       queue: 't2medium'
 
-  - label: ":python: 3.7.2"
+  - label: ":python: 3.7"
     command: ".buildkite/steps/script.sh"
     plugins:
       docker#v3.2.0:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -22,7 +22,7 @@ steps:
     command: ".buildkite/steps/script.sh"
     plugins:
       docker#v3.2.0:
-        image: "python:3.7.2"
+        image: "python:3.7-slim"
         environment:
           - PYTHONDONTWRITEBYTECODE=1
           - GIT_BRANCH=$BUILDKITE_BRANCH


### PR DESCRIPTION
Similarly to #394 this PR updates the Buildkite docker image to use `3.7-slim`. It also uses the minor version `3.7` which means the latest patch versions are always used (rather than pinning to `3.7.2`)