### PR TITLE
Remove the metaclass from StellarGraph

### DIFF
--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -363,7 +363,7 @@ class StellarGraph:
         """
         return self._graph.to_adjacency_matrix(nodes)
 
-    # Experimental/special-case methods that need to be considered more
+    # FIXME: Experimental/special-case methods that need to be considered more
     def get_index_for_nodes(self, nodes, node_type=None):
         """
         Get the indices for the specified node or nodes.

--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -114,8 +114,11 @@ class StellarGraph:
             a numeric feature vector for each node in the graph.
 
     """
+
     def __init__(self, *args, **kwargs):
+        # Avoid a circular import
         from .graph_networkx import NetworkXStellarGraph
+
         is_directed = kwargs.pop("is_directed", False)
         self._graph = NetworkXStellarGraph(is_directed=is_directed, *args, **kwargs)
 

--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -119,8 +119,7 @@ class StellarGraph:
         # Avoid a circular import
         from .graph_networkx import NetworkXStellarGraph
 
-        is_directed = kwargs.pop("is_directed", False)
-        self._graph = NetworkXStellarGraph(is_directed=is_directed, *args, **kwargs)
+        self._graph = NetworkXStellarGraph(*args, **kwargs)
 
     def is_directed(self) -> bool:
         """

--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -26,26 +26,7 @@ from typing import Iterable, Any, Mapping, Optional
 from .schema import GraphSchema
 
 
-class StellarGraphFactory(type):
-    """
-    Private class for instantiating the StellarGraph interface from
-    user-supplied information.
-    """
-
-    def __call__(cls, *args, **kwargs):
-        if cls is StellarGraph or cls is StellarDiGraph:
-            if "is_directed" in kwargs:
-                raise ValueError("Restricted keyword 'is_directed'")
-            is_directed = cls is StellarDiGraph
-            # XXX Import is here to avoid circular definitions
-            from .graph_networkx import NetworkXStellarGraph
-
-            return NetworkXStellarGraph(*args, is_directed=is_directed, **kwargs)
-        else:
-            return type.__call__(cls, *args, **kwargs)
-
-
-class StellarGraph(metaclass=StellarGraphFactory):
+class StellarGraph:
     """
     StellarGraph class for directed or undirected graph ML models. It stores both
     graph structure and features for machine learning.
@@ -133,6 +114,10 @@ class StellarGraph(metaclass=StellarGraphFactory):
             a numeric feature vector for each node in the graph.
 
     """
+    def __init__(self, *args, **kwargs):
+        from .graph_networkx import NetworkXStellarGraph
+        is_directed = kwargs.pop("is_directed", False)
+        self._graph = NetworkXStellarGraph(is_directed=is_directed, *args, **kwargs)
 
     def is_directed(self) -> bool:
         """
@@ -141,7 +126,7 @@ class StellarGraph(metaclass=StellarGraphFactory):
         Returns:
              bool: The graph directedness status.
         """
-        raise NotImplementedError
+        return self._graph.is_directed()
 
     def number_of_nodes(self) -> int:
         """
@@ -150,7 +135,7 @@ class StellarGraph(metaclass=StellarGraphFactory):
         Returns:
              int: The number of nodes.
         """
-        raise NotImplementedError
+        return self._graph.number_of_nodes()
 
     def number_of_edges(self) -> int:
         """
@@ -159,7 +144,7 @@ class StellarGraph(metaclass=StellarGraphFactory):
         Returns:
              int: The number of edges.
         """
-        raise NotImplementedError
+        return self._graph.number_of_edges()
 
     def nodes(self) -> Iterable[Any]:
         """
@@ -168,7 +153,7 @@ class StellarGraph(metaclass=StellarGraphFactory):
         Returns:
             The graph nodes.
         """
-        raise NotImplementedError
+        return self._graph.nodes()
 
     def edges(self, triple=False) -> Iterable[Any]:
         """
@@ -181,7 +166,7 @@ class StellarGraph(metaclass=StellarGraphFactory):
         Returns:
             The graph edges.
         """
