### PR TITLE
Add sections to make buildkite output clearer

### DIFF
--- a/.buildkite/steps/script.sh
+++ b/.buildkite/steps/script.sh
@@ -6,10 +6,16 @@ upload_tests() {
   buildkite-agent artifact upload "${BUILDKITE_BUILD_NUMBER}.xml" "s3://${AWS_LOGS_BUCKET}/pytest/${BUILDKITE_BRANCH}/${BUILDKITE_BUILD_NUMBER}"
 }
 
+echo "--- installing dependencies"
 pip install -q --no-cache-dir -r requirements.txt -e .
+
+echo "+++ running tests"
 py.test -ra --cov=stellargraph tests/ --doctest-modules --doctest-modules --cov-report=term-missing -p no:cacheprovider --junitxml=./"${BUILDKITE_BUILD_NUMBER}".xml
+
+echo "--- uploading coveralls"
 coveralls
 
 if [ "${BUILDKITE_BRANCH}" = "develop" ] || [ "${BUILDKITE_BRANCH}" = "master" ]; then
+  echo "--- uploading JUnit"
   upload_tests
 fi


### PR DESCRIPTION
This uses https://buildkite.com/docs/pipelines/managing-log-output to group commands and output on buildkite, and also show the time for each one.

Example: https://buildkite.com/stellar/stellargraph-public/builds/157#e2fb68c3-4022-4762-9f74-36390eae75cb

![image](https://user-images.githubusercontent.com/1203825/71647505-30571800-2d4c-11ea-99a4-ea008a612e78.png)

This also shows the times, on the right: ![image](https://user-images.githubusercontent.com/1203825/71647511-4238bb00-2d4c-11ea-9a6f-09d037051fb5.png)
