### PR TITLE
Promote various node feature and type related methods to be on StellarGraph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ In particular, calls like `list(G)` will no longer return a list of nodes; use `
 - Passing a `NodeSequence` or `LinkSequence` object to `GraphSAGE` and `HinSAGE` classes is now deprecated and no longer supported [\#498](https://github.com/stellargraph/stellargraph/pull/498).
 Users might need to update their calls of `GraphSAGE` and `HinSAGE` classes by passing `generator` objects instead of `generator.flow()` objects.
 
+- Various methods on `StellarGraph` have been renamed to be more succinct and uniform:
+   - `get_feature_for_nodes` is now `node_features`
+   - `type_for_node` is now `node_type`
+
 **Fixed bugs:**
 
 

--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -242,7 +242,7 @@ class StellarGraph(metaclass=StellarGraphFactory):
         Get the nodes of the graph with the specified node types.
 
         Args:
-            node_type: a type of nodes that exist in the graph
+            node_type (hashable, optional): a type of nodes that exist in the graph
 
         Returns:
             A list of node IDs with type node_type
@@ -276,7 +276,7 @@ class StellarGraph(metaclass=StellarGraphFactory):
         Get the feature sizes for the specified node types.
 
         Args:
-            node_types: (list) A list of node types. If None all current node types
+            node_types (list, optional): A list of node types. If None all current node types
                 will be used.
 
         Returns:
@@ -292,8 +292,8 @@ class StellarGraph(metaclass=StellarGraphFactory):
         for this method to be fast.
 
         Args:
-            n: (list or hashable) Node ID or list of node IDs
-            node_type: (hashable) the type of the nodes.
+            nodes (list or hashable): Node ID or list of node IDs
+            node_type (hashable): the type of the nodes.
 
         Returns:
             Numpy array containing the node features for the requested nodes.

--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -250,7 +250,7 @@ class StellarGraph(metaclass=StellarGraphFactory):
         """
         raise NotImplementedError
 
-    def node_features(self, nodes, node_type = None):
+    def node_features(self, nodes, node_type=None):
         """
         Get the numeric feature vectors for the specified node or nodes.
         If the node type is not specified the node types will be found

--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -237,6 +237,40 @@ class StellarGraph(metaclass=StellarGraphFactory):
         """
         raise NotImplementedError
 
+    def nodes_of_type(self, node_type=None):
+        """
+        Get the nodes of the graph with the specified node types.
+
+        Args:
+            node_type: a type of nodes that exist in the graph
+
+        Returns:
+            A list of node IDs with type node_type
+        """
+        raise NotImplementedError
+
+    def node_type(self, node):
+        """
+        Get the type of the node
+
+        Args:
+            node: Node ID
+
+        Returns:
+            Node type
+        """
+        raise NotImplementedError
+
+    @property
+    def node_types(self):
+        """
+        Get a list of all node types in the graph.
+
+        Returns:
+            set of types
+        """
+        raise NotImplementedError
+
     def node_feature_sizes(self, node_types=None):
         """
         Get the feature sizes for the specified node types.

--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2017-2019 Data61, CSIRO
+# Copyright 2017-2020 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -237,6 +237,35 @@ class StellarGraph(metaclass=StellarGraphFactory):
         """
         raise NotImplementedError
 
+    def node_feature_sizes(self, node_types=None):
+        """
+        Get the feature sizes for the specified node types.
+
+        Args:
+            node_types: (list) A list of node types. If None all current node types
+                will be used.
+
+        Returns:
+            A dictionary of node type and integer feature size.
+        """
+        raise NotImplementedError
+
+    def node_features(self, nodes, node_type = None):
+        """
+        Get the numeric feature vectors for the specified node or nodes.
+        If the node type is not specified the node types will be found
+        for all nodes. It is therefore important to supply the ``node_type``
+        for this method to be fast.
+
+        Args:
+            n: (list or hashable) Node ID or list of node IDs
+            node_type: (hashable) the type of the nodes.
+
+        Returns:
+            Numpy array containing the node features for the requested nodes.
+        """
+        raise NotImplementedError
+
     ##################################################################
     # Computationally intensive methods:
 

--- a/stellargraph/core/graph_networkx.py
+++ b/stellargraph/core/graph_networkx.py
@@ -401,7 +401,7 @@ class NetworkXStellarGraph(StellarGraph):
         node_indices = [nt_id_to_index.get(n) for n in nodes]
         return node_indices
 
-    def get_feature_for_nodes(self, nodes, node_type=None):
+    def node_features(self, nodes, node_type=None):
         """
         Get the numeric feature vectors for the specified node or nodes.
         If the node type is not specified the node types will be found
@@ -415,7 +415,7 @@ class NetworkXStellarGraph(StellarGraph):
         Returns:
             Numpy array containing the node features for the requested nodes.
         """
-        # TODO: change method's name to node_features(), and add @property decorator
+        # TODO: add @property decorator
         if not is_real_iterable(nodes):
             nodes = [nodes]
 
@@ -504,7 +504,7 @@ class NetworkXStellarGraph(StellarGraph):
                 if self._get_node_type(ndata) == node_type
             ]
 
-    def type_for_node(self, node):
+    def node_type(self, node):
         """
         Get the type of the node
 

--- a/stellargraph/data/explorer.py
+++ b/stellargraph/data/explorer.py
@@ -432,7 +432,7 @@ class UniformRandomMetaPathWalk(GraphWalk):
 
         for node in nodes:
             # retrieve node type
-            label = self.graph.type_for_node(node)
+            label = self.graph.node_type(node)
             filtered_metapaths = [
                 metapath
                 for metapath in metapaths
@@ -460,7 +460,7 @@ class UniformRandomMetaPathWalk(GraphWalk):
                         neighbours = [
                             n_node
                             for n_node in neighbours
-                            if self.graph.type_for_node(n_node) == metapath[d]
+                            if self.graph.node_type(n_node) == metapath[d]
                         ]
                         if len(neighbours) == 0:
                             # if no neighbours of the required type as dictated by the metapath exist, then stop.

--- a/stellargraph/data/explorer.py
+++ b/stellargraph/data/explorer.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2017-2019 Data61, CSIRO
+# Copyright 2017-2020 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stellargraph/mapper/full_batch_generators.py
+++ b/stellargraph/mapper/full_batch_generators.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2018-2019 Data61, CSIRO
+# Copyright 2018-2020 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stellargraph/mapper/full_batch_generators.py
+++ b/stellargraph/mapper/full_batch_generators.py
@@ -160,7 +160,7 @@ class FullBatchNodeGenerator:
             )
 
         # Get the features for the nodes
-        self.features = G.get_feature_for_nodes(self.node_list)
+        self.features = G.node_features(self.node_list)
 
         if transform is not None:
             if callable(transform):
@@ -297,7 +297,7 @@ class RelationalFullBatchNodeGenerator:
         # extract node, feature, and edge type info from G
         self.node_list = list(G.nodes())
 
-        self.features = G.get_feature_for_nodes(self.node_list)
+        self.features = G.node_features(self.node_list)
 
         edge_types = sorted(set(e[-1] for e in G.edges(triple=True)))
         self.node_index = dict(zip(self.node_list, range(len(self.node_list))))
@@ -342,7 +342,7 @@ class RelationalFullBatchNodeGenerator:
             self.As.append(A)
 
         # Get the features for the nodes
-        self.features = G.get_feature_for_nodes(self.node_list)
+        self.features = G.node_features(self.node_list)
 
     def flow(self, node_ids, targets=None):
         """

--- a/stellargraph/mapper/mini_batch_node_generators.py
+++ b/stellargraph/mapper/mini_batch_node_generators.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2018-2019 Data61, CSIRO
+# Copyright 2018-2020 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stellargraph/mapper/mini_batch_node_generators.py
+++ b/stellargraph/mapper/mini_batch_node_generators.py
@@ -148,7 +148,7 @@ class ClusterNodeGenerator:
             print(f"{i} cluster has size {len(c)}")
 
         # Get the features for the nodes
-        self.features = G.get_feature_for_nodes(self.node_list)
+        self.features = G.node_features(self.node_list)
 
     def flow(self, node_ids, targets=None, name=None):
         """
@@ -332,7 +332,7 @@ class ClusterNodeSequence(Sequence):
             cluster_targets = self.targets[cluster_target_indices]
             cluster_targets = cluster_targets.reshape((1,) + cluster_targets.shape)
 
-        features = self.graph.get_feature_for_nodes(g_node_list)
+        features = self.graph.node_features(g_node_list)
 
         features = np.reshape(features, (1,) + features.shape)
         adj_cluster = adj_cluster.reshape((1,) + adj_cluster.shape)

--- a/stellargraph/mapper/sampled_link_generators.py
+++ b/stellargraph/mapper/sampled_link_generators.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2018-2019 Data61, CSIRO
+# Copyright 2018-2020 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stellargraph/mapper/sampled_link_generators.py
+++ b/stellargraph/mapper/sampled_link_generators.py
@@ -259,7 +259,7 @@ class GraphSAGELinkGenerator(BatchedLinkGenerator):
             # Get features for the sampled nodes
             batch_feats.append(
                 [
-                    self.graph.get_feature_for_nodes(layer_nodes, node_type)
+                    self.graph.node_features(layer_nodes, node_type)
                     for layer_nodes in nodes_per_hop
                 ]
             )
@@ -357,7 +357,7 @@ class HinSAGELinkGenerator(BatchedLinkGenerator):
         # Resize features to (batch_size, n_neighbours, feature_size)
         # for each node type (note that we can have different feature size for each node type)
         batch_feats = [
-            self.graph.get_feature_for_nodes(layer_nodes, nt)
+            self.graph.node_features(layer_nodes, nt)
             for nt, layer_nodes in node_samples
         ]
 
@@ -465,7 +465,7 @@ class Attri2VecLinkGenerator(BatchedLinkGenerator):
 
         target_ids = [head_link[0] for head_link in head_links]
         context_ids = [head_link[1] for head_link in head_links]
-        target_feats = self.graph.get_feature_for_nodes(target_ids)
+        target_feats = self.graph.node_features(target_ids)
         context_feats = self.graph.get_index_for_nodes(context_ids)
         batch_feats = [target_feats, np.array(context_feats)]
 

--- a/stellargraph/mapper/sampled_link_generators.py
+++ b/stellargraph/mapper/sampled_link_generators.py
@@ -121,8 +121,8 @@ class BatchedLinkGenerator(abc.ABC):
 
                 src, dst = link
                 try:
-                    node_type_src = self.graph.type_for_node(src)
-                    node_type_dst = self.graph.type_for_node(dst)
+                    node_type_src = self.graph.node_type(src)
+                    node_type_dst = self.graph.node_type(dst)
                 except KeyError:
                     raise KeyError(
                         f"Node ID {n} supplied to generator not found in graph"

--- a/stellargraph/mapper/sampled_node_generators.py
+++ b/stellargraph/mapper/sampled_node_generators.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2018-2019 Data61, CSIRO
+# Copyright 2018-2020 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stellargraph/mapper/sampled_node_generators.py
+++ b/stellargraph/mapper/sampled_node_generators.py
@@ -133,7 +133,7 @@ class BatchedNodeGenerator(abc.ABC):
         # Check all IDs are actually in the graph and are of expected type
         for n in node_ids:
             try:
-                node_type = self.graph.type_for_node(n)
+                node_type = self.graph.node_type(n)
             except KeyError:
                 raise KeyError(f"Node ID {n} supplied to generator not found in graph")
 

--- a/stellargraph/mapper/sampled_node_generators.py
+++ b/stellargraph/mapper/sampled_node_generators.py
@@ -245,7 +245,7 @@ class GraphSAGENodeGenerator(BatchedNodeGenerator):
 
         # Get features for sampled nodes
         batch_feats = [
-            self.graph.get_feature_for_nodes(layer_nodes, node_type)
+            self.graph.node_features(layer_nodes, node_type)
             for layer_nodes in nodes_per_hop
         ]
 
@@ -340,7 +340,7 @@ class DirectedGraphSAGENodeGenerator(BatchedNodeGenerator):
 
         for slot in range(max_slots):
             nodes_in_slot = list(it.chain(*[sample[slot] for sample in node_samples]))
-            features_for_slot = self.graph.get_feature_for_nodes(
+            features_for_slot = self.graph.node_features(
                 nodes_in_slot, node_type
             )
             resize = -1 if np.size(features_for_slot) > 0 else 0
@@ -452,7 +452,7 @@ class HinSAGENodeGenerator(BatchedNodeGenerator):
 
         # Get features
         batch_feats = [
-            self.graph.get_feature_for_nodes(layer_nodes, nt)
+            self.graph.node_features(layer_nodes, nt)
             for nt, layer_nodes in nodes_by_type
         ]
 
@@ -507,7 +507,7 @@ class Attri2VecNodeGenerator(BatchedNodeGenerator):
             head node.
         """
 
-        batch_feats = self.graph.get_feature_for_nodes(head_nodes)
+        batch_feats = self.graph.node_features(head_nodes)
         return batch_feats
 
     def flow(self, node_ids):

--- a/stellargraph/mapper/sampled_node_generators.py
+++ b/stellargraph/mapper/sampled_node_generators.py
@@ -340,9 +340,7 @@ class DirectedGraphSAGENodeGenerator(BatchedNodeGenerator):
 
         for slot in range(max_slots):
             nodes_in_slot = list(it.chain(*[sample[slot] for sample in node_samples]))
-            features_for_slot = self.graph.node_features(
-                nodes_in_slot, node_type
-            )
+            features_for_slot = self.graph.node_features(nodes_in_slot, node_type)
             resize = -1 if np.size(features_for_slot) > 0 else 0
             features[slot] = np.reshape(
                 features_for_slot, (len(head_nodes), resize, features_for_slot.shape[1])

--- a/tests/core/test_stellargraph.py
+++ b/tests/core/test_stellargraph.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2017-2019 Data61, CSIRO
+# Copyright 2017-2020 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/core/test_stellargraph.py
+++ b/tests/core/test_stellargraph.py
@@ -248,7 +248,7 @@ def test_get_index_for_nodes():
 
 def test_feature_conversion_from_nodes():
     sg = example_stellar_graph_1(feature_name="feature", feature_size=8)
-    aa = sg.get_feature_for_nodes([1, 2, 3, 4])
+    aa = sg.node_features([1, 2, 3, 4])
     assert aa[:, 0] == pytest.approx([1, 2, 3, 4])
 
     assert aa.shape == (4, 8)
@@ -259,7 +259,7 @@ def test_feature_conversion_from_nodes():
         for_nodes=[0, 1, 2, 3, 4, 5],
         feature_sizes={"A": 4, "B": 2},
     )
-    aa = sg.get_feature_for_nodes([0, 1, 2, 3], "A")
+    aa = sg.node_features([0, 1, 2, 3], "A")
     assert aa[:, 0] == pytest.approx([0, 1, 2, 3])
     assert aa.shape == (4, 4)
 
@@ -267,49 +267,49 @@ def test_feature_conversion_from_nodes():
     assert fs["A"] == 4
     assert fs["B"] == 2
 
-    ab = sg.get_feature_for_nodes([4, 5], "B")
+    ab = sg.node_features([4, 5], "B")
     assert ab.shape == (2, 2)
     assert ab[:, 0] == pytest.approx([4, 5])
 
     # Test mixed types
     with pytest.raises(ValueError):
-        ab = sg.get_feature_for_nodes([1, 5])
+        ab = sg.node_features([1, 5])
 
     # Test incorrect manual node_type
     with pytest.raises(ValueError):
-        ab = sg.get_feature_for_nodes([4, 5], "A")
+        ab = sg.node_features([4, 5], "A")
 
     # Test feature for node with no set attributes
-    ab = sg.get_feature_for_nodes([4, 5, 6], "B")
+    ab = sg.node_features([4, 5, 6], "B")
     assert ab.shape == (3, 2)
     assert ab[:, 0] == pytest.approx([4, 5, 0])
 
 
 def test_null_node_feature():
     sg = example_stellar_graph_1(feature_name="feature", feature_size=6)
-    aa = sg.get_feature_for_nodes([1, None, 2, None])
+    aa = sg.node_features([1, None, 2, None])
     assert aa.shape == (4, 6)
     assert aa[:, 0] == pytest.approx([1, 0, 2, 0])
 
     sg = example_hin_1(feature_name="feature", feature_sizes={"A": 4, "B": 2})
 
     # Test feature for null node, without node type
-    ab = sg.get_feature_for_nodes([None, 5, None])
+    ab = sg.node_features([None, 5, None])
     assert ab.shape == (3, 2)
     assert ab[:, 0] == pytest.approx([0, 5, 0])
 
     # Test feature for null node, node type
-    ab = sg.get_feature_for_nodes([None, 6, None], "B")
+    ab = sg.node_features([None, 6, None], "B")
     assert ab.shape == (3, 2)
     assert ab[:, 0] == pytest.approx([0, 6, 0])
 
     # Test feature for null node, wrong type
     with pytest.raises(ValueError):
-        sg.get_feature_for_nodes([None, 5, None], "A")
+        sg.node_features([None, 5, None], "A")
 
     # Test null-node with no type
     with pytest.raises(ValueError):
-        sg.get_feature_for_nodes([None, None])
+        sg.node_features([None, None])
 
 
 def test_node_types():
@@ -330,11 +330,11 @@ def test_feature_conversion_from_dataframe():
     df = pd.DataFrame({v: np.ones(10) * float(v) for v in list(g)}).T
     gs = StellarGraph(g, node_features=df)
 
-    aa = gs.get_feature_for_nodes([1, 2, 3, 4])
+    aa = gs.node_features([1, 2, 3, 4])
     assert aa[:, 0] == pytest.approx([1, 2, 3, 4])
 
     # Check None identifier
-    aa = gs.get_feature_for_nodes([1, 2, None, None])
+    aa = gs.node_features([1, 2, None, None])
     assert aa[:, 0] == pytest.approx([1, 2, 0, 0])
 
     g = example_hin_1_nx()
@@ -351,24 +351,24 @@ def test_feature_conversion_from_dataframe():
     }
     gs = StellarGraph(g, node_features=df)
 
-    aa = gs.get_feature_for_nodes([0, 1, 2, 3], "A")
+    aa = gs.node_features([0, 1, 2, 3], "A")
     assert aa[:, 0] == pytest.approx([0, 1, 2, 3])
     assert aa.shape == (4, 10)
 
-    ab = gs.get_feature_for_nodes([4, 5], "B")
+    ab = gs.node_features([4, 5], "B")
     assert ab.shape == (2, 10)
     assert ab[:, 0] == pytest.approx([4, 5])
 
     # Test mixed types
     with pytest.raises(ValueError):
-        ab = gs.get_feature_for_nodes([1, 5])
+        ab = gs.node_features([1, 5])
 
     # Test incorrect manual node_type
     with pytest.raises(ValueError):
-        ab = gs.get_feature_for_nodes([4, 5], "A")
+        ab = gs.node_features([4, 5], "A")
 
     # Test feature for node with no set attributes
-    ab = gs.get_feature_for_nodes([4, None, None], "B")
+    ab = gs.node_features([4, None, None], "B")
     assert ab.shape == (3, 10)
     assert ab[:, 0] == pytest.approx([4, 0, 0])
 
@@ -380,11 +380,11 @@ def test_feature_conversion_from_iterator():
     node_features = [(v, np.ones(10) * float(v)) for v in list(g)]
     gs = StellarGraph(g, node_features=node_features)
 
-    aa = gs.get_feature_for_nodes([1, 2, 3, 4])
+    aa = gs.node_features([1, 2, 3, 4])
     assert aa[:, 0] == pytest.approx([1, 2, 3, 4])
 
     # Check None identifier
-    aa = gs.get_feature_for_nodes([1, 2, None, None])
+    aa = gs.node_features([1, 2, None, None])
     assert aa[:, 0] == pytest.approx([1, 2, 0, 0])
 
     g = example_hin_1_nx()
@@ -398,24 +398,24 @@ def test_feature_conversion_from_iterator():
     }
     gs = StellarGraph(g, node_features=nf)
 
-    aa = gs.get_feature_for_nodes([0, 1, 2, 3], "A")
+    aa = gs.node_features([0, 1, 2, 3], "A")
     assert aa[:, 0] == pytest.approx([0, 1, 2, 3])
     assert aa.shape == (4, 10)
 
-    ab = gs.get_feature_for_nodes([4, 5], "B")
+    ab = gs.node_features([4, 5], "B")
     assert ab.shape == (2, 10)
     assert ab[:, 0] == pytest.approx([4, 5])
 
     # Test mixed types
     with pytest.raises(ValueError):
-        ab = gs.get_feature_for_nodes([1, 5])
+        ab = gs.node_features([1, 5])
 
     # Test incorrect manual node_type
     with pytest.raises(ValueError):
-        ab = gs.get_feature_for_nodes([4, 5], "A")
+        ab = gs.node_features([4, 5], "A")
 
     # Test feature for node with no set attributes
-    ab = gs.get_feature_for_nodes([4, None, None], "B")
+    ab = gs.node_features([4, None, None], "B")
     assert ab.shape == (3, 10)
     assert ab[:, 0] == pytest.approx([4, 0, 0])
 
@@ -427,11 +427,11 @@ def test_feature_conversion_from_iterator():
     ]
     gs = StellarGraph(g, node_features=nf)
 
-    aa = gs.get_feature_for_nodes([0, 1, 2, 3], "A")
+    aa = gs.node_features([0, 1, 2, 3], "A")
     assert aa[:, 0] == pytest.approx([0, 1, 2, 3])
     assert aa.shape == (4, 5)
 
-    ab = gs.get_feature_for_nodes([4, 5], "B")
+    ab = gs.node_features([4, 5], "B")
     assert ab.shape == (2, 10)
     assert ab[:, 0] == pytest.approx([4, 5])
 
@@ -512,7 +512,7 @@ def test_benchmark_get_features(benchmark, num_types, type_arg):
         # does sampling might ask for
         ty, all_ids = random.choice(ty_ids)
         selected_ids = random.choices(all_ids, k=SAMPLE_SIZE)
-        sg.get_feature_for_nodes(selected_ids, node_type(ty))
+        sg.node_features(selected_ids, node_type(ty))
 
     benchmark(f)
 

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -103,7 +103,7 @@ def test_chebyshev_polynomial(example_graph):
 def test_GCN_Aadj_feats_op(example_graph):
     node_list = list(example_graph.nodes())
     Aadj = example_graph.to_adjacency_matrix()
-    features = example_graph.get_feature_for_nodes(node_list)
+    features = example_graph.node_features(node_list)
 
     features_, Aadj_ = GCN_Aadj_feats_op(features=features, A=Aadj, method="gcn")
     assert np.array_equal(features, features_)


### PR DESCRIPTION
These methods were previously only on the NetworkXStellarGraph subclass of `StellarGraph`, but were used in many places on values of type `StellarGraph`.

This also does the FIXME of renaming it to match the naming convention of other methods.