-        raise NotImplementedError
+        return self._graph.edges(triple)
 
     def has_node(self, node: Any) -> bool:
         """
@@ -194,7 +179,7 @@ class StellarGraph(metaclass=StellarGraphFactory):
              bool: A value of True (cf False) if the node is
              (cf is not) in the graph.
         """
-        raise NotImplementedError
+        return self._graph.has_node(node)
 
     def neighbors(self, node: Any) -> Iterable[Any]:
         """
@@ -207,7 +192,7 @@ class StellarGraph(metaclass=StellarGraphFactory):
         Returns:
             iterable: The neighbouring nodes.
         """
-        raise NotImplementedError
+        return self._graph.neighbors(node)
 
     def in_nodes(self, node: Any) -> Iterable[Any]:
         """
@@ -221,7 +206,7 @@ class StellarGraph(metaclass=StellarGraphFactory):
         Returns:
             iterable: The neighbouring in-nodes.
         """
-        raise NotImplementedError
+        return self._graph.in_nodes(node)
 
     def out_nodes(self, node: Any) -> Iterable[Any]:
         """
@@ -235,7 +220,7 @@ class StellarGraph(metaclass=StellarGraphFactory):
         Returns:
             iterable: The neighbouring out-nodes.
         """
-        raise NotImplementedError
+        return self._graph.out_nodes(node)
 
     def nodes_of_type(self, node_type=None):
         """
@@ -247,7 +232,7 @@ class StellarGraph(metaclass=StellarGraphFactory):
         Returns:
             A list of node IDs with type node_type
         """
-        raise NotImplementedError
+        return self._graph.nodes_of_type(node_type)
 
     def node_type(self, node):
         """
@@ -259,7 +244,7 @@ class StellarGraph(metaclass=StellarGraphFactory):
         Returns:
             Node type
         """
-        raise NotImplementedError
+        return self._graph.node_type(node)
 
     @property
     def node_types(self):
@@ -269,7 +254,7 @@ class StellarGraph(metaclass=StellarGraphFactory):
         Returns:
             set of types
         """
-        raise NotImplementedError
+        return self._graph.node_types()
 
     def node_feature_sizes(self, node_types=None):
         """
@@ -282,7 +267,7 @@ class StellarGraph(metaclass=StellarGraphFactory):
         Returns:
             A dictionary of node type and integer feature size.
         """
-        raise NotImplementedError
+        return self._graph.node_feature_sizes(node_types)
 
     def node_features(self, nodes, node_type=None):
         """
@@ -298,7 +283,7 @@ class StellarGraph(metaclass=StellarGraphFactory):
         Returns:
             Numpy array containing the node features for the requested nodes.
         """
-        raise NotImplementedError
+        return self._graph.node_features(nodes, node_types)
 
     ##################################################################
     # Computationally intensive methods:
@@ -319,7 +304,7 @@ class StellarGraph(metaclass=StellarGraphFactory):
         Returns:
             An information string.
         """
-        raise NotImplementedError
+        return self._graph.info(show_attributes, sample)
 
     def node_degrees(self) -> Mapping[Any, int]:
         """
@@ -328,7 +313,7 @@ class StellarGraph(metaclass=StellarGraphFactory):
         Returns:
             The degree of each node.
         """
-        raise NotImplementedError
+        return self._graph.node_degrees()
 
     def to_adjacency_matrix(self, nodes: Optional[Iterable] = None):
         """
@@ -343,9 +328,11 @@ class StellarGraph(metaclass=StellarGraphFactory):
         Returns:
              The weighted adjacency matrix.
         """
-        raise NotImplementedError
+        return self._graph.to_adjacency_matrix(nodes)
 
 
 # A convenience class that merely specifies that edges have direction.
 class StellarDiGraph(StellarGraph):
