### PR TITLE
Bug-fix: Naive ensembling does not work with unsupervised graphsage

### DIFF
--- a/stellargraph/utils/ensemble.py
+++ b/stellargraph/utils/ensemble.py
@@ -254,6 +254,7 @@ class Ensemble(object):
                 sg.mapper.LinkSequence,
                 sg.mapper.FullBatchNodeSequence,
                 sg.mapper.SparseFullBatchNodeSequence,
+                sg.mapper.OnDemandLinkSequence
             ),
         ):
             raise ValueError(
@@ -355,6 +356,7 @@ class Ensemble(object):
                 sg.mapper.LinkSequence,
                 sg.mapper.FullBatchNodeSequence,
                 sg.mapper.SparseFullBatchNodeSequence,
+                sg.mapper.OnDemandLinkSequence
             ),
         ):
             raise ValueError(
@@ -457,6 +459,7 @@ class Ensemble(object):
                 sg.mapper.LinkSequence,
                 sg.mapper.FullBatchNodeSequence,
                 sg.mapper.SparseFullBatchNodeSequence,
+                sg.mapper.OnDemandLinkSequence
             ),
         ):
             raise ValueError(

--- a/stellargraph/utils/ensemble.py
+++ b/stellargraph/utils/ensemble.py
@@ -72,8 +72,8 @@ class Ensemble(object):
             )
 
         self.metrics_names = (
-            None
-        )  # It will be set when the self.compile() method is called
+            None  # It will be set when the self.compile() method is called
+        )
         self.models = []
         self.history = []
         self.n_estimators = n_estimators
@@ -186,7 +186,8 @@ class Ensemble(object):
                 weighted_metrics=weighted_metrics,
             )
 
