### PR TITLE
Check copyright headers on CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -65,9 +65,6 @@ steps:
 
   - label: ":copyright: check copyright headers"
     command: '.buildkite/steps/check-copyright-headers.sh'
-    plugins:
-      docker#v3.2.0:
-        image: "alpine:3.10"
 
   - label: ":docker: publish numbered images"
     command: ".buildkite/steps/manage-images.sh build-publish-numbered"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -63,6 +63,12 @@ steps:
        docker#v3.2.0:
           image: "hadolint/hadolint:latest-debian"
 
+  - label: ":copyright: check copyright headers"
+    command: '.buildkite/steps/check-copyright-headers.sh'
+    plugins:
+      docker#v3.2.0:
+        image: "alpine:3.10"
+
   - label: ":docker: publish numbered images"
     command: ".buildkite/steps/manage-images.sh build-publish-numbered"
     agents:

--- a/.buildkite/steps/check-copyright-headers.sh
+++ b/.buildkite/steps/check-copyright-headers.sh
@@ -8,7 +8,14 @@ temp="$(mktemp)"
 copyrightRegex="# Copyright [0-9-]* Data61, CSIRO"
 
 echo "--- checking files have copyright headers"
-find . -name "*.py" -exec grep -L "$copyrightRegex" {} + | tee "$temp"
+# Some files shouldn't have our copyright header and so are ignored
+find . \( \
+  -name "*.py" \
+  -a ! -path "./demos/link-prediction/random-walks/utils/node2vec/node2vec.py" \
+  -a ! -path "./demos/link-prediction/random-walks/utils/node2vec/main.py" \
+  -a ! -path "./docs/conf.py" \
+  \) \
+  -exec grep -L "$copyrightRegex" {} + | tee "$temp"
 
 if [ -s "$temp" ]; then
   echo "^^^ +++"

--- a/.buildkite/steps/check-copyright-headers.sh
+++ b/.buildkite/steps/check-copyright-headers.sh
@@ -6,6 +6,7 @@ exitCode=0
 temp="$(mktemp)"
 
 copyrightRegex="# Copyright [0-9-]* Data61, CSIRO"
+
 echo "--- checking files have copyright headers"
 find . -name "*.py" -exec grep -L "$copyrightRegex" {} + | tee "$temp"
 
@@ -14,7 +15,6 @@ if [ -s "$temp" ]; then
   echo "found files without copyright header matching $copyrightRegex"
   exitCode=1
 fi
-
 
 echo "--- checking copyright headers are up to date"
 # look for files that have been modified in the last year (-mtime -$dayOfYear), where their

--- a/.buildkite/steps/check-copyright-headers.sh
+++ b/.buildkite/steps/check-copyright-headers.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -eux
+set -eu
 
 # FIXME: replace with git-bash image
 apk add git
@@ -31,7 +31,6 @@ echo "--- checking copyright headers are up to date"
 # year (grep -v $year), and then check (while read ....) whether there's been any commit touching
 # that file in the current year.
 year="$(date +%Y)"
-dayOfYear="$(date +%j)"
 
 find . -name "*.py" -exec grep "$copyrightRegex" {} + | grep -v "$year" | while read -r fileAndLine; do
   # grep prints `<filename>:<matching line>`, so remove everything from the first : to get the

--- a/.buildkite/steps/check-copyright-headers.sh
+++ b/.buildkite/steps/check-copyright-headers.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+set -eu
+
+exitCode=0
+temp="$(mktemp)"
+
+copyrightRegex="# Copyright [0-9-]* Data61, CSIRO"
+echo "--- checking files have copyright headers"
+find . -name "*.py" -exec grep -L "$copyrightRegex" {} + | tee "$temp"
+
+if [ -s "$temp" ]; then
+  echo "^^^ +++"
+  echo "found files without copyright header matching $copyrightRegex"
+  exitCode=1
+fi
+
+
+echo "--- checking copyright headers are up to date"
+# look for files that have been modified in the last year (-mtime -$dayOfYear), where their
+# copyright header (grep $copyrightRegex) doesn't mention the current year (grep -v $year).
+year="$(date +%Y)"
+dayOfYear="$(date +%j)"
+
+find . -name "*.py" -mtime "-$dayOfYear" -exec grep "$copyrightRegex" {} + | grep -v "$year" | tee "$temp"
+
+if [ -s "$temp" ]; then
+  echo "^^^ +++"
+  echo "found files modified in $year (in the last $dayOfYear days) without $year in their copyright header"
+  exitCode=1
+fi
+
+exit "$exitCode"

