### PR TITLE
Promote info method to StellarGraph class

### DIFF
--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -249,6 +249,7 @@ class StellarGraph(metaclass=StellarGraphFactory):
         time for a large graph.
 
         Args:
+            show_attributes (bool, default True): If True, include attributes information
             sample (int): To speed up the graph analysis, use only a random sample of
                           this many nodes and edges.
 

--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2017-2019 Data61, CSIRO
+# Copyright 2017-2020 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -240,6 +240,23 @@ class StellarGraph(metaclass=StellarGraphFactory):
     ##################################################################
     # Computationally intensive methods:
 
+    def info(self, show_attributes=True, sample=None):
+        """
+        Return an information string summarizing information on the current graph.
+        This includes node and edge type information and their attributes.
+
+        Note: This requires processing all nodes and edges and could take a long
+        time for a large graph.
+
+        Args:
+            sample (int): To speed up the graph analysis, use only a random sample of
+                          this many nodes and edges.
+
+        Returns:
+            An information string.
+        """
+        raise NotImplementedError
+
     def node_degrees(self) -> Mapping[Any, int]:
         """
         Obtains a map from node to node degree.


### PR DESCRIPTION
This method is used in various places that manipulate a `StellarGraph` instance, and so should be part of the overall interface, not just the `NetworkXStellarGraph` subclass.