### PR TITLE
Xfail (temporarily) hinsage test that fails with tensorflow 2.1

### DIFF
--- a/tests/layer/test_hinsage.py
+++ b/tests/layer/test_hinsage.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2018-2019 Data61, CSIRO
+# Copyright 2018-2020 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/layer/test_hinsage.py
+++ b/tests/layer/test_hinsage.py
@@ -567,6 +567,9 @@ def test_hinsage_unitary_layer_size():
         )
 
 
+@pytest.mark.xfail(
+    struct=True, reason="#626: tensorflow 2.1 changed the predicted values"
+)
 def test_hinsage_from_generator():
     G = example_hin_1({"A": 8, "B": 4})
 


### PR DESCRIPTION
This is a temporary work-around to unbreak CI until we can properly determine the cause and thus the fix.

It's marked as a `strict` xfail (that is, causes tests to fail, if it unexpectedly passes), so that we don't accidentally fix it without noticing, and are thus reminded to remove the `xfail` marker.

See: #626 