### PR TITLE
Add copyright header to tests/core/__init__.py file

### DIFF
--- a/tests/core/__init__.py
+++ b/tests/core/__init__.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Data61, CSIRO
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.


### PR DESCRIPTION
There was "merge skew" where #534 merged first and #530 wasn't correct with respect to that new check.