### PR TITLE
add shellcheck to pipeline + format code

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -51,6 +51,12 @@ steps:
         image: "mvdan/shfmt:v2.6.4"
         command: ["-d", "-i", "2", "-ci", "-sr", "."]
 
+  - label: ":shell: shellcheck"
+    command: 'find ./ -type f \( -name "*.sh" \) -print0 | xargs -0 shellcheck --color=always'
+    plugins:
+      docker#v3.2.0:
+        image: "koalaman/shellcheck-alpine"
+
   - label: ":docker: :hadolint: lint Dockerfiles"
     command: "find -name 'Dockerfile*' -print0 | xargs -0 hadolint"
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -52,7 +52,7 @@ steps:
         command: ["-d", "-i", "2", "-ci", "-sr", "."]
 
   - label: ":shell: shellcheck"
-    command: 'find ./ -type f \( -name "*.sh" \) -print0 | xargs -0 shellcheck --color=always'
+    command: 'find ./ -type f -name "*.sh" -print0 | xargs -0 shellcheck --color=always'
     plugins:
       docker#v3.2.0:
         image: "koalaman/shellcheck-alpine"

--- a/.buildkite/steps/manage-images.sh
+++ b/.buildkite/steps/manage-images.sh
@@ -38,7 +38,8 @@ delete_numbered() {
   shift
 
   set +x # don't print out the docker hub credentials
-  TOKEN=$(curl -s -H "Content-Type: application/json" -X POST -d '{"username": "'${DOCKER_LOGIN_USER}'", "password": "'${DOCKER_LOGIN_PASSWORD}'"}' https://hub.docker.com/v2/users/login/ | jq -r .token)
+  payload="{\"username\": \"${DOCKER_LOGIN_USER}\", \"password\": \"${DOCKER_LOGIN_PASSWORD}\"}"
+  TOKEN=$(curl -s -H "Content-Type: application/json" -X POST -d "${payload}" https://hub.docker.com/v2/users/login/ | jq -r .token)
   authHeader="Authorization: JWT ${TOKEN}"
 
   for image_name in "$@"; do

--- a/.buildkite/steps/script.sh
+++ b/.buildkite/steps/script.sh
@@ -10,6 +10,6 @@ pip install -q --no-cache-dir -r requirements.txt -e .
 py.test -ra --cov=stellargraph tests/ --doctest-modules --doctest-modules --cov-report=term-missing -p no:cacheprovider --junitxml=./"${BUILDKITE_BUILD_NUMBER}".xml
 coveralls
 
-#if [ "${BUILDKITE_BRANCH}" = "develop" ] || [ "${BUILDKITE_BRANCH}" = "master" ]; then
-upload_tests
-#fi
+if [ "${BUILDKITE_BRANCH}" = "develop" ] || [ "${BUILDKITE_BRANCH}" = "master" ]; then
+  upload_tests
+fi

--- a/.buildkite/steps/script.sh
+++ b/.buildkite/steps/script.sh
@@ -3,13 +3,13 @@
 set -xeo pipefail
 
 upload_tests() {
-  buildkite-agent artifact upload "${BUILDKITE_BUILD_NUMBER}.xml" s3://${AWS_LOGS_BUCKET}/pytest/${BUILDKITE_BRANCH}/${BUILDKITE_BUILD_NUMBER}
+  buildkite-agent artifact upload "${BUILDKITE_BUILD_NUMBER}.xml" "s3://${AWS_LOGS_BUCKET}/pytest/${BUILDKITE_BRANCH}/${BUILDKITE_BUILD_NUMBER}"
 }
 
 pip install -q --no-cache-dir -r requirements.txt -e .
-py.test -ra --cov=stellargraph tests/ --doctest-modules --doctest-modules --cov-report=term-missing -p no:cacheprovider --junitxml=./${BUILDKITE_BUILD_NUMBER}.xml
+py.test -ra --cov=stellargraph tests/ --doctest-modules --doctest-modules --cov-report=term-missing -p no:cacheprovider --junitxml=./"${BUILDKITE_BUILD_NUMBER}".xml
 coveralls
 
-if [ "${BUILDKITE_BRANCH}" = "develop" ] || [ "${BUILDKITE_BRANCH}" = "master" ]; then
-  upload_tests
-fi
+#if [ "${BUILDKITE_BRANCH}" = "develop" ] || [ "${BUILDKITE_BRANCH}" = "master" ]; then
+upload_tests
+#fi


### PR DESCRIPTION
PR:

* Adds [shellcheck](https://github.com/koalaman/shellcheck) to the CI
* Severity level is at default (`style`)
* PR also formats the code so the build passes the `shellcheck` step

Since it is trivial to add unsafe shell code, this enforces best practices when new shellcode is added.