### PR TITLE
Unify activations for GraphSAGE, HinSAGE, GCN and GAT

### DIFF
--- a/demos/interpretability/gat/node-link-importance-demo-gat.ipynb
+++ b/demos/interpretability/gat/node-link-importance-demo-gat.ipynb
@@ -1079,9 +1079,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "stellar-research-py35",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "stellar-research-py35"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1093,7 +1093,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,

--- a/demos/interpretability/gcn/hateful-twitters-interpretability.ipynb
+++ b/demos/interpretability/gcn/hateful-twitters-interpretability.ipynb
@@ -1903,9 +1903,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "stellar-research-py35",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "stellar-research-py35"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1917,7 +1917,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,

--- a/demos/interpretability/gcn/node-link-importance-demo-gcn-sparse.ipynb
+++ b/demos/interpretability/gcn/node-link-importance-demo-gcn-sparse.ipynb
@@ -1067,9 +1067,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "stellar-research-py35",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "stellar-research-py35"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/demos/node-classification/gcn/gcn-cora-example.py
+++ b/demos/node-classification/gcn/gcn-cora-example.py
@@ -60,11 +60,11 @@ def train(
     val_gen = generator.flow(val_nodes, val_targets)
     gcnModel = GCN(
         layer_sizes,
-        activations,
-        generator=generator,
+        generator,
         bias=True,
         dropout=dropout,
         kernel_regularizer=regularizers.l2(5e-4),
+        activations=activations,
     )
 
     # Expose the input and output sockets of the model:

--- a/stellargraph/layer/gcn.py
+++ b/stellargraph/layer/gcn.py
@@ -294,8 +294,6 @@ class GCN:
         if not isinstance(generator, FullBatchNodeGenerator):
             raise TypeError("Generator should be a instance of FullBatchNodeGenerator")
 
-        assert len(layer_sizes) == len(activations)
-
         n_layers = len(layer_sizes)
         self.layer_sizes = layer_sizes
         self.activations = activations

--- a/stellargraph/layer/gcn.py
+++ b/stellargraph/layer/gcn.py
@@ -279,7 +279,7 @@ class GCN:
         dropout (float): Dropout rate applied to input features of each GCN layer.
         kernel_regularizer (str): Normalization applied to the kernels of GCN layers.
         activations (list of str): Activations applied to each layer's output;
-            defaults to ['relu', ..., 'relu', 'linear'].
+            defaults to ['relu', ..., 'relu'].
     """
 
     def __init__(
@@ -313,7 +313,7 @@ class GCN:
 
         # Activation function for each layer
         if activations is None:
-            activations = ["relu"] * (n_layers - 1) + ["linear"]
+            activations = ["relu"] * n_layers
         elif len(activations) != n_layers:
             raise ValueError(
                 "Invalid number of activations; require one function per layer"

--- a/stellargraph/layer/graph_attention.py
+++ b/stellargraph/layer/graph_attention.py
@@ -599,6 +599,7 @@ class GAT:
     Args:
         layer_sizes (list of int): list of output sizes of GAT layers in the stack. The length of this list defines
             the number of GraphAttention layers in the stack.
+        generator (FullBatchNodeGenerator): an instance of FullBatchNodeGenerator class constructed on the graph of interest
         attn_heads (int or list of int): number of attention heads in GraphAttention layers. The options are:
 
             - a single integer: the passed value of ``attn_heads`` will be applied to all GraphAttention layers in the stack, except the last layer (for which the number of attn_heads will be set to 1).
@@ -608,25 +609,25 @@ class GAT:
             for all layers in the stack. Valid entries in the list are {'concat', 'average'}.
             If None is passed, the default reductions are applied: 'concat' reduction to all layers in the stack
             except the final layer, 'average' reduction to the last layer (Eqs. 5-6 of the GAT paper).
-        activations (list of str): list of activations applied to each layer's output
         bias (bool): toggles an optional bias in GAT layers
         in_dropout (float): dropout rate applied to input features of each GAT layer
         attn_dropout (float): dropout rate applied to attention maps
         normalize (str or None): normalization applied to the final output features of the GAT layers stack. Default is None.
-        generator (FullBatchNodeGenerator): an instance of FullBatchNodeGenerator class constructed on the graph of interest
+        activations (list of str): list of activations applied to each layer's output; defaults to ['relu', ..., 'relu', 'linear'].
+        saliency_map_support (bool): XXX What is this?
     """
 
     def __init__(
         self,
         layer_sizes,
-        activations,
+        generator=None,
         attn_heads=1,
         attn_heads_reduction=None,
         bias=True,
         in_dropout=0.0,
         attn_dropout=0.0,
         normalize=None,
-        generator=None,
+        activations=None,
         saliency_map_support=False,
     ):
         self.bias = bias
@@ -650,14 +651,15 @@ class GAT:
                 )
             )
         self.layer_sizes = layer_sizes
