### PR TITLE
Increase max_iter=500 to avoid conv warning

### DIFF
--- a/demos/link-prediction/random-walks/utils/predictors.py
+++ b/demos/link-prediction/random-walks/utils/predictors.py
@@ -64,7 +64,7 @@ def link_prediction_clf(feature_learner, edge_data, binary_operators=None):
                 (
                     "clf",
                     LogisticRegressionCV(
-                        Cs=10, cv=10, scoring="roc_auc", verbose=False
+                        Cs=10, cv=10, scoring="roc_auc", verbose=False, max_iter=500
                     ),
                 ),
             ]


### PR DESCRIPTION
Part of #565 

I followed the suggestion of the warning message 
```
ConvergenceWarning: lbfgs failed to converge. Increase the number of iterations.
```

I tried with `max_iter` of 200, 500, 1000, and it seems to get rid of the warnings with 500+, but let me know if increasing the max iteration is not what we want to do.

New output without convergence warnings:
```
$ python main.py --input_graph=~/data/cora/cora.cites --output_node_features=~/data/cora/cora.emb
/Users/jun021/miniconda3/envs/stellargraph-dev/lib/python3.7/site-packages/tensorflow/python/framework/dtypes.py:516: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.
  _np_qint8 = np.dtype([("qint8", np.int8, 1)])
/Users/jun021/miniconda3/envs/stellargraph-dev/lib/python3.7/site-packages/tensorflow/python/framework/dtypes.py:517: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.
  _np_quint8 = np.dtype([("quint8", np.uint8, 1)])
/Users/jun021/miniconda3/envs/stellargraph-dev/lib/python3.7/site-packages/tensorflow/python/framework/dtypes.py:518: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.
  _np_qint16 = np.dtype([("qint16", np.int16, 1)])
/Users/jun021/miniconda3/envs/stellargraph-dev/lib/python3.7/site-packages/tensorflow/python/framework/dtypes.py:519: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.
  _np_quint16 = np.dtype([("quint16", np.uint16, 1)])
/Users/jun021/miniconda3/envs/stellargraph-dev/lib/python3.7/site-packages/tensorflow/python/framework/dtypes.py:520: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.
  _np_qint32 = np.dtype([("qint32", np.int32, 1)])
/Users/jun021/miniconda3/envs/stellargraph-dev/lib/python3.7/site-packages/tensorflow/python/framework/dtypes.py:525: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.
  np_resource = np.dtype([("resource", np.ubyte, 1)])
/Users/jun021/miniconda3/envs/stellargraph-dev/lib/python3.7/site-packages/tensorboard/compat/tensorflow_stub/dtypes.py:541: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.
  _np_qint8 = np.dtype([("qint8", np.int8, 1)])
/Users/jun021/miniconda3/envs/stellargraph-dev/lib/python3.7/site-packages/tensorboard/compat/tensorflow_stub/dtypes.py:542: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.
  _np_quint8 = np.dtype([("quint8", np.uint8, 1)])
/Users/jun021/miniconda3/envs/stellargraph-dev/lib/python3.7/site-packages/tensorboard/compat/tensorflow_stub/dtypes.py:543: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.
  _np_qint16 = np.dtype([("qint16", np.int16, 1)])
/Users/jun021/miniconda3/envs/stellargraph-dev/lib/python3.7/site-packages/tensorboard/compat/tensorflow_stub/dtypes.py:544: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.
  _np_quint16 = np.dtype([("quint16", np.uint16, 1)])
/Users/jun021/miniconda3/envs/stellargraph-dev/lib/python3.7/site-packages/tensorboard/compat/tensorflow_stub/dtypes.py:545: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.
  _np_qint32 = np.dtype([("qint32", np.int32, 1)])
/Users/jun021/miniconda3/envs/stellargraph-dev/lib/python3.7/site-packages/tensorboard/compat/tensorflow_stub/dtypes.py:550: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.
  np_resource = np.dtype([("resource", np.ubyte, 1)])
Negative edges sampling method is set to global.
Graph statistics: 2708 nodes, 5278 edges
Graph is not connected
Largest subgraph statistics: 2485 nodes, 5069 edges
** Sampled 506 positive and 506 negative edges. **
** Sampled 456 positive and 456 negative edges. **
Learning 128-dimensional node features (embeddings) from g_train using node2vec algorithm with the following parameters:
        p = 1.0, q = 1.0
        num_walks = 10, walk length = 80, context window size = 10
(Node2VecFeatureLearning) Time for random walks 8 seconds
(Node2VecFeatureLearning) Time for learning embeddings 9 seconds.
Total time for fit() 16.90385103225708 seconds
Training binary link classifiers (link predictors) using the following binary operators: ['h', 'avg', 'l1', 'l2']
Operator: h Score (ROC AUC on test set of edge_data): 0.901
Operator: avg Score (ROC AUC on test set of edge_data): 0.556
Operator: l1 Score (ROC AUC on test set of edge_data): 0.861
Operator: l2 Score (ROC AUC on test set of edge_data): 0.877
Learning 128-dimensional node features (embeddings) from g_test using node2vec algorithm with the following parameters:
        p = 1.0, q = 1.0
        num_walks = 10, walk length = 80, context window size = 10
(Node2VecFeatureLearning) Time for random walks 8 seconds
(Node2VecFeatureLearning) Time for learning embeddings 9 seconds.
Total time for fit() 17.039473056793213 seconds
Evaluating best link predictor with h binary operator on test links in g_test
Prediction score (ROC AUC): 0.799797684700589

  **** Scores on test set of links ****

     Operator: h  Score (ROC AUC): 0.80

  ****************************
```
