### PR TITLE
Remove never-taken else from edge_splitter.py

### DIFF
--- a/stellargraph/data/edge_splitter.py
+++ b/stellargraph/data/edge_splitter.py
@@ -388,16 +388,13 @@ class EdgeSplitter(object):
         else:
             all_edges = list(self.g.edges())
 
-        if edge_attribute_label is None or edge_attribute_threshold is None:
+        if edge_attribute_label is None and edge_attribute_threshold is None:
             # filter by edge_label
             edges_with_label = [
                 e for e in all_edges if self.g.get_edge_data(*e)["label"] == edge_label
             ]
 
-        elif (
-            edge_attribute_threshold is not None
-            and edge_attribute_threshold is not None
-        ):
+        else:
             # filter by edge label, edge attribute and threshold value
             edge_attribute_threshold_dt = datetime.datetime.strptime(
                 edge_attribute_threshold, "%d/%m/%Y"
@@ -413,8 +410,6 @@ class EdgeSplitter(object):
                     > edge_attribute_threshold_dt
                 )
             ]
-        else:
-            raise ValueError("Invalid parameters")  # not the most informative error!
 
         return edges_with_label
 

--- a/stellargraph/data/edge_splitter.py
+++ b/stellargraph/data/edge_splitter.py
@@ -388,7 +388,7 @@ class EdgeSplitter(object):
         else:
             all_edges = list(self.g.edges())
 
-        if edge_attribute_label is None and edge_attribute_threshold is None:
+        if edge_attribute_label is None or edge_attribute_threshold is None:
             # filter by edge_label
             edges_with_label = [
                 e for e in all_edges if self.g.get_edge_data(*e)["label"] == edge_label


### PR DESCRIPTION
The condition in the `elif` branch was testing the same variable twice (`edge_attribute_threshold`), when it was likely meant to be testing `edge_attribute_label`. However,  even after making that correction, this code will always take one of the first two branches and the `else` will never be taken: the following table is a truth/"which branch is taken" table of the two variables, with `edge_attribute_label ` as the rows and `edge_attribute_threshold` as the columns, showing which branch is taken:

| label \ threshold | None | not None
|---|---|---|
| **None** | first | first |
| **not None** | first | second |

As such, the final `else` can be removed.

This was found via CodeClimate https://codeclimate.com/github/stellargraph/stellargraph/stellargraph/data/edge_splitter.py :

![image](https://user-images.githubusercontent.com/1203825/72394124-3ce66200-3789-11ea-9df7-132169bc5c0e.png)
