### PR TITLE
Add benchmarks measuring the time of neighbour and feature queries

### DIFF
--- a/tests/core/test_stellargraph.py
+++ b/tests/core/test_stellargraph.py
@@ -446,7 +446,9 @@ def example_benchmark_graph(feature_size=None, n_nodes=100, n_edges=200, n_types
             G.nodes[v]["feature"] = np.ones(feature_size)
             G.nodes[v]["label"] = v % n_types
 
-    G = StellarGraph(G, node_features="feature")
+        G = StellarGraph(G, node_features="feature")
+    else:
+        G = StellarGraph(G)
     return G
 
 

--- a/tests/core/test_stellargraph.py
+++ b/tests/core/test_stellargraph.py
@@ -450,7 +450,7 @@ def example_benchmark_graph(feature_size=None, n_nodes=100, n_edges=200, n_types
     return G
 
 
-@pytest.mark.benchmark(group="StellarGraph")
+@pytest.mark.benchmark(group="StellarGraph neighbours")
 def test_benchmark_get_neighbours(benchmark):
     g = example_benchmark_graph()
     num_nodes = g.number_of_nodes()
@@ -463,7 +463,7 @@ def test_benchmark_get_neighbours(benchmark):
     benchmark(f)
 
 
-@pytest.mark.benchmark(group="StellarGraph")
+@pytest.mark.benchmark(group="StellarGraph node features")
 @pytest.mark.parametrize("num_types", [1, 4])
 @pytest.mark.parametrize("lookup", ["individual", "bulk"])
 @pytest.mark.parametrize("type_arg", ["infer", "specify"])


### PR DESCRIPTION
This adds two benchmarks that construct a small graph (100 nodes, 200 edges)
and do:

- "get neighbours" on every node in the graph
- "get features" on a random subset of the nodes in the graph, with 4 different configurations, along 2 independent axes:
   - either homogeneous or heterogenous (with 4 node types)
   - "specifying" the node type (via the `node_type` argument) or "inferring" it

Current output:

```
$ py.test tests -k benchmark_get
==================================================================================================================================================== test session starts =====================================================================================================================================================
platform darwin -- Python 3.6.9, pytest-5.3.0, py-1.8.0, pluggy-0.13.1
benchmark: 3.2.2 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /Users/wil9dw/projects/stellargraph/stellargraph
plugins: benchmark-3.2.2
collected 302 items / 293 deselected / 9 selected                                                                                                                                                                                                                                                                            

tests/core/test_stellargraph.py .........                                                                                                                                                                                                                                                                              [100%]
...
------------------------------------------ benchmark 'StellarGraph neighbours': 1 tests ------------------------------------------
Name (time in us)                     Min       Max     Mean  StdDev   Median     IQR   Outliers  OPS (Kops/s)  Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------
test_benchmark_get_neighbours     21.1061  133.4969  23.1896  6.8984  21.4381  1.0589  1088;1128       43.1227   21868           1
----------------------------------------------------------------------------------------------------------------------------------

-------------------------------------------------------------------------------- benchmark 'StellarGraph node features': 4 tests ---------------------------------------------------------------------------------
Name (time in us)                              Min                 Max               Mean             StdDev             Median                IQR            Outliers  OPS (Kops/s)            Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_benchmark_get_features[specify-4]     25.8561 (1.0)      205.9911 (1.03)     29.6558 (1.0)       8.6885 (1.0)      27.5809 (1.0)       1.1480 (1.06)    1545;2098       33.7202 (1.0)       24575           1
test_benchmark_get_features[specify-1]     26.5401 (1.03)     200.4220 (1.0)      30.8766 (1.04)      8.8694 (1.02)     29.0291 (1.05)      1.0859 (1.0)     1263;1887       32.3870 (0.96)      24344           1
test_benchmark_get_features[infer-4]       66.3002 (2.56)     295.2679 (1.47)     75.0204 (2.53)     18.6644 (2.15)     69.9519 (2.54)      2.6514 (2.44)      662;830       13.3297 (0.40)       9137           1
test_benchmark_get_features[infer-1]       68.2280 (2.64)     240.7751 (1.20)     78.4736 (2.65)     13.2470 (1.52)     75.5291 (2.74)     14.0793 (12.97)       43;21       12.7431 (0.38)        767           1
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Legend:
  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
  OPS: Operations Per Second, computed as 1 / Mean
```

See: #528 