### PR TITLE
Reduce the amount of duplication and mutation in full-batch sequences

### DIFF
--- a/stellargraph/mapper/sequences.py
+++ b/stellargraph/mapper/sequences.py
@@ -496,9 +496,6 @@ class RelationalFullBatchNodeSequence(Sequence):
                 "When passed together targets and indices should be the same length."
             )
 
-        # Store features and targets as np.ndarray
-        self.features = np.asanyarray(features)
-        self.target_indices = np.asanyarray(indices)
         self.use_sparse = use_sparse
 
         # Convert all adj matrices to dense and reshape to have batch dimension of 1
@@ -512,23 +509,17 @@ class RelationalFullBatchNodeSequence(Sequence):
         else:
             self.As = [np.expand_dims(A.todense(), 0) for A in As]
 
-        # Reshape all inputs to have batch dimension of 1
-        self.target_indices = np.reshape(
-            self.target_indices, (1,) + self.target_indices.shape
-        )
+        # Make sure all inputs are numpy arrays, and have batch dimension of 1
+        def reshape(array):
+            return np.reshape(np.asanyarray(array), (1,) + array.shape)
 
-        self.features = np.reshape(self.features, (1,) + self.features.shape)
+        self.target_indices = reshape(indices)
+        self.features = reshape(features)
+
         self.inputs = [self.features, self.target_indices] + self.As
 
-        # Reshape all inputs to have batch dimension of 1
-        self.target_indices = np.reshape(
-            self.target_indices, (1,) + self.target_indices.shape
-        )
-        self.features = np.reshape(self.features, (1,) + self.features.shape)
-
         if targets is not None:
-            self.targets = np.asanyarray(targets)
-            self.targets = np.reshape(self.targets, (1,) + self.targets.shape)
+            self.targets = reshape(targets)
         else:
             self.targets = None
 

--- a/stellargraph/mapper/sequences.py
+++ b/stellargraph/mapper/sequences.py
@@ -323,6 +323,22 @@ class OnDemandLinkSequence(Sequence):
         return int(np.ceil(self.data_size / self.batch_size))
 
 
+def _full_batch_array_and_reshape(array, propagate_none=False):
+    """
+    Args:
+        array: an array-like object
+        propagate_none: if True, return None when array is None
+    Returns:
+        array as a numpy array with an extra first dimension (batch dimension) equal to 1
+    """
+    # if it's ok, just short-circuit on None (e.g. for target arrays, that may or may not exist)
+    if propagate_none and array is None:
+        return None
+
+    as_np = np.asanyarray(array)
+    return np.reshape(as_np, (1,) + as_np.shape)
+
+
 class FullBatchNodeSequence(Sequence):
     """
     Keras-compatible data generator for for node inference models
@@ -359,28 +375,20 @@ class FullBatchNodeSequence(Sequence):
 
         # Convert sparse matrix to dense:
         if sps.issparse(A) and hasattr(A, "toarray"):
-            self.A_dense = A.toarray()
+            self.A_dense = _full_batch_array_and_reshape(A.toarray())
         elif isinstance(A, (np.ndarray, np.matrix)):
-            self.A_dense = np.asanyarray(A)
+            self.A_dense = _full_batch_array_and_reshape(A)
         else:
             raise TypeError(
                 "Expected input matrix to be either a Scipy sparse matrix or a Numpy array."
             )
 
         # Reshape all inputs to have batch dimension of 1
-        self.features = np.reshape(self.features, (1,) + self.features.shape)
-        self.A_dense = self.A_dense.reshape((1,) + self.A_dense.shape)
-        self.target_indices = np.reshape(
-            self.target_indices, (1,) + self.target_indices.shape
-        )
-
+        self.features = _full_batch_array_and_reshape(features)
+        self.target_indices = _full_batch_array_and_reshape(indices)
         self.inputs = [self.features, self.target_indices, self.A_dense]
 
-        if targets is not None:
-            self.targets = np.asanyarray(targets)
-            self.targets = np.reshape(self.targets, (1,) + self.targets.shape)
-        else:
-            self.targets = None
+        self.targets = _full_batch_array_and_reshape(targets, propagate_none=True)
 
     def __len__(self):
         return 1
@@ -423,10 +431,6 @@ class SparseFullBatchNodeSequence(Sequence):
                 "When passed together targets and indices should be the same length."
             )
 
-        # Store features and targets as np.ndarray
-        self.features = np.asanyarray(features)
-        self.target_indices = np.asanyarray(indices)
-
         # Ensure matrix is in COO format to extract indices
         if sps.isspmatrix(A):
             A = A.tocoo()
@@ -441,10 +445,8 @@ class SparseFullBatchNodeSequence(Sequence):
         self.A_values = np.expand_dims(A.data, 0)
 
         # Reshape all inputs to have batch dimension of 1
-        self.target_indices = np.reshape(
-            self.target_indices, (1,) + self.target_indices.shape
-        )
-        self.features = np.reshape(self.features, (1,) + self.features.shape)
+        self.target_indices = _full_batch_array_and_reshape(indices)
+        self.features = _full_batch_array_and_reshape(features)
         self.inputs = [
             self.features,
             self.target_indices,
@@ -452,11 +454,7 @@ class SparseFullBatchNodeSequence(Sequence):
             self.A_values,
         ]
 
-        if targets is not None:
-            self.targets = np.asanyarray(targets)
-            self.targets = np.reshape(self.targets, (1,) + self.targets.shape)
-        else:
-            self.targets = None
+        self.targets = _full_batch_array_and_reshape(targets, propagate_none=True)
 
     def __len__(self):
         return 1
@@ -510,18 +508,11 @@ class RelationalFullBatchNodeSequence(Sequence):
             self.As = [np.expand_dims(A.todense(), 0) for A in As]
 
         # Make sure all inputs are numpy arrays, and have batch dimension of 1
-        def reshape(array):
-            return np.reshape(np.asanyarray(array), (1,) + array.shape)
-
-        self.target_indices = reshape(indices)
-        self.features = reshape(features)
-
+        self.target_indices = _full_batch_array_and_reshape(indices)
+        self.features = _full_batch_array_and_reshape(features)
         self.inputs = [self.features, self.target_indices] + self.As
 
-        if targets is not None:
-            self.targets = reshape(targets)
-        else:
-            self.targets = None
+        self.targets = _full_batch_array_and_reshape(targets, propagate_none=True)
 
     def __len__(self):
         return 1


### PR DESCRIPTION
All of the full batch methods reshape the data to have a single batch (first dimension 1), so we can pull this out and not have to repeat the somewhat fiddly incantation every time.

Also, this removes some of the `self.x = ...; self.x = f(self.x); ...` mutation that occurs in these functions, and, removes a repeat of identical code that occurs in the relational sequence.

The GCN and RGCN demo notebooks both still run and give the ~same results as they did.