### PR TITLE
Feature/conda package

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,8 @@ The StellarGraph library requires [Keras](https://keras.io/), so you'll need to 
 
 The StellarGraph library can be installed in one of two ways, described next.
 
-#### Install StellarGraph using pip:
-To install StellarGraph library from [PyPi](https://pypi.org) using `pip`, execute the following command:
+#### Install StellarGraph using PyPI:
+To install StellarGraph library from [PyPI](https://pypi.org) using `pip`, execute the following command:
 ```
 pip install stellargraph
 ```
@@ -149,6 +149,14 @@ Some of the examples in the `demos` directory require installing additional depe
 ```
 pip install stellargraph[demos]
 ```
+
+
+#### Install StellarGraph in Anaconda Python:
+The StellarGraph library is available an [Anaconda Cloud](https://anaconda.org/stellargraph/stellargraph) and can be installed in [Anaconda Python](https://anaconda.com) using the command line `conda` tool, execute the following command:
+```
+conda install -c stellargraph stellargraph
+```
+
 
 #### Install StellarGraph from Github source:
 First, clone the StellarGraph repository using `git`:

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,0 +1,66 @@
+{% set name = "stellargraph" %}
+{% set version = "0.8.1" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: c9e5a69bb94e4edcbde544fed1c07861b432c6b07b1d8a7d63ca8f40892a246e
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+  skip: True  # [py<36]
+
+requirements:
+  host:
+    - gensim >=3.4.0
+    - matplotlib >=2.2
+    - networkx >=2.2,<2.4
+    - numpy >=1.14
+    - pandas >=0.24
+    - pip
+    - python
+    - scikit-learn >=0.20
+    - scipy >=1.1.0
+    - tensorflow 1.14.*
+    - ipython
+    - ipykernel
+  run:
+    - gensim >=3.4.0
+    - matplotlib >=2.2
+    - networkx >=2.2,<2.4
+    - numpy >=1.14
+    - pandas >=0.24
+    - python
+    - scikit-learn >=0.20
+    - scipy >=1.1.0
+    - tensorflow 1.14.*
+    - ipython
+    - ipykernel
+
+test:
+  imports:
+    - stellargraph
+    - stellargraph.core
+    - stellargraph.data
+    - stellargraph.layer
+    - stellargraph.mapper
+    - stellargraph.utils
+    - stellargraph.utils.saliency_maps
+
+about:
+  home: "https://github.com/stellargraph/stellargraph"
+  license: Apache Software
+  license_family: APACHE
+  license_file: LICENSE
+  summary: "Python library for machine learning on graphs"
+  doc_url: https://stellargraph.readthedocs.io/
+  dev_url: https://github.com/stellargraph/stellargraph
+
+extra:
+  recipe-maintainers:
+    - adocherty


### PR DESCRIPTION
Added `meta.yaml` that enables building an Anaconda package (see the issue for details).

The package is available on Anaconda Cloud, but currently needs manual updates. We can automate this by moving to conda-forge potentially, but this will be a new issue.