### PR TITLE
update buildkite docker plugin v3.4.0

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -32,14 +32,14 @@ steps:
 
   - label: ":shell: format"
     plugins:
-      docker#v3.2.0:
+      docker#v3.4.0:
         image: "mvdan/shfmt:v2.6.4"
         command: ["-d", "-i", "2", "-ci", "-sr", "."]
 
   - label: ":shell: shellcheck"
     command: 'find ./ -type f -name "*.sh" -print0 | xargs -0 shellcheck --color=always'
     plugins:
-      docker#v3.2.0:
+      docker#v3.4.0:
         image: "koalaman/shellcheck-alpine:stable"
 
   - label: ":docker: :hadolint: lint Dockerfiles"


### PR DESCRIPTION
Updates the remaining Buildkite docker plugin steps to `v3.4.0` (https://github.com/buildkite-plugins/docker-buildkite-plugin/releases/tag/v3.4.0) for consistency 