### PR TITLE
Add labels automatically when using issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,7 @@
 ---
 name: Bug report
 about: Create a report to help us improve
+labels: bug, sg-library
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/new_feature.md
+++ b/.github/ISSUE_TEMPLATE/new_feature.md
@@ -1,6 +1,7 @@
 ---
 name: New feature
 about: A new feature to be implemented
+labels: enhancement, sg-library
 
 ---
 
@@ -27,4 +28,3 @@ about: A new feature to be implemented
 - [ ] Version number reflects new status
 - [ ] CHANGELOG.md updated
 - [ ] Team demo
-


### PR DESCRIPTION
This extends the YAML front matter for the existing templates to automatically add `bug`, `enhancement` or `sg-library` labels, as appropriate. This will help with high-level triage and the zenhub view.