### PR TITLE
Set pytest junit_family to xunit2 to avoid deprecation warning

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+junit_family = xunit2


### PR DESCRIPTION
This jumps us ahead to the newer JUnit format used by pytest, see https://docs.pytest.org/en/latest/deprecations.html#junit-family-default-value-change-to-xunit2 .

See: #586 