### PR TITLE
Unsupervised graphsage ensembles

### DIFF
--- a/stellargraph/utils/ensemble.py
+++ b/stellargraph/utils/ensemble.py
@@ -72,8 +72,8 @@ class Ensemble(object):
             )
 
         self.metrics_names = (
-            None
-        )  # It will be set when the self.compile() method is called
+            None  # It will be set when the self.compile() method is called
+        )
         self.models = []
         self.history = []
         self.n_estimators = n_estimators
@@ -254,6 +254,7 @@ class Ensemble(object):
                 sg.mapper.LinkSequence,
                 sg.mapper.FullBatchNodeSequence,
                 sg.mapper.SparseFullBatchNodeSequence,
+                sg.mapper.OnDemandLinkSequence,
             ),
         ):
             raise ValueError(
@@ -355,6 +356,7 @@ class Ensemble(object):
                 sg.mapper.LinkSequence,
                 sg.mapper.FullBatchNodeSequence,
                 sg.mapper.SparseFullBatchNodeSequence,
+                sg.mapper.OnDemandLinkSequence,
             ),
         ):
             raise ValueError(
@@ -457,6 +459,7 @@ class Ensemble(object):
                 sg.mapper.LinkSequence,
                 sg.mapper.FullBatchNodeSequence,
                 sg.mapper.SparseFullBatchNodeSequence,
+                sg.mapper.OnDemandLinkSequence,
             ),
         ):
             raise ValueError(

--- a/tests/utils/test_ensemble.py
+++ b/tests/utils/test_ensemble.py
@@ -42,7 +42,6 @@ from tensorflow.keras.optimizers import Adam
 from tensorflow.keras.losses import categorical_crossentropy, binary_crossentropy
 from tensorflow import keras
 
-
 def example_graph_1(feature_size=None):
     G = nx.Graph()
     elist = [(1, 2), (2, 3), (1, 4), (3, 2), (5, 6), (1, 5)]
@@ -57,7 +56,6 @@ def example_graph_1(feature_size=None):
 
     else:
         return StellarGraph(G)
-
 
 def create_graphSAGE_model(graph, link_prediction=False):
 
@@ -102,7 +100,6 @@ def create_graphSAGE_model(graph, link_prediction=False):
 
     return base_model, keras_model, generator, train_gen
 
-
 def create_Unsupervised_graphSAGE_model(graph):
     generator = GraphSAGELinkGenerator(graph, batch_size=2, num_samples=[2, 2])
     unsupervisedSamples = UnsupervisedSampler(
@@ -121,7 +118,6 @@ def create_Unsupervised_graphSAGE_model(graph):
 
     keras_model = Model(inputs=x_inp, outputs=prediction)
     return base_model, keras_model, generator, train_gen
-
 
 def create_HinSAGE_model(graph, link_prediction=False):
 
@@ -151,7 +147,6 @@ def create_HinSAGE_model(graph, link_prediction=False):
 
     return base_model, keras_model, generator, train_gen
 
-
 def create_GCN_model(graph):
 
     generator = FullBatchNodeGenerator(graph)
@@ -170,7 +165,6 @@ def create_GCN_model(graph):
     keras_model = Model(inputs=x_inp, outputs=x_out)
 
     return base_model, keras_model, generator, train_gen
-
 
 def create_GAT_model(graph):
 
@@ -192,7 +186,6 @@ def create_GAT_model(graph):
     keras_model = Model(inputs=x_inp, outputs=x_out)
 
     return base_model, keras_model, generator, train_gen
-
 
 #
 # Test for class Ensemble instance creation with invalid parameters given.
@@ -276,7 +269,6 @@ def test_ensemble_init_parameters():
         assert ens.n_estimators == 7
         assert ens.n_predictions == 10
 
-
 def test_compile():
 
     graph = example_graph_1(feature_size=10)
@@ -336,7 +328,6 @@ def test_compile():
                 weighted_metrics=["f1_accuracy"],
             )
 
-
 def test_Ensemble_fit_generator():
 
     graph = example_graph_1(feature_size=10)
@@ -371,7 +362,6 @@ def test_Ensemble_fit_generator():
                 shuffle=False,
             )
 
-
 def test_unsupervised_Ensemble_fit_generator():
 
     graph = example_graph_1(feature_size=10)
@@ -398,7 +388,6 @@ def test_unsupervised_Ensemble_fit_generator():
                 verbose=0,
                 shuffle=False,
             )
-
 
 def test_BaggingEnsemble_fit_generator():
 
@@ -492,7 +481,6 @@ def test_BaggingEnsemble_fit_generator():
                 shuffle=False,
                 bag_size=10,  # larger than the number of training points
             )
-
 
 def test_evaluate_generator():
 
@@ -590,7 +578,6 @@ def test_evaluate_generator():
         assert len(test_metrics_mean.shape) == 1
         assert len(test_metrics_std.shape) == 1
 
-
 def test_predict_generator():
 
     # test_data = np.array([[0, 0], [1, 1], [0.8, 0.8]])
@@ -682,7 +669,6 @@ def test_predict_generator():
         else:
             assert test_predictions.shape[2] == len(test_data)
         assert test_predictions.shape[-1] == test_targets.shape[-1]
-
 
 #
 # Tests for link prediction that can't be combined easily with the node attribute inference workflow above.
@@ -785,7 +771,6 @@ def test_evaluate_generator_link_prediction():
         assert len(test_metrics_mean.shape) == 1
         assert len(test_metrics_std.shape) == 1
 
-
 def test_predict_generator_link_prediction():
 
     edge_ids_test = np.array([[1, 2], [2, 3], [1, 3]])
@@ -859,7 +844,6 @@ def test_predict_generator_link_prediction():
         assert test_predictions.shape[1] == ens.n_predictions
         assert test_predictions.shape[2] == len(edge_ids_test)
         assert test_predictions.shape[3] == 1
-
 
 def test_unsupervised_embeddings_prediction():
     #


### PR DESCRIPTION
## Prob def:
Naive ensembling using unsupervised GraphSage does not work, as the `OnDemandLinkGenerator` was not included as an acceptable training generator type.

## Fix:
Added `OnDemandLinkGenerator` to train generator type onto `ensemble.py` class.

## Tests:
- [x] Unit test written and working
- [x] All SG tests passed: Run `py.test tests/`
- [x] Naive ensembling on unsupervised graphsage: training and inference found to be working on local environment post fix