### PR TITLE
Upgrade pytest to 5.3.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ scikit_learn>=0.20
 matplotlib>=2.2
 pandas>=0.24
 gensim>=3.4.0
-pytest==3.9.3
+pytest==5.3.1
 pytest-benchmark>=3.1
 pytest-cov>=2.6.0
 coveralls>=1.5.1


### PR DESCRIPTION
This will remove the numpy deprecation warnings we're seeing (see https://github.com/pytest-dev/pytest/pull/4643 and [warnings in BK currently](https://buildkite.com/stellar/stellargraph-public/builds/58#e210db25-4322-4cff-ae65-58bdac56d93d)), along with a whole heap of other improvements and bugfixes.