### PR TITLE
Move tensorflow to extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,10 @@ StellarGraph depends upon.
 The StellarGraph library requires [Keras](https://keras.io/), so you'll need to install Keras and a selected backend (we recommend tensorflow, which is used to test StellarGraph).  Other requirements are the NetworkX library (to create and modify graphs and networks), numpy (to manipulate numeric arrays), pandas (to manipulate tabular data), and gensim (to use the Word2Vec model), scikit-learn (to prepare datasets for machine learning), and matplotlib (for plotting).
 -->
 
+Stellargraph requires a compatible version of Tensorflow installed. A compatible
+CPU version of Tensorflow can be installed together with Stellargraph by referring
+to `stellargraph[cpu]` in any of the installation steps below.
+
 The StellarGraph library can be installed from PyPI, from Anaconda Cloud, or directly from GitHub, as described below.
 
 #### Install StellarGraph using PyPI:

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ URL = "https://github.com/stellargraph/stellargraph"
 
 # Required packages
 REQUIRES = [
+    "tensorflow>=1.14,<1.15",
     "numpy>=1.14",
     "scipy>=1.1.0",
     "networkx>=2.2",
@@ -42,7 +43,7 @@ REQUIRES = [
 EXTRAS_REQURES = {
     "demos": ["numba", "jupyter", "seaborn"],
     "test": ["pytest", "pytest-benchmark"],
-    "cpu": ["tensorflow>=1.14,<1.15"],
+    "gpu": ["tensorflow-gpu>=1.14,<1.15"],
 }
 
 # Long description

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ URL = "https://github.com/stellargraph/stellargraph"
 
 # Required packages
 REQUIRES = [
-    "tensorflow>=1.14,<1.15",
     "numpy>=1.14",
     "scipy>=1.1.0",
     "networkx>=2.2",
@@ -43,6 +42,7 @@ REQUIRES = [
 EXTRAS_REQURES = {
     "demos": ["numba", "jupyter", "seaborn"],
     "test": ["pytest", "pytest-benchmark"],
+    "cpu": ["tensorflow>=1.14,<1.15"],
 }
 
 # Long description


### PR DESCRIPTION
Part of #546 

I'm not sure if we would land this as is, since this feels like a big breaking change, so I'm open to suggestions for how to make migration easier.

I'm hoping to figure out a way to print a warning if tensorflow is not installed with stellargraph as @adocherty has suggested in #546 but let me know if you have ideas.

I also didn't add a `stellargraph[gpu]` option for now since we're not verifying it in CI currently, although the user would have the option to try use their own gpu tensorflow installation regardless.