### PR TITLE
Use junit-annotate buildkite plugin to highlight failures on CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,6 @@
 steps:
   - label: ":python: 3.6"
+    key: "python_3_6"
     command: ".buildkite/steps/script.sh"
     plugins:
       docker#v3.2.0:
@@ -19,6 +20,7 @@ steps:
       queue: 't2medium'
 
   - label: ":python: 3.7"
+    key: "python_3_7"
     command: ".buildkite/steps/script.sh"
     plugins:
       docker#v3.2.0:
@@ -77,3 +79,15 @@ steps:
   - label: ":docker: publish docker images"
     command: ".buildkite/steps/manage-images.sh publish-images"
     branches: "develop feature/*"
+
+  # Analyse the results of the testing, e.g. failures. This is not part of the testing, and has
+  # explicit dependencies, so can be listed after all of the `wait` steps and publishings, so that
+  # it runs in parallel with them.
+  - label: ":memo: annotate with junit"
+    plugins:
+      junit-annotate#v1.7.0:
+        artifacts: junit-*.xml
+    depends_on:
+      - "python_3_6"
+      - "python_3_7"
+    allow_dependency_failure: true

--- a/.buildkite/steps/script.sh
+++ b/.buildkite/steps/script.sh
@@ -13,7 +13,7 @@ pip install -q --no-cache-dir -r requirements.txt -e .
 
 echo "+++ running tests"
 exitCode=$?
-py.test -ra --cov=stellargraph tests/ --doctest-modules --doctest-modules --cov-report=term-missing -p no:cacheprovider --junitxml="./${junit_file}" || exitCode=0
+py.test -ra --cov=stellargraph tests/ --doctest-modules --doctest-modules --cov-report=term-missing -p no:cacheprovider --junitxml="./${junit_file}" || exitCode=$?
 
 echo "--- uploading coveralls"
 coveralls


### PR DESCRIPTION
https://github.com/buildkite-plugins/junit-annotate-buildkite-plugin can read JUnit XML files (that record the results of a test run) and annotate a build with a summary of the failures. This makes it easier to understand what went wrong, at a glance, without having to dig into the raw logs.

Example: https://buildkite.com/stellar/stellargraph-public/builds/181#_

![image](https://user-images.githubusercontent.com/1203825/71648802-330e3900-2d5d-11ea-953b-e39e081c1857.png)