### PR TITLE
Disable code complexity checks on Code Climate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -8,6 +8,9 @@ checks:
   file-lines:
     enabled: false
 
+  method-complexity:
+    enabled: false
+
   method-count:
     enabled: false
 
@@ -19,7 +22,7 @@ plugins:
     enabled: true
 
   radon:
-    enabled: true
+    enabled: false
 
   sonar-python:
     enabled: true

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,22 @@
+---
+version: "2"
+
+checks:
+  argument-count:
+    enabled: false
+
+  file-lines:
+    enabled: false
+
+  similar-code:
+    enabled: false
+
+plugins:
+  bandit:
+    enabled: true
+
+  radon:
+    enabled: true
+
+  sonar-python:
+    enabled: true

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -8,6 +8,9 @@ checks:
   file-lines:
     enabled: false
 
+  method-count:
+    enabled: false
+
   similar-code:
     enabled: false
 

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -23,3 +23,19 @@ plugins:
 
   sonar-python:
     enabled: true
+
+exclude_patterns:
+  # default exclude patterns:
+  - "config/"
+  - "db/"
+  - "dist/"
+  - "features/"
+  - "**/node_modules/"
+  - "script/"
+  - "**/spec/"
+  - "**/test/"
+  - "**/tests/"
+  - "Tests/"
+  - "**/vendor/"
+  - "**/*_test.go"
+  - "**/*.d.ts"


### PR DESCRIPTION
These are very noisy with our current state of the repository and code complexity metrics seem to be low value, in many cases: https://en.wikipedia.org/wiki/Cyclomatic_complexity#Correlation_to_number_of_defects

If we improve/fix other higher-value warnings, we can potentially re-enable this in future and see what it would take to address.