### PR TITLE
Benchmark StellarGraph.neighbors, not networkx.Graph.neighbors

### DIFF
--- a/tests/core/test_stellargraph.py
+++ b/tests/core/test_stellargraph.py
@@ -479,7 +479,7 @@ def test_benchmark_get_neighbours(benchmark):
     # get the neigbours of every node in the graph
     def f():
         for i in range(num_nodes):
-            g.neighbors(i)
+            sg.neighbors(i)
 
     benchmark(f)
 


### PR DESCRIPTION
This was a mistake made when the benchmark was written. Unfortunately, it looks like the `StellarGraph` `neighbors` is significantly slower, but this was always true, and so the "regression" is just getting back to the way it should be:

| name    |  min |  max | mean | stddev | median |  iqr | outliers | ops (/s) | rounds | iterations |
|---------|-----:|-----:|-----:|-------:|-------:|-----:|---------:|---------:|-------:|-----------:|
| develop | 21.3 |  297 | 24.2 |   6.32 |   23.5 | 1.25 | 706;1613 |    41254 |  27577 |          1 |
| this PR |  722 | 1900 |  871 |    104 |    863 | 53.4 |  140;123 |     1148 |   1048 |          1 |

(Times in microseconds.)