### PR TITLE
Replace exit(0) on error in library function with an exception

### DIFF
--- a/stellargraph/data/loader.py
+++ b/stellargraph/data/loader.py
@@ -92,8 +92,7 @@ def load_dataset_BlogCatalog3(location):
     """
     location = os.path.expanduser(location)
     if not os.path.isdir(location):
-        print("The location {} is not a directory.".format(location))
-        exit(0)
+        raise NotADirectoryError("The location {} is not a directory.".format(location))
 
     # load the raw data
     user_node_ids = pd.read_csv(os.path.join(location, "nodes.csv"), header=None)


### PR DESCRIPTION
`print` + `exit(0)` isn't quite the right tool to indicate a failure to the user here:

- `exit(0)` will result in the whole process completing immediately, even if the user had something else to do (e.g. in an interactive shell or Jupyter notebook they might pause their scripting work and download the dataset, and then come back and rerun the command/cell)
- the `0` means it will finish as a success, rather than indicating a failure, which can mean that, for instance, testing passes accidentally because it doesn't notice that the dataset couldn't even be loaded
- `print` will put output on `stdout`, instead of `stderr`, which means some tools won't pick up on it

Throwing an exception improves on all of these: 

- the exception will propagate until it is caught. For an interactive shell or Jupyter notebook, it is always caught before the program exits, so the user has the opportunity to observe the failure and then fix/rerun their code
- if the exception isn't caught (e.g. in a non-interactive script), the process will exit with error code 1:
  ```shell
  $ python -c 'raise NotADirectoryError("The location {} is not a directory.".format("/some/directory"))'; echo $?
  Traceback (most recent call last):
    File "<string>", line 1, in <module>
  NotADirectoryError: The location /some/directory is not a directory.
  1
  ```
- the default exception printing output goes to stderr