### PR TITLE
pin shellcheck image to stable tag

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -55,7 +55,7 @@ steps:
     command: 'find ./ -type f -name "*.sh" -print0 | xargs -0 shellcheck --color=always'
     plugins:
       docker#v3.2.0:
-        image: "koalaman/shellcheck-alpine"
+        image: "koalaman/shellcheck-alpine:stable"
 
   - label: ":docker: :hadolint: lint Dockerfiles"
     command: "find -name 'Dockerfile*' -print0 | xargs -0 hadolint"


### PR DESCRIPTION
Pins the `shellcheck` docker image to the `stable` tag