### PR TITLE
Use explicit argument list, not splats, for StellarGraph constructor

### DIFF
--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -448,7 +448,8 @@ class StellarGraph:
 
 # A convenience class that merely specifies that edges have direction.
 class StellarDiGraph(StellarGraph):
-    def __init__(self,
+    def __init__(
+        self,
         graph=None,
         edge_weight_label="weight",
         node_type_name=globalvar.TYPE_ATTR_NAME,

--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -448,6 +448,28 @@ class StellarGraph:
 
 # A convenience class that merely specifies that edges have direction.
 class StellarDiGraph(StellarGraph):
-    def __init__(self, *args, **kwargs):
-        kwargs["is_directed"] = True
-        super().__init__(*args, **kwargs)
+    def __init__(self,
+        graph=None,
+        edge_weight_label="weight",
+        node_type_name=globalvar.TYPE_ATTR_NAME,
+        edge_type_name=globalvar.TYPE_ATTR_NAME,
+        node_type_default=globalvar.NODE_TYPE_DEFAULT,
+        edge_type_default=globalvar.EDGE_TYPE_DEFAULT,
+        feature_name=globalvar.FEATURE_ATTR_NAME,
+        target_name=globalvar.TARGET_ATTR_NAME,
+        node_features=None,
+        dtype="float32",
+    ):
+        super().__init__(
+            graph=graph,
+            is_directed=True,
+            edge_weight_label=edge_weight_label,
+            node_type_name=node_type_name,
+            edge_type_name=edge_type_name,
+            node_type_default=node_type_default,
+            edge_type_default=edge_type_default,
+            feature_name=feature_name,
+            target_name=target_name,
+            node_features=node_features,
+            dtype=dtype,
+        )

--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -23,6 +23,7 @@ __all__ = ["StellarGraph", "StellarDiGraph", "GraphSchema"]
 
 from typing import Iterable, Any, Mapping, List, Optional, Set
 
+from .. import globalvar
 from .schema import GraphSchema
 
 
@@ -115,11 +116,36 @@ class StellarGraph:
 
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(
+        self,
+        graph=None,
+        is_directed=False,
+        edge_weight_label="weight",
+        node_type_name=globalvar.TYPE_ATTR_NAME,
+        edge_type_name=globalvar.TYPE_ATTR_NAME,
+        node_type_default=globalvar.NODE_TYPE_DEFAULT,
+        edge_type_default=globalvar.EDGE_TYPE_DEFAULT,
+        feature_name=globalvar.FEATURE_ATTR_NAME,
+        target_name=globalvar.TARGET_ATTR_NAME,
+        node_features=None,
+        dtype="float32",
+    ):
         # Avoid a circular import
         from .graph_networkx import NetworkXStellarGraph
 
-        self._graph = NetworkXStellarGraph(*args, **kwargs)
+        self._graph = NetworkXStellarGraph(
+            graph,
+            is_directed,
+            edge_weight_label,
+            node_type_name,
+            edge_type_name,
+            node_type_default,
+            edge_type_default,
+            feature_name,
+            target_name,
+            node_features,
+            dtype,
+        )
 
     def is_directed(self) -> bool:
         """

--- a/stellargraph/core/graph_networkx.py
+++ b/stellargraph/core/graph_networkx.py
@@ -34,7 +34,6 @@ import networkx as nx
 
 from typing import Iterable, Iterator, Any, Mapping, List, Set, Optional
 
-from .. import globalvar
 from .schema import GraphSchema
 from .utils import is_real_iterable
 
@@ -250,7 +249,20 @@ class NetworkXStellarGraph(StellarGraph):
     Implementation based on encapsulating a NetworkX graph.
     """
 
-    def __init__(self, graph=None, is_directed=False, **attr):
+    def __init__(
+        self,
+        graph,
+        is_directed,
+        edge_weight_label,
+        node_type_name,
+        edge_type_name,
+        node_type_default,
+        edge_type_default,
+        feature_name,
+        target_name,
+        node_features,
+        dtype,
+    ):
         if is_directed:
             if not isinstance(graph, nx.MultiDiGraph):
                 graph = nx.MultiDiGraph(graph)
@@ -260,24 +272,20 @@ class NetworkXStellarGraph(StellarGraph):
         self._graph = graph
 
         # Name of optional attribute for edge weights
-        self._edge_weight_label = attr.get("edge_weight_label", "weight")
+        self._edge_weight_label = edge_weight_label
 
         # Names of attributes that store the type of nodes and edges
-        self._node_type_attr = attr.get("node_type_name", globalvar.TYPE_ATTR_NAME)
-        self._edge_type_attr = attr.get("edge_type_name", globalvar.TYPE_ATTR_NAME)
+        self._node_type_attr = node_type_name
+        self._edge_type_attr = edge_type_name
 
         # Default types of nodes and edges
-        self._node_type_default = attr.get(
-            "node_type_default", globalvar.NODE_TYPE_DEFAULT
-        )
-        self._edge_type_default = attr.get(
-            "edge_type_default", globalvar.EDGE_TYPE_DEFAULT
-        )
+        self._node_type_default = node_type_default
+        self._edge_type_default = edge_type_default
 
         # Names for the feature/target type (used if they are supplied and
         #  feature/target spec not supplied"
-        self._feature_attr = attr.get("feature_name", globalvar.FEATURE_ATTR_NAME)
-        self._target_attr = attr.get("target_name", globalvar.TARGET_ATTR_NAME)
+        self._feature_attr = feature_name
+        self._target_attr = target_name
 
         # Ensure that the incoming graph data has node & edge types
         # TODO: This requires traversing all nodes and edges. Is there another way?
@@ -290,10 +298,6 @@ class NetworkXStellarGraph(StellarGraph):
         edge_types = set()
         for n1, n2, k, edata in graph.edges(keys=True, data=True):
             edge_types.add(self._get_edge_type(edata))
-
-        # New style: we are passed numpy arrays or pandas arrays of the feature vectors
-        node_features = attr.get("node_features", None)
-        dtype = attr.get("dtype", "float32")
 
         # If node_features is a string, load features from this attribute of the nodes in the graph
         if isinstance(node_features, str):


### PR DESCRIPTION
An explicit argument list is nicer in a few ways than the fully dynamic `*args`/`**kwargs` version, even when there's many arguments (or, maybe, especially when there are):

- means it's clear what the interface is for our upcoming refactoring, so we're less likely to break something accidentally
- it makes it clearer to users too, for at-a-glance documentation reading (e.g. a user who already knows the library may just need a reminder of how to spell an argument), e.g. `help(StellarGraph)` now says:
  ```
  ...
   |  Methods defined here:
   |  
   |  __init__(self, graph=None, is_directed=False, edge_weight_label='weight', node_type_name='label', edge_type_name='label', node_type_default='default', edge_type_default='default', feature_name='feature', target_name='target', node_features=None, dtype='float32')
   |      Initialize self.  See help(type(self)) for accurate signature.
  ...
  ```
- it integrates better into static analysis and code tools, e.g. PyCharm's argument listing and autocomplete:
  
  ![image](https://user-images.githubusercontent.com/1203825/72227350-91ee7080-35ef-11ea-8141-729bcc4d6d50.png)
  ![image](https://user-images.githubusercontent.com/1203825/72227353-9ca90580-35ef-11ea-8c4c-ebbdd1275dfd.png)

This is work along the lines of #644.