### PR TITLE
Restricted tensorflow to less than version 2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 networkx==2.2
 setuptools>=39.1.0
 Keras>=2.2.3
-tensorflow>=1.12.1
+tensorflow>=1.12.1,<2.0
 numba>=0.39.0
 numpy>=1.14
 scipy>=1.1.0

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ URL = "https://github.com/stellargraph/stellargraph"
 # Required packages
 REQUIRES = [
     "keras>=2.2.4",
-    "tensorflow>=1.12",
+    "tensorflow>=1.12,<2.0",
     "numpy>=1.14",
     "scipy>=1.1.0",
     "networkx>=2.2",


### PR DESCRIPTION
Tested that `pip install stellar graph`, `pip install stellar graph[demos]` and `python setup.py develop` all install tensor flow < 2.0 under a Python 3.7 environment.