### PR TITLE
Require Python >= 3.6, since 3.5 no longer works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 **Breaking changes:**
 - The stellargraph library now only supports `tensorflow` versions 2.0 and above [\#518](https://github.com/stellargraph/stellargraph/pull/518). Backward compatibility with earlier versions of `tensorflow` is not guaranteed.
+- The stellargraph library now only supports Python versions 3.6 and above [\#](). Backward compatibility with earlier versions of Python is not guaranteed.
 
 - The `StellarGraph` class no longer exposes `NetworkX` internals, only required functionality.
 In particular, calls like `list(G)` will no longer return a list of nodes; use `G.nodes()` instead.

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2018-2019 Data61, CSIRO
+# Copyright 2018-2020 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setuptools.setup(
     long_description=LONG_DESCRIPTION,
     long_description_content_type="text/markdown",
     include_package_data=True,
-    python_requires=">=3.5.0, <3.8.0",
+    python_requires=">=3.6.0, <3.8.0",
     install_requires=REQUIRES,
     extras_require=EXTRAS_REQURES,
     packages=setuptools.find_packages(exclude=("tests",)),


### PR DESCRIPTION
In https://github.com/stellargraph/stellargraph/pull/638, it was observed that stellargraph no longer supports Python 3.5, due to use of 3.6 features like [f-strings](https://docs.python.org/3/whatsnew/3.6.html#pep-498-formatted-string-literals).

This makes this requirement formal, in `setup.py`.

This may have been accidental, so maybe we want to not land this and instead fix our support for 3.5?