--- a/.buildkite/steps/check-copyright-headers.sh
+++ b/.buildkite/steps/check-copyright-headers.sh
@@ -1,9 +1,6 @@
-#!/bin/sh
+#!/bin/bash
 
-set -eu
-
-# FIXME: replace with git-bash image
-apk add git
+set -euo pipefail
 
 exitCode=0
 temp="$(mktemp)"
@@ -22,8 +19,10 @@ find . \( \
 
 if [ -s "$temp" ]; then
   echo "^^^ +++"
-  echo "found files without copyright header matching $copyrightRegex"
+  echo "found files without a copyright header (no matches for /$copyrightRegex/)"
   exitCode=1
+else
+  echo "all files have a copyright header (have a match for /$copyrightRegex/)"
 fi
 
 echo "--- checking copyright headers are up to date"
@@ -50,6 +49,8 @@ if [ -s "$temp" ]; then
   echo "^^^ +++"
   echo "found files modified in $year (according to git) without $year in their copyright header"
   exitCode=1
+else
+  echo "all files modified in $year (according to git) have $year in their copyright header"
 fi
 
 exit "$exitCode"

--- a/demos/link-prediction/graphsage/cora-links-example.py
+++ b/demos/link-prediction/graphsage/cora-links-example.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2018 Data61, CSIRO
+# Copyright 2018-2019 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/demos/link-prediction/hinsage/movielens-recommender.py
+++ b/demos/link-prediction/hinsage/movielens-recommender.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2018 Data61, CSIRO
+# Copyright 2018-2019 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/demos/link-prediction/hinsage/utils.py
+++ b/demos/link-prediction/hinsage/utils.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2018 Data61, CSIRO
+# Copyright 2018-2019 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/demos/link-prediction/random-walks/main.py
+++ b/demos/link-prediction/random-walks/main.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2017-2018 Data61, CSIRO
+# Copyright 2017-2019 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/demos/link-prediction/random-walks/utils/__init__.py
+++ b/demos/link-prediction/random-walks/utils/__init__.py
@@ -1,3 +1,19 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2018-2019 Data61, CSIRO
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 #--------------------------------------
 # Simple utilities
 #--------------------------------------

--- a/demos/link-prediction/random-walks/utils/cl_arguments_parser.py
+++ b/demos/link-prediction/random-walks/utils/cl_arguments_parser.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2017-2018 Data61, CSIRO
+# Copyright 2017-2019 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/demos/link-prediction/random-walks/utils/metapath2vec_feature_learning.py
+++ b/demos/link-prediction/random-walks/utils/metapath2vec_feature_learning.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2017-2018 Data61, CSIRO
+# Copyright 2017-2019 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/demos/link-prediction/random-walks/utils/node2vec_feature_learning.py
+++ b/demos/link-prediction/random-walks/utils/node2vec_feature_learning.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2017-2018 Data61, CSIRO
+# Copyright 2017-2019 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/demos/link-prediction/random-walks/utils/predictors.py
+++ b/demos/link-prediction/random-walks/utils/predictors.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2017-2018 Data61, CSIRO
+# Copyright 2017-2019 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/demos/link-prediction/random-walks/utils/read_graph.py
+++ b/demos/link-prediction/random-walks/utils/read_graph.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2017-2018 Data61, CSIRO
+# Copyright 2017-2019 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/demos/node-classification/graphsage/graphsage-cora-example.py
+++ b/demos/node-classification/graphsage/graphsage-cora-example.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2018 Data61, CSIRO
+# Copyright 2018-2019 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/demos/node-classification/hinsage/yelp-example.py
+++ b/demos/node-classification/hinsage/yelp-example.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2018 Data61, CSIRO
+# Copyright 2018-2019 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/demos/node-classification/hinsage/yelp-preprocessing.py
+++ b/demos/node-classification/hinsage/yelp-preprocessing.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2018 Data61, CSIRO
+# Copyright 2018-2019 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/test_demos.py
+++ b/scripts/test_demos.py
@@ -1,4 +1,20 @@
 #!/usr/bin/env python
+#
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Data61, CSIRO
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import os
 import sys

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2018 Data61, CSIRO
+# Copyright 2018-2019 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stellargraph/__init__.py
+++ b/stellargraph/__init__.py
@@ -1,3 +1,19 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2018-2019 Data61, CSIRO
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """
 Stellar Machine Learning Library
 

--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2017-2018 Data61, CSIRO
+# Copyright 2017-2019 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stellargraph/core/schema.py
+++ b/stellargraph/core/schema.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2017-2018 Data61, CSIRO
+# Copyright 2017-2019 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stellargraph/data/__init__.py
+++ b/stellargraph/data/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2018 Data61, CSIRO
+# Copyright 2018-2019 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stellargraph/data/converter.py
+++ b/stellargraph/data/converter.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2018 Data61, CSIRO
+# Copyright 2018-2019 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stellargraph/data/edge_splitter.py
+++ b/stellargraph/data/edge_splitter.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2017-2018 Data61, CSIRO
+# Copyright 2017-2019 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stellargraph/data/epgm.py
+++ b/stellargraph/data/epgm.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2017-2018 Data61, CSIRO
+# Copyright 2017-2019 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stellargraph/data/node_splitter.py
+++ b/stellargraph/data/node_splitter.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2017-2018 Data61, CSIRO
+# Copyright 2017-2019 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stellargraph/data/unsupervised_sampler.py
+++ b/stellargraph/data/unsupervised_sampler.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+#
+# Copyright 2019 Data61, CSIRO
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 __all__ = ["UnsupervisedSampler"]
 

--- a/stellargraph/globalvar.py
+++ b/stellargraph/globalvar.py
@@ -1,3 +1,19 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2018-2019 Data61, CSIRO
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # This file contains global attributes used throughout stellargraph
 
 FEATURE_ATTR_NAME = "feature"

--- a/stellargraph/layer/__init__.py
+++ b/stellargraph/layer/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2018 Data61, CSIRO
+# Copyright 2018-2019 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stellargraph/layer/appnp.py
+++ b/stellargraph/layer/appnp.py
@@ -1,3 +1,19 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Data61, CSIRO
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from tensorflow.keras.layers import Dense, Lambda, Dropout, Input, Layer
 import tensorflow.keras.backend as K
 

--- a/stellargraph/layer/attri2vec.py
+++ b/stellargraph/layer/attri2vec.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2018 Data61, CSIRO
+# Copyright 2018-2019 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stellargraph/layer/graphsage.py
+++ b/stellargraph/layer/graphsage.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2018 Data61, CSIRO
+# Copyright 2018-2019 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stellargraph/layer/hinsage.py
+++ b/stellargraph/layer/hinsage.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2018 Data61, CSIRO
+# Copyright 2018-2019 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stellargraph/layer/link_inference.py
+++ b/stellargraph/layer/link_inference.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2018 Data61, CSIRO
+# Copyright 2018-2019 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stellargraph/layer/ppnp.py
+++ b/stellargraph/layer/ppnp.py
@@ -1,3 +1,19 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Data61, CSIRO
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from tensorflow.keras.layers import Dense, Lambda, Layer, Dropout, Input
 import tensorflow.keras.backend as K
 import tensorflow as tf

--- a/stellargraph/mapper/__init__.py
+++ b/stellargraph/mapper/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2018 Data61, CSIRO
+# Copyright 2018-2019 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stellargraph/utils/saliency_maps/integrated_gradients.py
+++ b/stellargraph/utils/saliency_maps/integrated_gradients.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2018 Data61, CSIRO
+# Copyright 2018-2019 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stellargraph/utils/saliency_maps/integrated_gradients_gat.py
+++ b/stellargraph/utils/saliency_maps/integrated_gradients_gat.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2018 Data61, CSIRO
+# Copyright 2018-2019 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stellargraph/utils/saliency_maps/saliency.py
+++ b/stellargraph/utils/saliency_maps/saliency.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2018 Data61, CSIRO
+# Copyright 2018-2019 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stellargraph/utils/saliency_maps/saliency_gat.py
+++ b/stellargraph/utils/saliency_maps/saliency_gat.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2018 Data61, CSIRO
+# Copyright 2018-2019 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stellargraph/version.py
+++ b/stellargraph/version.py
@@ -1,2 +1,18 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2018-2019 Data61, CSIRO
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Global version information
 __version__ = "0.9.0b"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2018-2019 Data61, CSIRO
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/core/test_schema.py
+++ b/tests/core/test_schema.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2017-2018 Data61, CSIRO
+# Copyright 2017-2019 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/core/test_stellargraph.py
+++ b/tests/core/test_stellargraph.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2017-2018 Data61, CSIRO
+# Copyright 2017-2019 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/data/test_biased_random_walker.py
+++ b/tests/data/test_biased_random_walker.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2017-2018 Data61, CSIRO
+# Copyright 2017-2019 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/data/test_converters.py
+++ b/tests/data/test_converters.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2018 Data61, CSIRO
+# Copyright 2018-2019 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/data/test_edge_splitter.py
+++ b/tests/data/test_edge_splitter.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2017-2018 Data61, CSIRO
+# Copyright 2017-2019 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/data/test_heterogeneous_breadth_first_walker.py
+++ b/tests/data/test_heterogeneous_breadth_first_walker.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2017-2018 Data61, CSIRO
+# Copyright 2017-2019 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/data/test_metapath_walker.py
+++ b/tests/data/test_metapath_walker.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2017-2018 Data61, CSIRO
+# Copyright 2017-2019 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/data/test_node_splitter.py
+++ b/tests/data/test_node_splitter.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2017-2018 Data61, CSIRO
+# Copyright 2017-2019 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/data/test_uniform_random_walker.py
+++ b/tests/data/test_uniform_random_walker.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2017-2018 Data61, CSIRO
+# Copyright 2017-2019 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/data/test_unsupervised_sampler.py
+++ b/tests/data/test_unsupervised_sampler.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2017-2018 Data61, CSIRO
+# Copyright 2017-2019 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/layer/__init__.py
+++ b/tests/layer/__init__.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2018-2019 Data61, CSIRO
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/layer/test_appnp.py
+++ b/tests/layer/test_appnp.py
@@ -1,3 +1,19 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Data61, CSIRO
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from stellargraph.layer.appnp import *
 from stellargraph.mapper import FullBatchNodeGenerator
 from stellargraph import StellarGraph

--- a/tests/layer/test_attri2vec.py
+++ b/tests/layer/test_attri2vec.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2018 Data61, CSIRO
+# Copyright 2018-2019 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/layer/test_gcn.py
+++ b/tests/layer/test_gcn.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2018 Data61, CSIRO
+# Copyright 2018-2019 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/layer/test_graph_attention.py
+++ b/tests/layer/test_graph_attention.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2018 Data61, CSIRO
+# Copyright 2018-2019 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/layer/test_graphsage.py
+++ b/tests/layer/test_graphsage.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2018 Data61, CSIRO
+# Copyright 2018-2019 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/layer/test_hinsage.py
+++ b/tests/layer/test_hinsage.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2018 Data61, CSIRO
+# Copyright 2018-2019 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/layer/test_link_inference.py
+++ b/tests/layer/test_link_inference.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2018 Data61, CSIRO
+# Copyright 2018-2019 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/layer/test_misc.py
+++ b/tests/layer/test_misc.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2018 Data61, CSIRO
+# Copyright 2018-2019 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/layer/test_ppnp.py
+++ b/tests/layer/test_ppnp.py
@@ -1,3 +1,19 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Data61, CSIRO
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from stellargraph.layer import PPNP
 from stellargraph.mapper import FullBatchNodeGenerator
 from stellargraph import StellarGraph

--- a/tests/mapper/test_benchmark_generators.py
+++ b/tests/mapper/test_benchmark_generators.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2018 Data61, CSIRO
+# Copyright 2018-2019 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/mapper/test_link_mappers.py
+++ b/tests/mapper/test_link_mappers.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2018 Data61, CSIRO
+# Copyright 2018-2019 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/mapper/test_node_mappers.py
+++ b/tests/mapper/test_node_mappers.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2018 Data61, CSIRO
+# Copyright 2018-2019 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
This checks two things about the copyright headers:

- that every Python file has one, which is estimated by looking for matches for the regex `# Copyright [0-9-]* Data61, CSIRO`
- that files that have been modified recently (have a git commit touching them in the current year), mention the current year in their header; this will force people to update the headers of any files they touch

In order to land these changes, this PR also has to update all the files appropriately:

- 12 files did not have a header at all
- 50 files have been modified in 2019 but did not mention it in their headers; this was done automatically via a slightly different approach (the file system modification time `find -mtime` rather than checking `git`; this works for my local check-out that was created in 2018, but not on CI, where the checkouts are created for each build, and thus the mtimes are very recent):
   ```
   find . -name "*.py" -mtime "-331" -exec grep "Copyright .* Data61" {} + | grep -v 2019 | cut -d: -f1 | xargs sed -i '' 's/Copyright 2017-2018/Copyright 2017-2019/; s/Copyright 2018/Copyright 2018-2019/;'
   ```

See: #533 