### PR TITLE
added thread lock acquire and release to OnDemandLinkSequence, to allow multithreading

### DIFF
--- a/demos/embeddings/embeddings-unsupervised-graphsage-cora.ipynb
+++ b/demos/embeddings/embeddings-unsupervised-graphsage-cora.ipynb
@@ -451,7 +451,7 @@
     "    epochs=epochs,\n",
     "    verbose=1,\n",
     "    use_multiprocessing=False,\n",
-    "    workers=0,\n",
+    "    workers=4,\n",
     "    shuffle=True,\n",
     ")"
    ]
@@ -460,9 +460,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that multiprocessing is switched off, since with a large training set of node pairs, multiprocessing can considerably slow down the training process with the data being transferred between various threads. \n",
+    "Note that multiprocessing is switched off, since with a large training set of node pairs, multiprocessing can considerably slow down the training process with the data being transferred between various processes. \n",
     "\n",
-    "Also, multiple workers can be used with `Keras version 2.2.4` and it speeds up the training process considerably. However, we noticed that the behavior of the node pair generator is unpredictable when training the model with multiple workers, due to locking enabled on the generator when multiple workers are using the same instance of the `UnsupervisedSampler` for \"on demand\" sampling. We are working on the fix."
+    "Also, multiple workers can be used with `Keras version 2.2.4` and above, and it speeds up the training process considerably due to multi-threading."
    ]
   },
   {
@@ -838,7 +838,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,

--- a/stellargraph/mapper/link_mappers.py
+++ b/stellargraph/mapper/link_mappers.py
@@ -33,6 +33,7 @@ import itertools as it
 import operator
 import collections
 from functools import reduce
+import threading
 
 import keras
 from keras.utils import Sequence
@@ -185,6 +186,8 @@ class OnDemandLinkSequence(Sequence):
 
     def __init__(self, generator, walker):
 
+        self.lock = threading.Lock()
+
         self.generator = generator  # graphlinkgenerator instance
 
         self.head_node_types = self.generator.schema.node_types * 2
@@ -240,7 +243,9 @@ class OnDemandLinkSequence(Sequence):
         # print("Fetching {} batch {} [{}]".format(self.name, batch_num, start_idx))
 
         # Get head nodes and labels
+        self.lock.acquire()
         head_ids, batch_targets = next(self._gen)
+        self.lock.release()
 
         if self.head_node_types is None:
 


### PR DESCRIPTION
This patch, inspired by [this post](https://www.bogotobogo.com/python/Multithread/python_multithreading_Synchronization_Lock_Objects_Acquire_Release.php), appears to have fixed the multithreading issue. The way to use is
```
model.fit_generator(
    train_gen,
    epochs=epochs,
    verbose=1,
    use_multiprocessing=False,
    workers=4,
    shuffle=True,
)
```

@PantelisElinas the speed up is significant on CPU; let's try this on `fractal` using GPU.