-        self.metrics_names = self.models[0].metrics_names  # assumes all models are same
+        # assumes all models are same
+        self.metrics_names = self.models[0].metrics_names
 
     def fit_generator(
         self,
@@ -254,7 +255,7 @@ class Ensemble(object):
                 sg.mapper.LinkSequence,
                 sg.mapper.FullBatchNodeSequence,
                 sg.mapper.SparseFullBatchNodeSequence,
-                sg.mapper.OnDemandLinkSequence
+                sg.mapper.OnDemandLinkSequence,
             ),
         ):
             raise ValueError(
@@ -356,7 +357,7 @@ class Ensemble(object):
                 sg.mapper.LinkSequence,
                 sg.mapper.FullBatchNodeSequence,
                 sg.mapper.SparseFullBatchNodeSequence,
-                sg.mapper.OnDemandLinkSequence
+                sg.mapper.OnDemandLinkSequence,
             ),
         ):
             raise ValueError(
@@ -459,7 +460,7 @@ class Ensemble(object):
                 sg.mapper.LinkSequence,
                 sg.mapper.FullBatchNodeSequence,
                 sg.mapper.SparseFullBatchNodeSequence,
-                sg.mapper.OnDemandLinkSequence
+                sg.mapper.OnDemandLinkSequence,
             ),
         ):
             raise ValueError(

--- a/tests/core/__init__.py
+++ b/tests/core/__init__.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Data61, CSIRO
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/utils/test_ensemble.py
+++ b/tests/utils/test_ensemble.py
@@ -476,9 +476,7 @@ def test_unsupervised_Ensemble_fit_generator():
     graph = example_graph_1(feature_size=10)
 
     # base_model, keras_model, generator, train_gen
-    gnn_models = [
-        create_graphSAGE_model(graph),
-    ]
+    gnn_models = [create_graphSAGE_model(graph)]
 
     for gnn_model in gnn_models:
         keras_model = gnn_model[1]
@@ -507,9 +505,7 @@ def test_unsupervised_BaggingEnsemble_fit_generator():
     graph = example_graph_1(feature_size=10)
 
     # base_model, keras_model, generator, train_gen
-    gnn_models = [
-        create_graphSAGE_model(graph),
-    ]
+    gnn_models = [create_graphSAGE_model(graph)]
 
     for gnn_model in gnn_models:
         keras_model = gnn_model[1]

--- a/tests/utils/test_ensemble.py
+++ b/tests/utils/test_ensemble.py
@@ -34,11 +34,13 @@ from stellargraph.mapper import (
     HinSAGELinkGenerator,
 )
 from stellargraph.data.converter import *
+from stellargraph.data import UnsupervisedSampler
 from stellargraph.utils import Ensemble, BaggingEnsemble
 
 from tensorflow.keras import layers, Model
 from tensorflow.keras.optimizers import Adam
 from tensorflow.keras.losses import categorical_crossentropy, binary_crossentropy
+from tensorflow import keras
 
 
 def example_graph_1(feature_size=None):
@@ -97,6 +99,26 @@ def create_graphSAGE_model(graph, link_prediction=False):
         prediction = layers.Dense(units=2, activation="softmax")(x_out)
 
         keras_model = Model(inputs=x_inp, outputs=prediction)
+
+    return base_model, keras_model, generator, train_gen
+
+
+def create_Unsupervised_graphSAGE_model(graph):
+    generator = GraphSAGELinkGenerator(graph, batch_size=2, num_samples=[2, 2])
+    unsupervisedSamples = UnsupervisedSampler(
+        graph, nodes=graph.nodes(), length=3, number_of_walks=2
+    )
+    train_gen = generator.flow(unsupervisedSamples)
+
+    base_model = GraphSAGE(
+        layer_sizes=[8, 8], generator=generator, bias=True, dropout=0.5
+    )
+    x_inp, x_out = base_model.build()
+    prediction = link_classification(
+        output_dim=1, output_act="sigmoid", edge_embedding_method="ip"
+    )(x_out)
+
+    keras_model = Model(inputs=x_inp, outputs=prediction)
 
     return base_model, keras_model, generator, train_gen
 
@@ -191,6 +213,7 @@ def test_ensemble_init_parameters():
     # base_model, keras_model, generator, train_gen
     gnn_models = [
         create_graphSAGE_model(graph),
+        create_Unsupervised_graphSAGE_model(graph),
         create_HinSAGE_model(graph),
         create_graphSAGE_model(graph, link_prediction=True),
         create_HinSAGE_model(graph, link_prediction=True),
@@ -268,6 +291,7 @@ def test_compile():
     # base_model, keras_model, generator, train_gen
     gnn_models = [
         create_graphSAGE_model(graph),
+        create_Unsupervised_graphSAGE_model(graph),
         create_HinSAGE_model(graph),
         create_graphSAGE_model(graph, link_prediction=True),
         create_HinSAGE_model(graph, link_prediction=True),
@@ -338,11 +362,9 @@ def test_Ensemble_fit_generator():
         train_gen = gnn_model[3]
 
         ens = Ensemble(keras_model, n_estimators=2, n_predictions=1)
-
         ens.compile(
             optimizer=Adam(), loss=categorical_crossentropy, weighted_metrics=["acc"]
         )
-
         ens.fit_generator(train_gen, epochs=1, verbose=0, shuffle=False)
 
         with pytest.raises(ValueError):
@@ -379,6 +401,124 @@ def test_BaggingEnsemble_fit_generator():
 
         ens.compile(
             optimizer=Adam(), loss=categorical_crossentropy, weighted_metrics=["acc"]
+        )
+
+        ens.fit_generator(
+            generator=generator,
+            train_data=train_data,
+            train_targets=train_targets,
+            epochs=1,
+            validation_data=train_gen,
+            verbose=0,
+            shuffle=False,
+        )
+
+        # This is a BaggingEnsemble so the generator in the below call is of the wrong type.
+        with pytest.raises(ValueError):
+            ens.fit_generator(
+                train_gen,
+                train_data=train_data,
+                train_targets=train_targets,
+                epochs=10,
+                verbose=0,
+                shuffle=False,
+            )
+
+        with pytest.raises(ValueError):
+            ens.fit_generator(
+                generator=generator,
+                train_data=train_data,
+                train_targets=None,  # Should not be None
+                epochs=10,
+                validation_data=train_gen,
+                verbose=0,
+                shuffle=False,
+            )
+
+        with pytest.raises(ValueError):
+            ens.fit_generator(
+                generator=generator,
+                train_data=None,
+                train_targets=None,
+                epochs=10,
+                validation_data=None,
+                verbose=0,
+                shuffle=False,
+            )
+
+        with pytest.raises(ValueError):
+            ens.fit_generator(
+                generator=generator,
+                train_data=train_data,
+                train_targets=train_targets,
+                epochs=10,
+                validation_data=None,
+                verbose=0,
+                shuffle=False,
+                bag_size=-1,  # should be positive integer smaller than or equal to len(train_data) or None
+            )
+
+        with pytest.raises(ValueError):
+            ens.fit_generator(
+                generator=generator,
+                train_data=train_data,
+                train_targets=train_targets,
+                epochs=10,
+                validation_data=None,
+                verbose=0,
+                shuffle=False,
+                bag_size=10,  # larger than the number of training points
+            )
+
+
+def test_unsupervised_Ensemble_fit_generator():
+
+    graph = example_graph_1(feature_size=10)
+
+    # base_model, keras_model, generator, train_gen
+    gnn_models = [
+        create_graphSAGE_model(graph),
+    ]
+
+    for gnn_model in gnn_models:
+        keras_model = gnn_model[1]
+        generator = gnn_model[2]
+        train_gen = gnn_model[3]
+
+        ens = Ensemble(keras_model, n_estimators=2, n_predictions=1)
+        ens.compile(
+            optimizer=Adam(), loss=binary_crossentropy, weighted_metrics=["acc"]
+        )
+        ens.fit_generator(train_gen, epochs=1, verbose=0, shuffle=False)
+
+        with pytest.raises(ValueError):
+            ens.fit_generator(
+                generator=generator,  # wrong type
+                epochs=10,
+                validation_data=train_gen,
+                verbose=0,
+                shuffle=False,
+            )
+
+
+def test_unsupervised_BaggingEnsemble_fit_generator():
+    train_data = np.array([1, 2])
+    train_targets = np.array([[1, 0], [0, 1]])
+    graph = example_graph_1(feature_size=10)
+
+    # base_model, keras_model, generator, train_gen
+    gnn_models = [
+        create_graphSAGE_model(graph),
+    ]
+
+    for gnn_model in gnn_models:
+        keras_model = gnn_model[1]
+        generator = gnn_model[2]
+        train_gen = gnn_model[3]
+
+        ens = BaggingEnsemble(keras_model, n_estimators=2, n_predictions=1)
+        ens.compile(
+            optimizer=Adam(), loss=binary_crossentropy, weighted_metrics=["acc"]
         )
 
         ens.fit_generator(
@@ -814,3 +954,74 @@ def test_predict_generator_link_prediction():
         assert test_predictions.shape[1] == ens.n_predictions
         assert test_predictions.shape[2] == len(edge_ids_test)
         assert test_predictions.shape[3] == 1
+
+
+def test_unsupervised_embeddings_prediction():
+    #
+    # Tests for embedding generation using inductive GCNs
+    #
+    edge_ids_test = np.array([[1, 2], [2, 3], [1, 3]])
+
+    graph = example_graph_1(feature_size=2)
+
+    # base_model, keras_model, generator, train_gen
+    gnn_models = [create_Unsupervised_graphSAGE_model(graph)]
+
+    for gnn_model in gnn_models:
+        keras_model = gnn_model[1]
+        generator = gnn_model[2]
+        train_gen = gnn_model[3]
+
+        ens = Ensemble(keras_model, n_estimators=2, n_predictions=1)
+
+        ens.compile(
+            optimizer=Adam(), loss=binary_crossentropy, weighted_metrics=["acc"]
+        )
+
+        # Check that passing invalid parameters is handled correctly. We will not check error handling for those
+        # parameters that Keras will be responsible for.
+        with pytest.raises(ValueError):
+            ens.predict_generator(generator=generator, predict_data=edge_ids_test)
+
+        # We won't train the model instead use the initial random weights to test
+        # the evaluate_generator method.
+        ens.models = [
+            keras.Model(inputs=model.input, outputs=model.output[-1])
+            for model in ens.models
+        ]
+
+        test_predictions = ens.predict_generator(train_gen, summarise=False)
+
+        print("test_predictions embeddings shape {}".format(test_predictions.shape))
+        assert test_predictions.shape[0] == ens.n_estimators
+        assert test_predictions.shape[1] == ens.n_predictions
+        assert (
+            test_predictions.shape[2] > 1
+        )  # Embeddings dim is > than binary prediction
+
+        #
+        # Repeat for BaggingEnsemble
+        ens = BaggingEnsemble(keras_model, n_estimators=2, n_predictions=1)
+
+        ens.compile(
+            optimizer=Adam(), loss=binary_crossentropy, weighted_metrics=["acc"]
+        )
+
+        # Check that passing invalid parameters is handled correctly. We will not check error handling for those
+        # parameters that Keras will be responsible for.
+        with pytest.raises(ValueError):
+            ens.predict_generator(generator=train_gen, predict_data=edge_ids_test)
+
+        # We won't train the model instead use the initial random weights to test
+        # the evaluate_generator method.
+        test_predictions = ens.predict_generator(train_gen, summarise=False)
+
+        print("test_predictions shape {}".format(test_predictions.shape))
+
+        assert test_predictions.shape[1] == 1
+
+        test_predictions = ens.predict_generator(train_gen, summarise=False)
+
+        assert test_predictions.shape[0] == ens.n_estimators
+        assert test_predictions.shape[1] == ens.n_predictions
+        assert test_predictions.shape[2] > 1


### PR DESCRIPTION
## Prob def:
Naive ensembling using unsupervised GraphSage does not work, as the `OnDemandLinkGenerator` was not included as an acceptable training generator type.

## Fix:
Added `OnDemandLinkGenerator` to train generator type onto `ensemble.py` class.

## Tests:
- [x] Unit test written and working
- [x] All SG tests passed: Run `py.test tests/`
- [x] Naive ensembling on unsupervised graphsage: training and inference found to be working on local environment post fix
