### PR TITLE
Add more & easier "Environment" to bug template, and other tweaks

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -37,7 +37,7 @@ Package versions: *for example: stellargraph==0.8.3, tensorflow==2.0.0*
 ~~~
 import subprocess, platform, sys
 pkgs = subprocess.Popen(["pip", "freeze"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT).communicate()[0].decode("utf-8")
-print("Operating system: `{}`\nPython version:\n```\n{}\n```\nPackage versions:\n<details>\n\n```\n{}\n```\n\n</details>".format(platform.platform(), sys.version, pkgs))'
+print("Operating system: `{}`\nPython version:\n```\n{}\n```\nPackage versions:\n<details>\n\n```\n{}\n```\n\n</details>".format(platform.platform(), sys.version, pkgs))
 ~~~
 
 ### Additional context

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -33,24 +33,11 @@ Python version: *for example: 3.7.2*
 
 Package versions: *for example: stellargraph==0.8.3, tensorflow==2.0.0*
 
-*The following Python code can automatically compute the data for this section (for example: on macOS, copy the code and run `pbpaste | python -`):*
-
-~~~python
+*The following Python code can automatically compute the data for this section (for example: run the code in a Jupyter notebook cell, or, on macOS, copy the code and run `pbpaste | python -` in a terminal):*
+~~~
 import subprocess, platform, sys
-packages=subprocess.run(["pip", "freeze"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT).stdout.decode("utf-8")
-print("""Operating system: `{}`
-Python version:
-```
-{}
-```
-Package versions:
-<details>
-
-```
-{}
-```
-
-</details>""".format(platform.platform(), sys.version, packages))
+pkgs = subprocess.Popen(["pip", "freeze"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT).communicate()[0].decode("utf-8")
+print("Operating system: `{}`\nPython version:\n```\n{}\n```\nPackage versions:\n<details>\n\n```\n{}\n```\n\n</details>".format(platform.platform(), sys.version, pkgs))'
 ~~~
 
 ### Additional context

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -5,27 +5,58 @@ labels: bug, sg-library
 
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+### Describe the bug
 
-**To Reproduce**
+*A clear and concise description of what the bug is.*
+
+### To Reproduce
+
 Steps to reproduce the behavior:
-1. Go to '...'
-2. Execute '...'
-4. See error
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+1. *Go to '...'*
+2. *Execute '...'*
+3. *See error*
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+### Observed behavior
 
-**Desktop (please complete the following information):**
- - OS: [e.g. MacOS, Ubuntu]
- - Version [e.g. 18.01]
+*Describe or paste the exact output that demonstrates the bug (for example, the stack trace if it is an exception).*
 
-**Data used**
-If this problem appears with a specific dataset you are using, specify how to get the dataset to duplicate the problem.
+### Expected behavior
 
-**Additional context**
-Add any other context about the problem here.
+*A clear and concise description of what you expected to happen.*
+
+### Environment
+
+Operating system: *for example: macOS, Ubuntu*
+
+Python version: *for example: 3.7.2*
+
+Package versions: *for example: stellargraph==0.8.3, tensorflow==2.0.0*
+
+*The following Python code can automatically compute the data for this section (for example: on macOS, copy the code and run `pbpaste | python -`):*
+
+~~~python
+import subprocess, platform, sys
+packages=subprocess.run(["pip", "freeze"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT).stdout.decode("utf-8")
+print("""Operating system: `{}`
+Python version:
+```
+{}
+```
+Package versions:
+<details>
+
+```
+{}
+```
+
+</details>""".format(platform.platform(), sys.version, packages))
+~~~
+
+### Additional context
+
+Add any other context about the problem here. For example:
+
+Data used: *if this occurs with a specific dataset, which dataset and how to acquire it*
+
+Screenshots: *if applicable, add some screenshots to explain the behaviour*


### PR DESCRIPTION
This tweaks the issue template in a few ways:

- renames "Desktop" to "Environment" and add a request for Python and package versions
- adds some code that can automatically compute the above information
- introduces "Observed Behaviour" which asks for specific information about the output, since this is really important to be sure we're debugging the right thing (I think this was somewhat suggested by "Screenshots", but not entirely)
- folds the "data" and "screenshots" section into "Additional Context", since hopefully the rest of the description is enough to understand the bug

This is prompted by noticing some bugs that don't have as much info as would be helpful, so hopefully this serves as somewhat of a simplification.