### PR TITLE
Make UniformRandomWalk ~2x faster

### DIFF
--- a/stellargraph/data/explorer.py
+++ b/stellargraph/data/explorer.py
@@ -219,7 +219,6 @@ class UniformRandomWalk(GraphWalk):
         return walk
 
 
-
 def naive_weighted_choices(rs, weights):
     """
     Select an index at random, weighted by the iterator `weights` of

--- a/stellargraph/data/explorer.py
+++ b/stellargraph/data/explorer.py
@@ -200,25 +200,24 @@ class UniformRandomWalk(GraphWalk):
         self._check_common_parameters(nodes, n, length, seed)
         rs = self._get_random_state(seed)
 
-        walks = []
-        for node in nodes:  # iterate over root nodes
-            for walk_number in range(n):  # generate n walks per root node
-                walk = list()
-                current_node = node
-                for _ in range(length):
-                    walk.extend([current_node])
-                    neighbours = self.neighbors(current_node)
-                    if (
-                        len(neighbours) == 0
-                    ):  # for whatever reason this node has no neighbours so stop
-                        break
-                    else:
-                        rs.shuffle(neighbours)  # shuffles the list in place
-                        current_node = neighbours[0]  # select the first node to follow
+        # for each root node, do n walks
+        return [self._walk(rs, node, length) for node in nodes for _ in range(n)]
 
-                walks.append(walk)
+    def _walk(self, rs, start_node, length):
+        walk = [start_node]
+        current_node = start_node
+        for _ in range(length - 1):
+            neighbours = self.neighbors(current_node)
+            if not neighbours:
+                # dead end, so stop
+                break
+            else:
+                # has neighbours, so pick one to walk to
+                current_node = rs.choice(neighbours)
+            walk.append(current_node)
 
-        return walks
+        return walk
+
 
 
 def naive_weighted_choices(rs, weights):


### PR DESCRIPTION
This adjusts `UniformRandomWalk` in a few ways:

- use `choice` to select a single element directly instead of `shuffle` + `[0]` (this is the majority of the speedup)
- do `length - 1` samples by starting with a walk of length 1 (instead of `length` samples and ignoring the last one) (this is a slight speed-up, most noticable for short walks, i.e. small `length`s where `length/(length - 1)` is largest)
- pull out a separate function, to be able to use a neater list comprehension for executing multiple walks

Benchmark results (times in microseconds):

| source  | min  | max | mean | stddev | median | iqr  | outliers | ops   | rounds | iterations |
|--------|-----:|----:|-----:|-------:|-------:|-----:|---------:|------:|-------:|-----------:|
| this PR | 49.3 | 436 | 56.5 |   11.6 |   55.6 | 5.36 |  410;452 | 17700 |   9156 |          1 |
| develop | 86.2 | 466 |  106 |   18.5 |    102 | 12.2 |  600;562 |  9440 |   6397 |          1 |