+        n_layers = len(layer_sizes)
 
         # Check attn_heads (must be int or list of int):
         if isinstance(attn_heads, list):
             # check the length
-            if not len(attn_heads) == len(layer_sizes):
+            if not len(attn_heads) == n_layers:
                 raise ValueError(
                     "{}: length of attn_heads list ({}) should match the number of GAT layers ({})".format(
-                        type(self).__name__, len(attn_heads), len(layer_sizes)
+                        type(self).__name__, len(attn_heads), n_layers
                     )
                 )
             # check that values in the list are valid
@@ -673,7 +675,7 @@ class GAT:
             self.attn_heads = list()
             for l, _ in enumerate(layer_sizes):
                 # number of attention heads for layer l: attn_heads (int) for all but the last layer (for which it's set to 1)
-                self.attn_heads.append(attn_heads if l < len(layer_sizes) - 1 else 1)
+                self.attn_heads.append(attn_heads if l < n_layers - 1 else 1)
 
         else:
             raise TypeError(
@@ -685,9 +687,7 @@ class GAT:
         # Check attn_heads_reduction (list of str, or None):
         if attn_heads_reduction is None:
             # set default head reductions, see eqs 5-6 of the GAT paper
-            self.attn_heads_reduction = ["concat"] * (len(layer_sizes) - 1) + [
-                "average"
-            ]
+            self.attn_heads_reduction = ["concat"] * (n_layers - 1) + ["average"]
         else:
             # user-specified list of head reductions (valid entries are 'concat' and 'average')
             # check type (must be a list of str):
@@ -702,7 +702,7 @@ class GAT:
             if not len(attn_heads_reduction) == len(layer_sizes):
                 raise ValueError(
                     "{}: length of attn_heads_reduction list ({}) should match the number of GAT layers ({})".format(
-                        type(self).__name__, len(attn_heads_reduction), len(layer_sizes)
+                        type(self).__name__, len(attn_heads_reduction), n_layers
                     )
                 )
 
@@ -720,6 +720,8 @@ class GAT:
 
         # Check activations (list of str):
         # check type:
+        if activations is None:
+            activations = ["relu"] * (n_layers - 1) + ["linear"]
         if not isinstance(activations, list):
             raise TypeError(
                 "{}: activations should be a list of strings; received {} instead".format(
@@ -727,10 +729,10 @@ class GAT:
                 )
             )
         # check length:
-        if not len(activations) == len(layer_sizes):
+        if not len(activations) == n_layers:
             raise ValueError(
                 "{}: length of activations list ({}) should match the number of GAT layers ({})".format(
-                    type(self).__name__, len(activations), len(layer_sizes)
+                    type(self).__name__, len(activations), n_layers
                 )
             )
         self.activations = activations

--- a/stellargraph/layer/graph_attention.py
+++ b/stellargraph/layer/graph_attention.py
@@ -613,7 +613,7 @@ class GAT:
         in_dropout (float): dropout rate applied to input features of each GAT layer
         attn_dropout (float): dropout rate applied to attention maps
         normalize (str or None): normalization applied to the final output features of the GAT layers stack. Default is None.
-        activations (list of str): list of activations applied to each layer's output; defaults to ['relu', ..., 'relu', 'linear'].
+        activations (list of str): list of activations applied to each layer's output; defaults to ['elu', ..., 'elu'].
         saliency_map_support (bool): XXX What is this?
     """
 
@@ -721,7 +721,7 @@ class GAT:
         # Check activations (list of str):
         # check type:
         if activations is None:
-            activations = ["relu"] * (n_layers - 1) + ["linear"]
+            activations = ["elu"] * n_layers
         if not isinstance(activations, list):
             raise TypeError(
                 "{}: activations should be a list of strings; received {} instead".format(

--- a/stellargraph/layer/hinsage.py
+++ b/stellargraph/layer/hinsage.py
@@ -196,6 +196,7 @@ class HinSAGE:
         bias=True,
         dropout=0.0,
         normalize="l2",
+        activations=None,
     ):
         """
         Args:
@@ -209,9 +210,11 @@ class HinSAGE:
             input_dim: The input dimensions for each node type as a dictionary of the form
                 {node_type: feature_size}.
             aggregator: The HinSAGE aggregator to use. Defaults to the `MeanHinAggregator`.
-            bias: If True a bias vector is learnt for each layer in the HinSAGE model
+            bias (bool): If True a bias vector is learnt for each layer in the HinSAGE model
             dropout: The dropout supplied to each layer in the HinSAGE model.
             normalize: The normalization used after each layer, defaults to L2 normalization.
+            activations (list of str): Activations applied to each layer's output;
+                defaults to ['relu', ..., 'relu', 'linear'].
         """
 
         def eval_neigh_tree_per_layer(input_tree):
@@ -310,13 +313,20 @@ class HinSAGE:
             for layer, dim in enumerate([self.input_dims] + layer_sizes)
         ]
 
+        # Activation function for each layer
+        if activations is None:
+            activations = ["relu"] * (self.n_layers - 1) + ["linear"]
+        elif len(activations) != self.n_layers:
+            raise ValueError(
+                "Invalid number of activations; require one function per layer"
+            )
+        self.activations = activations
+
         # Dict of {node type: aggregator} per layer
         self._aggs = [
             {
                 node_type: self._aggregator(
-                    output_dim,
-                    bias=self.bias,
-                    act="relu" if layer < self.n_layers - 1 else "linear",
+                    output_dim, bias=self.bias, act=self.activations[layer]
                 )
                 for node_type, output_dim in self.dims[layer + 1].items()
             }

--- a/stellargraph/layer/hinsage.py
+++ b/stellargraph/layer/hinsage.py
@@ -210,7 +210,7 @@ class HinSAGE:
             input_dim: The input dimensions for each node type as a dictionary of the form
                 {node_type: feature_size}.
             aggregator: The HinSAGE aggregator to use. Defaults to the `MeanHinAggregator`.
-            bias (bool): If True a bias vector is learnt for each layer in the HinSAGE model
+            bias (bool): If True, a bias vector is learnt for each layer in the HinSAGE model
             dropout: The dropout supplied to each layer in the HinSAGE model.
             normalize: The normalization used after each layer, defaults to L2 normalization.
             activations (list of str): Activations applied to each layer's output;

--- a/tests/layer/test_gcn.py
+++ b/tests/layer/test_gcn.py
@@ -221,13 +221,13 @@ def test_GCN_activations():
     generator = FullBatchNodeGenerator(G, sparse=False, method="none")
 
     gcn = GCN([2], generator)
-    assert gcn.activations == ["linear"]
+    assert gcn.activations == ["relu"]
 
     gcn = GCN([2, 2], generator)
-    assert gcn.activations == ["relu", "linear"]
+    assert gcn.activations == ["relu", "relu"]
 
-    gcn = GCN([2], generator, activations=["relu"])
-    assert gcn.activations == ["relu"]
+    gcn = GCN([2], generator, activations=["linear"])
+    assert gcn.activations == ["linear"]
 
     with pytest.raises(ValueError):
         # More regularisers than layers

--- a/tests/layer/test_gcn.py
+++ b/tests/layer/test_gcn.py
@@ -142,7 +142,7 @@ def test_GCN_init():
     G = StellarGraph(G, node_type_name="node", node_features=node_features)
 
     generator = FullBatchNodeGenerator(G)
-    gcnModel = GCN([2], ["relu"], generator=generator, dropout=0.5)
+    gcnModel = GCN([2], generator, activations=["relu"], dropout=0.5)
 
     assert gcnModel.layer_sizes == [2]
     assert gcnModel.activations == ["relu"]
@@ -161,7 +161,7 @@ def test_GCN_apply_dense():
     G = StellarGraph(G, node_features=node_features)
 
     generator = FullBatchNodeGenerator(G, sparse=False, method="none")
-    gcnModel = GCN([2], ["relu"], generator=generator, dropout=0.5)
+    gcnModel = GCN([2], generator, activations=["relu"], dropout=0.5)
 
     x_in, x_out = gcnModel.node_model()
     model = keras.Model(inputs=x_in, outputs=x_out)
@@ -190,7 +190,7 @@ def test_GCN_apply_sparse():
     G = StellarGraph(G, node_features=node_features)
 
     generator = FullBatchNodeGenerator(G, sparse=False, method="none")
-    gcnModel = GCN([2], ["relu"], generator=generator, dropout=0.5)
+    gcnModel = GCN([2], generator, activations=["relu"], dropout=0.5)
 
     x_in, x_out = gcnModel.node_model()
     model = keras.Model(inputs=x_in, outputs=x_out)

--- a/tests/layer/test_graph_attention.py
+++ b/tests/layer/test_graph_attention.py
@@ -304,7 +304,7 @@ class Test_GAT:
         gen = FullBatchNodeGenerator(G, sparse=self.sparse, method=self.method)
         # test default if no activations are passed:
         gat = GAT(layer_sizes=self.layer_sizes, generator=gen, bias=True)
-        assert gat.activations == ['elu', 'elu']
+        assert gat.activations == ["elu", "elu"]
 
         # test error if too many activations:
         with pytest.raises(ValueError):

--- a/tests/layer/test_graph_attention.py
+++ b/tests/layer/test_graph_attention.py
@@ -304,7 +304,7 @@ class Test_GAT:
         gen = FullBatchNodeGenerator(G, sparse=self.sparse, method=self.method)
         # test default if no activations are passed:
         gat = GAT(layer_sizes=self.layer_sizes, generator=gen, bias=True)
-        assert gat.activations == self.activations
+        assert gat.activations == ['elu', 'elu']
 
         # test error if too many activations:
         with pytest.raises(ValueError):

--- a/tests/layer/test_graph_attention.py
+++ b/tests/layer/test_graph_attention.py
@@ -302,9 +302,17 @@ class Test_GAT:
     def test_constructor(self):
         G = example_graph_1(feature_size=self.F_in)
         gen = FullBatchNodeGenerator(G, sparse=self.sparse, method=self.method)
-        # test error if no activations are passed:
-        with pytest.raises(TypeError):
-            gat = GAT(layer_sizes=self.layer_sizes, generator=gen, bias=True)
+        # test default if no activations are passed:
+        gat = GAT(layer_sizes=self.layer_sizes, generator=gen, bias=True)
+        assert gat.activations == self.activations
+
+        # test error if too many activations:
+        with pytest.raises(ValueError):
+            gat = GAT(layer_sizes=[10], activations=self.activations, generator=gen)
+
+        # test error if too few activations:
+        with pytest.raises(ValueError):
+            gat = GAT(layer_sizes=[10, 10], activations=["relu"], generator=gen)
 
         # test error where layer_sizes is not a list:
         with pytest.raises(TypeError):

--- a/tests/layer/test_graphsage.py
+++ b/tests/layer/test_graphsage.py
@@ -497,3 +497,46 @@ def test_graphsage_zero_neighbours():
     actual = model.predict(x)
     expected = np.array([[5, 5]])
     assert actual == pytest.approx(expected)
+
+
+def test_graphsage_passing_activations():
+    gs = GraphSAGE(layer_sizes=[4], n_samples=[2], input_dim=2)
+    assert gs.activations == ["linear"]
+
+    gs = GraphSAGE(layer_sizes=[4, 4], n_samples=[2, 2], input_dim=2)
+    assert gs.activations == ["relu", "linear"]
+
+    gs = GraphSAGE(layer_sizes=[4, 4, 4], n_samples=[2, 2, 2], input_dim=2)
+    assert gs.activations == ["relu", "relu", "linear"]
+
+    with pytest.raises(ValueError):
+        GraphSAGE(
+            layer_sizes=[4, 4, 4],
+            n_samples=[2, 2, 2],
+            input_dim=2,
+            activations=["relu"],
+        )
+
+    with pytest.raises(ValueError):
+        GraphSAGE(
+            layer_sizes=[4, 4, 4],
+            n_samples=[2, 2, 2],
+            input_dim=2,
+            activations=["relu"] * 2,
+        )
+
+    with pytest.raises(ValueError):
+        GraphSAGE(
+            layer_sizes=[4, 4, 4],
+            n_samples=[2, 2, 2],
+            input_dim=2,
+            activations=["fred", "wilma", "barney"],
+        )
+
+    gs = GraphSAGE(
+        layer_sizes=[4, 4, 4],
+        n_samples=[2, 2, 2],
+        input_dim=2,
+        activations=["linear"] * 3,
+    )
+    assert gs.activations == ["linear"] * 3

--- a/tests/layer/test_hinsage.py
+++ b/tests/layer/test_hinsage.py
@@ -422,3 +422,68 @@ def test_hinsage_aggregators():
     actual = model.predict(x)
     expected = np.array([[12, 35.5]])
     assert actual == pytest.approx(expected)
+
+
+def test_hinsage_passing_activations():
+    hs = HinSAGE(
+        layer_sizes=[2, 2],
+        n_samples=[2, 2],
+        input_neighbor_tree=[
+            ("1", [1, 2]),
+            ("1", [3, 4]),
+            ("2", [5]),
+            ("1", []),
+            ("2", []),
+            ("2", []),
+        ],
+        input_dim={"1": 2, "2": 2},
+    )
+    assert hs.activations == ["relu", "linear"]
+
+    with pytest.raises(ValueError):
+        hs = HinSAGE(
+            layer_sizes=[2, 2],
+            n_samples=[2, 2],
+            input_neighbor_tree=[
+                ("1", [1, 2]),
+                ("1", [3, 4]),
+                ("2", [5]),
+                ("1", []),
+                ("2", []),
+                ("2", []),
+            ],
+            input_dim={"1": 2, "2": 2},
+            activations=["fred", "wilma"],
+        )
+
+    with pytest.raises(ValueError):
+        hs = HinSAGE(
+            layer_sizes=[2, 2],
+            n_samples=[2, 2],
+            input_neighbor_tree=[
+                ("1", [1, 2]),
+                ("1", [3, 4]),
+                ("2", [5]),
+                ("1", []),
+                ("2", []),
+                ("2", []),
+            ],
+            input_dim={"1": 2, "2": 2},
+            activations=["relu"],
+        )
+
+    hs = HinSAGE(
+        layer_sizes=[2, 2],
+        n_samples=[2, 2],
+        input_neighbor_tree=[
+            ("1", [1, 2]),
+            ("1", [3, 4]),
+            ("2", [5]),
+            ("1", []),
+            ("2", []),
+            ("2", []),
+        ],
+        input_dim={"1": 2, "2": 2},
+        activations=["linear"] * 2,
+    )
+    assert hs.activations == ["linear"] * 2


### PR DESCRIPTION
Issue #381 requires optional activations to be added to GraphSAGE and HinSAGE, with a default to match the original fixed behaviour of `['relu', ..., 'relu', 'linear']`.

In addition, I have made the required activations of GCN and GAT to also be optional with the standard default, so that all models have similar behaviours in regards to activations.