### PR TITLE
Install tensorflow-cpu package when building docs on Read the Docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,6 +5,5 @@ version: 2
 python:
   version: 3.6
   install:
-    - requirements: requirements.txt
     - method: pip
       path: .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 networkx>=2.2
 setuptools>=39.1.0
-tensorflow>=2.0.0
+tensorflow-cpu>=2.0.0
 numba>=0.39.0
 numpy>=1.14
 scipy>=1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 networkx>=2.2
 setuptools>=39.1.0
-tensorflow-cpu>=2.0.0
+tensorflow>=2.0.0
 numba>=0.39.0
 numpy>=1.14
 scipy>=1.1.0

--- a/setup.py
+++ b/setup.py
@@ -15,13 +15,16 @@
 # limitations under the License.
 
 import setuptools
+import sys
 
 DESCRIPTION = "Python library for machine learning on graphs"
 URL = "https://github.com/stellargraph/stellargraph"
 
 # Required packages
+# full tensorflow is too big for readthedocs's builder
+tensorflow = "tensorflow-cpu" if "READTHEDOCS" in sys.environ else "tensorflow"
 REQUIRES = [
-    "tensorflow-cpu>=2.0.0",
+    f"{tensorflow}>=2.0.0",
     "numpy>=1.14",
     "scipy>=1.1.0",
     "networkx>=2.2",

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2018-2019 Data61, CSIRO
+# Copyright 2018-2020 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ URL = "https://github.com/stellargraph/stellargraph"
 
 # Required packages
 REQUIRES = [
-    "tensorflow>=2.0.0",
+    "tensorflow-cpu>=2.0.0",
     "numpy>=1.14",
     "scipy>=1.1.0",
     "networkx>=2.2",

--- a/setup.py
+++ b/setup.py
@@ -15,14 +15,14 @@
 # limitations under the License.
 
 import setuptools
-import sys
+import os
 
 DESCRIPTION = "Python library for machine learning on graphs"
 URL = "https://github.com/stellargraph/stellargraph"
 
 # Required packages
 # full tensorflow is too big for readthedocs's builder
-tensorflow = "tensorflow-cpu" if "READTHEDOCS" in sys.environ else "tensorflow"
+tensorflow = "tensorflow-cpu" if "READTHEDOCS" in os.environ else "tensorflow"
 REQUIRES = [
     f"{tensorflow}>=2.0.0",
     "numpy>=1.14",


### PR DESCRIPTION
With tensorflow 2.1, the `tensorflow` package includes GPU support by default. This seems to be enough to exceed readthedocs's memory limits and cause the build to fail. `tensorflow-cpu` 2.1 does not hit this problem, and so we can fall back to that when building documentation.

We probably want to make this more generally configurable (#546), but that's a more intricate problem, and this gets us back to having working documentation.

This also switches to only using the dependencies in `setup.py`, as building documentation doesn't need any of the dev dependencies listed in `requirements.txt`.

See: #602 