### PR TITLE
Check yamllint and prettier YAML formatting on CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -65,7 +65,7 @@ steps:
       docker#v3.4.0:
         image: "stellargraph/hadolint:snapshot"
 
-  - label: ":prettier::yaml::json::markdown: format YAML"
+  - label: ":prettier::yaml: format YAML"
     plugins:
       docker#v3.4.0:
         image: "stellargraph/prettier:${BIGDATA_DOCKER_TAG-snapshot}"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -68,7 +68,7 @@ steps:
   - label: ":prettier::yaml: format YAML"
     plugins:
       docker#v3.4.0:
-        image: "stellargraph/prettier:${BIGDATA_DOCKER_TAG-snapshot}"
+        image: "stellargraph/prettier:snapshot"
         command: [
             "--check",
             "**/*.yml",
@@ -80,7 +80,7 @@ steps:
   - label: ":yaml::lint-roller: lint YAML"
     plugins:
       docker#v3.4.0:
-        image: "stellargraph/yamllint:${BIGDATA_DOCKER_TAG-snapshot}"
+        image: "stellargraph/yamllint:snapshot"
 
   - label: ":copyright: check copyright headers"
     command: ".buildkite/steps/check-copyright-headers.sh"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,3 +1,4 @@
+---
 steps:
   - label: ":python: 3.6"
     key: "python_3_6"
@@ -17,7 +18,7 @@ steps:
           - BUILDKITE_PULL_REQUEST
           - BUILDKITE_JOB_ID
     agents:
-      queue: 't2medium'
+      queue: "t2medium"
 
   - label: ":python: 3.7"
     key: "python_3_7"
@@ -37,7 +38,7 @@ steps:
           - BUILDKITE_PULL_REQUEST
           - BUILDKITE_JOB_ID
     agents:
-      queue: 't2medium'
+      queue: "t2medium"
 
   - label: ":python-black: format"
     plugins:
@@ -64,8 +65,25 @@ steps:
       docker#v3.4.0:
         image: "stellargraph/hadolint:snapshot"
 
+  - label: ":prettier::yaml::json::markdown: format YAML"
+    plugins:
+      docker#v3.4.0:
+        image: "stellargraph/prettier:${BIGDATA_DOCKER_TAG-snapshot}"
+        command: [
+            "--check",
+            "**/*.yml",
+            "**/*.yaml",
+            # not valid YAML because of jinja templating
+            "!meta.yaml",
+          ]
+
+  - label: ":yaml::lint-roller: lint YAML"
+    plugins:
+      docker#v3.4.0:
+        image: "stellargraph/yamllint:${BIGDATA_DOCKER_TAG-snapshot}"
+
   - label: ":copyright: check copyright headers"
-    command: '.buildkite/steps/check-copyright-headers.sh'
+    command: ".buildkite/steps/check-copyright-headers.sh"
 
   - label: ":docker: build image"
     plugins:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,10 +1,10 @@
 # .readthedocs.yml
-
+---
 version: 2
 
 python:
   version: 3.6
   install:
-     - requirements: requirements.txt
-     - method: pip
-       path: .
+    - requirements: requirements.txt
+    - method: pip
+      path: .

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,3 +1,6 @@
+# yamllint disable-file
+# This file is not valid YAML because of the jinja templating
+
 {% set name = "stellargraph" %}
 {% set version = "0.8.1" %}
 
@@ -13,7 +16,7 @@ build:
   noarch: python
   number: 0
   script: "{{ PYTHON }} -m pip install . -vv"
-  skip: True  # [py<36]
+  skip: True # [py<36]
 
 requirements:
   host:


### PR DESCRIPTION
Yamllint will catch minor issues like `foo: yes` becoming `foo: true` (not `foo: "yes"`) implicitly, and using `prettier` to check the formatting will ensure our diffs are more focused, because there won't be any extraneous indentation or syntax changes.