### PR TITLE
Include `StellarGraph` in the documentation of the core module

### DIFF
--- a/docs/api.txt
+++ b/docs/api.txt
@@ -5,7 +5,7 @@ Core
 ----------------
 
 .. automodule:: stellargraph.core
-  :members: StellarGraphBase, GraphSchema
+  :members: StellarGraph, GraphSchema
 
 
 Data

--- a/stellargraph/layer/rgcn.py
+++ b/stellargraph/layer/rgcn.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2019 Data61, CSIRO
+# Copyright 2019-2020 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stellargraph/layer/rgcn.py
+++ b/stellargraph/layer/rgcn.py
@@ -372,7 +372,7 @@ class RGCN:
         in the same way as the adjacency matrix.
 
     Examples:
-        Creating a RGCN node classification model from an existing :class:`StellarGraphBase`
+        Creating a RGCN node classification model from an existing :class:`StellarGraph`
         object ``G``::
 
             generator = RelationalFullBatchNodeGenerator(G)

--- a/stellargraph/mapper/full_batch_generators.py
+++ b/stellargraph/mapper/full_batch_generators.py
@@ -272,7 +272,7 @@ class RelationalFullBatchNodeGenerator:
         model.fit_generator(train_gen, epochs=num_epochs, ...)
 
     Args:
-        G (StellarGraphBase): a machine-learning StellarGraph-type graph
+        G (StellarGraph): a machine-learning StellarGraph-type graph
         name (str): an optional name of the generator
         transform (callable): an optional function to apply on features and adjacency matrix
             the function takes (features, Aadj) as arguments.


### PR DESCRIPTION
These were missed in #501 (and #502, after merging with #501) which renamed the `StellarGraphBase` type to `StellarGraph`.

See: #632 