### PR TITLE
Convert Code Climate configuration to YAML

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,22 @@
+---
+version: "2"
+
+checks:
+  argument-count:
+    enabled: false
+
+  file-lines:
+    enabled: false
+
+  similar-code:
+    enabled: false
+
+plugins:
+  bandit:
+    enabled: true
+
+  radon:
+    enabled: true
+
+  sonar-python:
+    enabled: true

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -8,6 +8,9 @@ checks:
   file-lines:
     enabled: false
 
+  method-count:
+    enabled: false
+
   similar-code:
     enabled: false
 

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -23,3 +23,19 @@ plugins:
 
   sonar-python:
     enabled: true
+
+exclude_patterns:
+  # default exclude patterns:
+  - "config/"
+  - "db/"
+  - "dist/"
+  - "features/"
+  - "**/node_modules/"
+  - "script/"
+  - "**/spec/"
+  - "**/test/"
+  - "**/tests/"
+  - "Tests/"
+  - "**/vendor/"
+  - "**/*_test.go"
+  - "**/*.d.ts"


### PR DESCRIPTION
This converts our current Code Climate configuration to YAML without making any changes. This was done by checking the GUI settings: https://analysttools.slack.com/archives/C9YQZ8YVC/p1578265787024400

By versioning this with the code, we have all the benefits of git (tracking changes, easy to revert, ...) as well as making easier to be tweaked as required, rather than having to find someone with access to the web interface.