### PR TITLE
Install dependencies with `.[test]` on CI, not requirements.txt

### DIFF
--- a/.buildkite/steps/script.sh
+++ b/.buildkite/steps/script.sh
@@ -9,7 +9,7 @@ upload_tests() {
 }
 
 echo "--- installing dependencies"
-pip install -q --no-cache-dir -r requirements.txt .
+pip install -q --no-cache-dir .[test]
 
 echo "--- listing dependency versions"
 pip freeze

--- a/.buildkite/steps/script.sh
+++ b/.buildkite/steps/script.sh
@@ -9,7 +9,7 @@ upload_tests() {
 }
 
 echo "--- installing dependencies"
-pip install -q --no-cache-dir .[test]
+pip install -q --no-cache-dir '.[test]'
 
 echo "--- listing dependency versions"
 pip freeze


### PR DESCRIPTION
This was missed in #661.