### PR TITLE
Build the docker image using the buildkite docker-compose plugin

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+echo "~~~ setting docker image tag"
+case "${BUILDKITE_BRANCH}" in
+  develop)
+    IMAGE_TAG="latest"
+    ;;
+  *)
+    if [ "$BUILDKITE_PULL_REQUEST" != "false" ]; then
+      IMAGE_TAG="PR-$BUILDKITE_PULL_REQUEST"
+    else
+      IMAGE_TAG="testing"
+    fi
+    ;;
+esac
+
+echo "IMAGE_TAG: $IMAGE_TAG"
+
+export IMAGE_TAG

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -63,8 +63,15 @@ steps:
        docker#v3.2.0:
           image: "hadolint/hadolint:latest-debian"
 
-  - label: ":docker: publish numbered images"
-    command: ".buildkite/steps/manage-images.sh build-publish-numbered"
+  - label: ":docker: build image"
+    plugins:
+      docker-compose#v3.1.0:
+        build:
+          - stellargraph
+        image-repository: index.docker.io/stellargraph/stellargraph
+        cache-from:
+          - stellargraph:index.docker.io/stellargraph/stellargraph:${IMAGE_TAG}
+          - stellargraph:index.docker.io/stellargraph/stellargraph:latest
     agents:
       queue: "t2medium"
     branches: "develop feature/*"
@@ -72,10 +79,11 @@ steps:
   - wait: ~
     key: "wait-for-tests"
 
-  - label: ":docker: publish docker images"
-    key: "publish-images"
-    command: ".buildkite/steps/manage-images.sh publish-images"
-    branches: "develop feature/*"
+  - label: ":docker: publish image"
+    plugins:
+      docker-compose#v3.1.0:
+        push:
+          - stellargraph:index.docker.io/stellargraph/stellargraph:${IMAGE_TAG}
 
   - label: ":console: push logs"
     command: .buildkite/utils/pushlogs.sh "#build-bots"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,5 @@
+---
+services:
+  stellargraph:
+    build:
+      dockerfile: docker/stellargraph/Dockerfile


### PR DESCRIPTION
This uses https://github.com/buildkite-plugins/docker-compose-buildkite-plugin to automate the building of the docker image. It doesn't work great for now, due to the restrictions around being a public repository.