### PR TITLE
Add pip freeze on CI to ease debugging problems from version changes

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,7 +5,7 @@ steps:
     command: ".buildkite/steps/script.sh"
     plugins:
       docker#v3.2.0:
-        image: "python:3.6"
+        image: "python:3.6-slim"
         environment:
           - PYTHONDONTWRITEBYTECODE=1
           - GIT_BRANCH=$BUILDKITE_BRANCH
@@ -25,7 +25,7 @@ steps:
     command: ".buildkite/steps/script.sh"
     plugins:
       docker#v3.2.0:
-        image: "python:3.7"
+        image: "python:3.7-slim"
         environment:
           - PYTHONDONTWRITEBYTECODE=1
           - GIT_BRANCH=$BUILDKITE_BRANCH

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,7 +5,7 @@ steps:
     command: ".buildkite/steps/script.sh"
     plugins:
       docker#v3.2.0:
-        image: "python:3.6-slim"
+        image: "python:3.6"
         environment:
           - PYTHONDONTWRITEBYTECODE=1
           - GIT_BRANCH=$BUILDKITE_BRANCH
@@ -25,7 +25,7 @@ steps:
     command: ".buildkite/steps/script.sh"
     plugins:
       docker#v3.2.0:
-        image: "python:3.7-slim"
+        image: "python:3.7"
         environment:
           - PYTHONDONTWRITEBYTECODE=1
           - GIT_BRANCH=$BUILDKITE_BRANCH

--- a/.buildkite/steps/script.sh
+++ b/.buildkite/steps/script.sh
@@ -8,6 +8,9 @@ upload_tests() {
   buildkite-agent artifact upload "$junit_file" "s3://${AWS_LOGS_BUCKET}/pytest/${BUILDKITE_BRANCH}/${BUILDKITE_BUILD_NUMBER}"
 }
 
+echo "--- installing required packages"
+apt install -y git
+
 echo "--- installing dependencies"
 pip install -q --no-cache-dir -r requirements.txt -e .
 

--- a/.buildkite/steps/script.sh
+++ b/.buildkite/steps/script.sh
@@ -11,6 +11,9 @@ upload_tests() {
 echo "--- installing dependencies"
 pip install -q --no-cache-dir -r requirements.txt -e .
 
+echo "--- listing dependency versions"
+pip freeze
+
 echo "+++ running tests"
 exitCode=$?
 py.test -ra --cov=stellargraph tests/ --doctest-modules --doctest-modules --cov-report=term-missing -p no:cacheprovider --junitxml="./${junit_file}" || exitCode=$?

--- a/.buildkite/steps/script.sh
+++ b/.buildkite/steps/script.sh
@@ -9,6 +9,7 @@ upload_tests() {
 }
 
 echo "--- installing required packages"
+apt update
 apt install -y git
 
 echo "--- installing dependencies"

--- a/.buildkite/steps/script.sh
+++ b/.buildkite/steps/script.sh
@@ -8,15 +8,14 @@ upload_tests() {
   buildkite-agent artifact upload "$junit_file" "s3://${AWS_LOGS_BUCKET}/pytest/${BUILDKITE_BRANCH}/${BUILDKITE_BUILD_NUMBER}"
 }
 
-echo "--- installing required packages"
-apt update
-apt install -y git
-
 echo "--- installing dependencies"
-pip install -q --no-cache-dir -r requirements.txt -e .
+pip install -q --no-cache-dir -r requirements.txt
 
 echo "--- listing dependency versions"
 pip freeze
+
+echo "--- installing stellargraph"
+pip install -q --no-cache-dir -e .
 
 echo "+++ running tests"
 exitCode=$?

--- a/.buildkite/steps/script.sh
+++ b/.buildkite/steps/script.sh
@@ -9,13 +9,10 @@ upload_tests() {
 }
 
 echo "--- installing dependencies"
-pip install -q --no-cache-dir -r requirements.txt
+pip install -q --no-cache-dir -r requirements.txt .
 
 echo "--- listing dependency versions"
 pip freeze
-
-echo "--- installing stellargraph"
-pip install -q --no-cache-dir -e .
 
 echo "+++ running tests"
 exitCode=$?


### PR DESCRIPTION
This invocation shows the versions of each library installed with `pip`.

Doing this on CI makes it easy to find which version(s) of dependencies changed between passing and failing builds, helping to narrow down the possible cause of a failure. This thus ties into #611 and the daily scheduled build.