### PR TITLE
Replace print("Warning: ...") with warnings.warn("...")

### DIFF
--- a/stellargraph/core/graph_networkx.py
+++ b/stellargraph/core/graph_networkx.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2019 Data61, CSIRO
+# Copyright 2019-2020 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stellargraph/core/graph_networkx.py
+++ b/stellargraph/core/graph_networkx.py
@@ -26,6 +26,7 @@ from stellargraph.core.graph import StellarGraph
 import random
 import itertools as it
 from collections import defaultdict
+import warnings
 
 import pandas as pd
 import numpy as np
@@ -97,9 +98,11 @@ def _convert_from_node_attribute(
 
         # Warn if nodes don't have the attribute
         if 0 in data_sizes:
-            print(
-                "Warning: Some nodes have no value for attribute '{}', "
-                "using default value.".format(attr_name)
+            warnings.warn(
+                "Some nodes have no value for attribute '{}', "
+                "using default value.".format(attr_name),
+                RuntimeWarning,
+                stacklevel=2,
             )
             data_sizes.discard(0)
 

--- a/stellargraph/core/schema.py
+++ b/stellargraph/core/schema.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2017-2019 Data61, CSIRO
+# Copyright 2017-2020 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stellargraph/core/schema.py
+++ b/stellargraph/core/schema.py
@@ -106,7 +106,7 @@ class GraphSchema:
 
         except IndexError:
             warnings.warn(
-                "Node key '{}' not found in type map.".format(name), RuntimeWarning
+                "Node key '{}' not found in type map.".format(node), RuntimeWarning
             )
             node_type = None
         return node_type

--- a/stellargraph/core/schema.py
+++ b/stellargraph/core/schema.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import queue
+import warnings
 from collections.__init__ import namedtuple
 from ..core.utils import is_real_iterable
 
@@ -60,7 +61,7 @@ class GraphSchema:
         try:
             index = self.node_types.index(name)
         except ValueError:
-            print("Warning: Node key '{}' not found.".format(name))
+            warnings.warn("Node key '{}' not found.".format(name), RuntimeWarning)
             index = None
         return index
 
@@ -104,7 +105,9 @@ class GraphSchema:
             node_type = nt if index else self.node_types[nt]
 
         except IndexError:
-            print("Warning: Node '{}' not found in type map.".format(node))
+            warnings.warn(
+                "Node key '{}' not found in type map.".format(name), RuntimeWarning
+            )
             node_type = None
         return node_type
 

--- a/stellargraph/core/utils.py
+++ b/stellargraph/core/utils.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2018-2019 Data61, CSIRO
+# Copyright 2018-2020 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stellargraph/core/utils.py
+++ b/stellargraph/core/utils.py
@@ -86,8 +86,9 @@ def rescale_laplacian(laplacian):
         print("Calculating largest eigenvalue of normalized graph Laplacian...")
         largest_eigval = eigsh(laplacian, 1, which="LM", return_eigenvectors=False)[0]
     except ArpackNoConvergence:
-        print(
-            "Eigenvalue calculation did not converge! Using largest_eigval=2 instead."
+        warnings.warn(
+            "Eigenvalue calculation did not converge! Using largest_eigval=2 instead.",
+            RuntimeWarning,
         )
         largest_eigval = 2
 

--- a/stellargraph/data/converter.py
+++ b/stellargraph/data/converter.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2018-2019 Data61, CSIRO
+# Copyright 2018-2020 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stellargraph/data/converter.py
+++ b/stellargraph/data/converter.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 from abc import ABC, abstractmethod
+import warnings
 import numpy as np
 from tensorflow.keras.utils import to_categorical
 from stellargraph.core.graph import StellarGraph
@@ -541,7 +542,7 @@ class OneHotCategoricalConverter(StellarAttributeConverter):
     def fit_transform(self, data):
         self.categories = sorted(set(data), key=str)
         if len(self.categories) == 1:
-            print("Warning: Only one category for attribute")
+            warnings.warn("Only one category for attribute", RuntimeWarning)
 
         return self.transform(data)
 

--- a/stellargraph/data/edge_splitter.py
+++ b/stellargraph/data/edge_splitter.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2017-2019 Data61, CSIRO
+# Copyright 2017-2020 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stellargraph/data/edge_splitter.py
+++ b/stellargraph/data/edge_splitter.py
@@ -122,6 +122,7 @@ class EdgeSplitter(object):
                         probs
                     ),
                     RuntimeWarning,
+                    stacklevel=2,
                 )
             negative_edges = self._sample_negative_examples_local_dfs(
                 p=p, probs=probs, limit_samples=len(positive_edges)
@@ -231,6 +232,7 @@ class EdgeSplitter(object):
                         probs
                     ),
                     RuntimeWarning,
+                    stacklevel=2,
                 )
             negative_edges = self._sample_negative_examples_by_edge_type_local_dfs(
                 p=p,

--- a/stellargraph/data/edge_splitter.py
+++ b/stellargraph/data/edge_splitter.py
@@ -17,6 +17,7 @@
 __all__ = ["EdgeSplitter"]
 
 import datetime
+import warnings
 import networkx as nx
 import pandas as pd
 import numpy as np
@@ -116,10 +117,11 @@ class EdgeSplitter(object):
         else:  # method == 'local'
             if probs is None:  # use default values if not given, by warn user
                 probs = [0.0, 0.25, 0.50, 0.25]
-                print(
-                    "WARNING: Using default sampling probabilities (distance from source node): {}".format(
+                warnings.warn(
+                    "Using default sampling probabilities (distance from source node): {}".format(
                         probs
-                    )
+                    ),
+                    RuntimeWarning,
                 )
             negative_edges = self._sample_negative_examples_local_dfs(
                 p=p, probs=probs, limit_samples=len(positive_edges)
@@ -224,10 +226,11 @@ class EdgeSplitter(object):
         else:  # method == 'local'
             if probs is None:
                 probs = [0.0, 0.25, 0.50, 0.25]
-                print(
-                    "WARNING: Using default sampling probabilities (distance from source node): {}".format(
+                warnings.warn(
+                    "Using default sampling probabilities (distance from source node): {}".format(
                         probs
-                    )
+                    ),
+                    RuntimeWarning,
                 )
             negative_edges = self._sample_negative_examples_by_edge_type_local_dfs(
                 p=p,
@@ -671,8 +674,8 @@ class EdgeSplitter(object):
         """
         if probs is None:
             probs = [0.0, 0.25, 0.50, 0.25]
-            print(
-                "Warning: Using default sampling probabilities up to 3 hops from source node with values {}".format(
+            warnings.warn(
+                "Using default sampling probabilities up to 3 hops from source node with values {}".format(
                     probs
                 )
             )
@@ -805,10 +808,11 @@ class EdgeSplitter(object):
         """
         if probs is None:
             probs = [0.0, 0.25, 0.50, 0.25]
-            print(
-                "Warning: Using default sampling probabilities up to 3 hops from source node with values {}".format(
+            warnings.warn(
+                "Using default sampling probabilities up to 3 hops from source node with values {}".format(
                     probs
-                )
+                ),
+                RuntimeWarning,
             )
 
         if not isclose(sum(probs), 1.0):

--- a/stellargraph/data/explorer.py
+++ b/stellargraph/data/explorer.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2017-2019 Data61, CSIRO
+# Copyright 2017-2020 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stellargraph/data/explorer.py
+++ b/stellargraph/data/explorer.py
@@ -26,6 +26,7 @@ __all__ = [
 
 import numpy as np
 import random
+import warnings
 from collections import defaultdict, deque
 
 from ..core.schema import GraphSchema
@@ -141,10 +142,10 @@ class GraphWalk(object):
         if (
             len(nodes) == 0
         ):  # this is not an error but maybe a warning should be printed to inform the caller
-            print(
-                "({}) WARNING: No root node IDs given. An empty list will be returned as a result.".format(
-                    type(self).__name__
-                )
+            warnings.warn(
+                "No root node IDs given. An empty list will be returned as a result.",
+                RuntimeWarning,
+                stacklevel=3,
             )
 
     def _check_repetitions(self, n):

--- a/stellargraph/data/loader.py
+++ b/stellargraph/data/loader.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2018 Data61, CSIRO
+# Copyright 2018-2020 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stellargraph/data/loader.py
+++ b/stellargraph/data/loader.py
@@ -16,6 +16,7 @@
 
 
 import os
+import warnings
 import pandas as pd
 
 import networkx as nx
@@ -43,10 +44,11 @@ def from_epgm(epgm_location, dataset_name=None, directed=False):
     # if dataset_name is not given, use the name of the 1st graph head
     if not dataset_name:
         dataset_name = graphs[0]["meta"]["label"]
-        print(
-            "WARNING: dataset name not specified, using dataset '{}' in the 1st graph head".format(
+        warnings.warn(
+            "dataset name not specified, using dataset '{}' in the 1st graph head".format(
                 dataset_name
-            )
+            ),
+            RuntimeWarning,
         )
 
     # Select graph using dataset_name

--- a/stellargraph/mapper/sampled_link_generators.py
+++ b/stellargraph/mapper/sampled_link_generators.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2018-2019 Data61, CSIRO
+# Copyright 2018-2020 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stellargraph/mapper/sampled_link_generators.py
+++ b/stellargraph/mapper/sampled_link_generators.py
@@ -28,6 +28,7 @@ import itertools as it
 import operator
 import collections
 import abc
+import warnings
 from functools import reduce
 from tensorflow import keras
 from ..core.graph import StellarGraph
@@ -206,8 +207,9 @@ class GraphSAGELinkGenerator(BatchedLinkGenerator):
 
         # Check that there is only a single node type for GraphSAGE
         if len(self.schema.node_types) > 1:
-            print(
-                "Warning: running homogeneous GraphSAGE on a graph with multiple node types"
+            warnings.warn(
+                "running homogeneous GraphSAGE on a graph with multiple node types",
+                RuntimeWarning,
             )
 
         self.head_node_types = self.schema.node_types * 2

--- a/stellargraph/mapper/sampled_node_generators.py
+++ b/stellargraph/mapper/sampled_node_generators.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2018-2019 Data61, CSIRO
+# Copyright 2018-2020 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stellargraph/mapper/sampled_node_generators.py
+++ b/stellargraph/mapper/sampled_node_generators.py
@@ -29,6 +29,7 @@ import warnings
 import operator
 import random
 import abc
+import warnings
 import numpy as np
 import itertools as it
 import networkx as nx
@@ -202,8 +203,9 @@ class GraphSAGENodeGenerator(BatchedNodeGenerator):
 
         # Check that there is only a single node type for GraphSAGE
         if len(self.head_node_types) > 1:
-            print(
-                "Warning: running homogeneous GraphSAGE on a graph with multiple node types"
+            warnings.warn(
+                "running homogeneous GraphSAGE on a graph with multiple node types",
+                RuntimeWarning,
             )
 
         # Create sampler for GraphSAGE
@@ -298,8 +300,9 @@ class DirectedGraphSAGENodeGenerator(BatchedNodeGenerator):
 
         # Check that there is only a single node type for GraphSAGE
         if len(self.head_node_types) > 1:
-            print(
-                "Warning: running homogeneous GraphSAGE on a graph with multiple node types"
+            warnings.warn(
+                "running homogeneous GraphSAGE on a graph with multiple node types",
+                RuntimeWarning,
             )
 
         # Create sampler for GraphSAGE


### PR DESCRIPTION
This ensures:

- warnings can be controlled, e.g. https://docs.python.org/3/library/warnings.html#overriding-the-default-filter , `warnings.simplefilter("ignore")` to silence them all, `warnings.simplefilter("error")` to turn them into hard errors (it's easier to fix them with full stack traces)
- warnings get printed to `stderr` and so do not contaminate `stdout`
- there's more context for what an warning is caused by, due to printing line numbers

See: #584 