-    pass
+    def __init__(self, *args, **kwargs):
+        kwargs["is_directed"] = True
+        super().__init__(*args, **kwargs)

--- a/tests/core/test_stellargraph.py
+++ b/tests/core/test_stellargraph.py
@@ -100,25 +100,25 @@ def example_hin_1_nx(feature_name=False, for_nodes=[]):
 def test_graph_constructor():
     sg = StellarGraph()
     assert sg.is_directed() == False
-    assert sg._node_type_attr == "label"
-    assert sg._edge_type_attr == "label"
+    assert sg._graph._node_type_attr == "label"
+    assert sg._graph._edge_type_attr == "label"
 
     sg = StellarGraph(node_type_name="type", edge_type_name="type")
     assert sg.is_directed() == False
-    assert sg._node_type_attr == "type"
-    assert sg._edge_type_attr == "type"
+    assert sg._graph._node_type_attr == "type"
+    assert sg._graph._edge_type_attr == "type"
 
 
 def test_digraph_constructor():
     sg = StellarDiGraph()
     assert sg.is_directed() == True
-    assert sg._node_type_attr == "label"
-    assert sg._edge_type_attr == "label"
+    assert sg._graph._node_type_attr == "label"
+    assert sg._graph._edge_type_attr == "label"
 
     sg = StellarDiGraph(node_type_name="type", edge_type_name="type")
     assert sg.is_directed() == True
-    assert sg._node_type_attr == "type"
-    assert sg._edge_type_attr == "type"
+    assert sg._graph._node_type_attr == "type"
+    assert sg._graph._edge_type_attr == "type"
 
 
 def test_info():

--- a/tests/mapper/test_node_mappers.py
+++ b/tests/mapper/test_node_mappers.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2018-2019 Data61, CSIRO
+# Copyright 2018-2020 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/mapper/test_node_mappers.py
+++ b/tests/mapper/test_node_mappers.py
@@ -366,9 +366,9 @@ def test_nodemapper_isolated_nodes():
     G = example_graph_3(feature_size=n_feat, n_nodes=6, n_isolates=1, n_edges=20)
 
     # Check connectedness
-    assert isinstance(G, NetworkXStellarGraph)
+    assert isinstance(G._graph, NetworkXStellarGraph)
     # XXX Hack - Only works for NetworkXStellarGraph instances
-    Gnx = G._graph
+    Gnx = G._graph._graph
     ccs = list(nx.connected_components(Gnx))
     assert len(ccs) == 2
 

--- a/tests/mapper/test_relational_node_mappers.py
+++ b/tests/mapper/test_relational_node_mappers.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2019 Data61, CSIRO
+# Copyright 2019-2020 Data61, CSIRO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/mapper/test_relational_node_mappers.py
+++ b/tests/mapper/test_relational_node_mappers.py
@@ -59,7 +59,7 @@ class Test_RelationalFullBatchNodeGenerator:
 
     def test_generator_constructor_wrong_G_type(self):
         with pytest.raises(TypeError):
-            generator = RelationalFullBatchNodeGenerator(nx.Graph(self.G._graph))
+            generator = RelationalFullBatchNodeGenerator(nx.Graph(self.G._graph._graph))
 
     def generator_flow(self, G, node_ids, node_targets, sparse=False):
         generator = RelationalFullBatchNodeGenerator(G, sparse=sparse)


### PR DESCRIPTION
This replaces the use of the metaclass with storing a `NetworkXStellarGraph` and then calling its methods. This does not move the implementations directly into the class, since that will be a lot of noise just to support the to-be-removed `NetworkXStellarGraph` class better. Improvements to the functionality can land directly in this class.

This copies the more experimental methods from `NetworkXStellarGraph` onto `StellarGraph` too, so that no other changes are required to the code (other than a couple of places that poke into the NetworkX internals (#599)).

~TODO: check that the notebooks still work.~ `python scripts/test_demos.py` passes.

See: #644