### PR TITLE
Add @experimental to mark functions and classes as experimental

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - Cluster-GCN algorithm (an extension of GCN that can be trained using SGD) + demo [\#487](https://github.com/stellargraph/stellargraph/issues/487)
 
-- Relational-GCN (RGCN) algorithm (a generalisation of GCN to relational/multi edge type graphs) + demo [\#490](https://github.com/stellargraph/stellargraph/issues/490)
+- *Experimental*: Relational-GCN (RGCN) algorithm (a generalisation of GCN to relational/multi edge type graphs) + demo [\#490](https://github.com/stellargraph/stellargraph/issues/490)
 
 **Implemented enhancements:**
 - Neighbourhood methods in `StellarGraph` class (`neighbors`, `in_nodes`, `out_nodes`) now support additional parameters to include edge weights in the results or filter by a set of edge types. [\#646](https://github.com/stellargraph/stellargraph/pull/646)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,9 +68,29 @@ StellarGraph considers courtesy and respect for others an essential part of the 
 
 ### Experimental code
 
-Code can be marked as experimental using the `@experimental` decorator. This should be applied to new code that isn't fully documented, tested or validated. This allows landing code faster and iterating on it inside the repository.
+Functions, methods and classes can be marked as experimental using the `@experimental` decorator. For example:
 
-This is meant to be a lightweight annotation, with a low bar for "graduating". Code does not need to be `@experimental` if it satisfies the following check-list:
+``` python
+# On a class: (the reason argument is required)
+@experimental(reason="it has no documentation")
+class Foo:
+    pass
+
+# On a function: (the issues argument will link to those stellargraph issues)
+@experimental(reason="the API is not satisfactory", issues=[123])
+def bar():
+    pass
+
+class Baz:
+    # On a method:
+    @experimental(reason="it is not fully tested")
+    def f():
+        pass
+```
+
+This should be applied to new code that isn't fully documented, tested or validated. This allows landing code faster and iterating on it inside the repository. The annotation will add an obvious "warning" admonition to the attached item's documentation.
+
+This is meant to be a lightweight status, with a low bar for "graduating". Code does not need to be `@experimental` if it satisfies the following check-list:
 
 - [ ] tests
 - [ ] documentation for all classes, functions and their parameters

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,3 +65,13 @@ StellarGraph considers courtesy and respect for others an essential part of the 
 8. Update the documentation. If introducing new functionality, make sure you include code snippets demonstrating the usage of your new feature.
 
 9. Create a pull request on GitHub from your branch to `develop` branch. If you have already discussed the new features on GitHub with the developers and they are aware of what the pull request contains, then the developers will endeavour to approve the pull request promptly.
+
+### Experimental code
+
+Code can be marked as experimental using the `@experimental` decorator. This should be applied to new code that isn't fully documented, tested or validated. This allows landing code faster and iterating on it inside the repository.
+
+This is meant to be a lightweight annotation, with a low bar for "graduating". Code does not need to be `@experimental` if it satisfies the following check-list:
+
+- [ ] tests
+- [ ] documentation for all classes, functions and their parameters
+- [ ] a demo notebook, if applicable; if there are relevant research papers, the demo(s) should produce similar results, to validate that the implementation matches the description

--- a/demos/node-classification/rgcn/rgcn-aifb-node-classification-example.ipynb
+++ b/demos/node-classification/rgcn/rgcn-aifb-node-classification-example.ipynb
@@ -6,6 +6,8 @@
    "source": [
     "# Stellargraph example: Relational Graph Convolutional Network (RGCN) on the AIFB relational dataset\n",
     "\n",
+    "**Warning**: the RGCN model used in this notebook is **experimental** (see known bugs [#649](https://github.com/stellargraph/stellargraph/issues/649) and [#677](https://github.com/stellargraph/stellargraph/issues/677)).\n",
+    "\n",
     "This example demonstrates how use an RGCN [1] on the AIFB dataset with stellargraph. This dataset can be downloaded [here](https://figshare.com/articles/AIFB_DataSet/745364). \n",
     "\n",
     "The AIFB dataset describes the AIFB research institute in terms of its staff, research group, and publications. It contains ~8k entities, ~29k edges, and 45 different relationships or edge types. In (Bloehdorn et al 2007) the dataset was first used to predict the affiliation (i.e., research group) for people in the dataset. The dataset contains 178 members of a research group with 5 different research groups. The goal is to predict which research group a researcher belongs to.\n",

--- a/stellargraph/core/experimental.py
+++ b/stellargraph/core/experimental.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2018-2020 Data61, CSIRO
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from textwrap import dedent
+
+
+def experimental(*, reason):
+    def decorator(decl):
+        # add warning at the start of the documentation
+        # <https://docutils.sourceforge.io/docs/ref/rst/directives.html#caution>
+        decl.__doc__ = f"""\
+.. warning::
+
+   ``{decl.__qualname__}`` is experimental: {reason}. It may be difficult to use and may have major
+   changes at any time.
+
+{dedent(decl.__doc__)}
+"""
+        return decl
+
+    return decorator

--- a/stellargraph/core/experimental.py
+++ b/stellargraph/core/experimental.py
@@ -14,14 +14,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+__all__ = ["experimental"]
+
 from textwrap import dedent
 
 ISSUE_BASE = "https://github.com/stellargraph/stellargraph/issues"
 
+
 def render_issue_link(number):
     return f"`#{number} <{ISSUE_BASE}/{number}>`_"
 
+
 def experimental(*, reason, issues=None):
+    """
+    A decorator to mark a function, method or class as experimental, meaning it may not be complete.
+
+    Args:
+        reason (str): why this is experimental
+        issues (list of int, optional): any relevant ``stellargraph/stellargraph`` issues
+    """
     if issues is None:
         issues = []
 

--- a/stellargraph/core/experimental.py
+++ b/stellargraph/core/experimental.py
@@ -48,9 +48,8 @@ def experimental(*, reason, issues=None):
         decl.__doc__ = f"""\
 .. warning::
 
-   ``{decl.__qualname__}`` is experimental: {reason}{issue_text}. It may be difficult to use and 
-   may have major
-   changes at any time.
+   ``{decl.__qualname__}`` is experimental: {reason}{issue_text}. It may be difficult to use and may
+   have major changes at any time.
 
 {dedent(decl.__doc__)}
 """

--- a/stellargraph/core/experimental.py
+++ b/stellargraph/core/experimental.py
@@ -16,15 +16,29 @@
 
 from textwrap import dedent
 
+ISSUE_BASE = "https://github.com/stellargraph/stellargraph/issues"
 
-def experimental(*, reason):
+def render_issue_link(number):
+    return f"`#{number} <{ISSUE_BASE}/{number}>`_"
+
+def experimental(*, reason, issues=None):
+    if issues is None:
+        issues = []
+
+    if issues:
+        links = ", ".join(render_issue_link(number) for number in issues)
+        issue_text = f" (see: {links})"
+    else:
+        issue_text = ""
+
     def decorator(decl):
         # add warning at the start of the documentation
         # <https://docutils.sourceforge.io/docs/ref/rst/directives.html#caution>
         decl.__doc__ = f"""\
 .. warning::
 
-   ``{decl.__qualname__}`` is experimental: {reason}. It may be difficult to use and may have major
+   ``{decl.__qualname__}`` is experimental: {reason}{issue_text}. It may be difficult to use and 
+   may have major
    changes at any time.
 
 {dedent(decl.__doc__)}

--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -25,6 +25,7 @@ from typing import Iterable, Any, Mapping, List, Optional, Set
 
 from .. import globalvar
 from .schema import GraphSchema
+from .experimental import experimental
 
 
 class StellarGraph:
@@ -424,6 +425,7 @@ class StellarGraph:
         return self._graph.to_networkx()
 
     # FIXME: Experimental/special-case methods that need to be considered more
+    @experimental(reason="special-case method that needs more consideration")
     def get_index_for_nodes(self, nodes, node_type=None):
         """
         Get the indices for the specified node or nodes.
@@ -440,6 +442,7 @@ class StellarGraph:
         """
         return self._graph.get_index_for_nodes(nodes, node_type)
 
+    @experimental(reason="special-case method that needs more consideration")
     def adjacency_types(self, graph_schema: GraphSchema):
         """
         Obtains the edges in the form of the typed mapping:
@@ -453,6 +456,7 @@ class StellarGraph:
         """
         return self._graph.adjacency_types(graph_schema)
 
+    @experimental(reason="special-case method that needs more consideration")
     def edge_weights(self, source_node: Any, target_node: Any) -> List[Any]:
         """
         Obtains the weights of edges between the given pair of nodes.
@@ -466,6 +470,7 @@ class StellarGraph:
         """
         return self._graph.edge_weights(source_node, target_node)
 
+    @experimental(reason="special-case method that needs more consideration")
     def node_attributes(self, node: Any) -> Set[Any]:
         """
         Obtains the names of any (non-standard) node attributes that are

--- a/stellargraph/layer/rgcn.py
+++ b/stellargraph/layer/rgcn.py
@@ -23,9 +23,7 @@ from ..mapper.full_batch_generators import RelationalFullBatchNodeGenerator
 from ..core.experimental import experimental
 
 
-@experimental(
-    reason="`#649 <https://github.com/stellargraph/stellargraph/issues/649>`_ is a severe known bug"
-)
+@experimental(reason="it has severe known bugs", issues=[649, 677])
 class RelationalGraphConvolution(Layer):
     """
         Relational Graph Convolution (RGCN) Keras layer.
@@ -344,9 +342,7 @@ class RelationalGraphConvolution(Layer):
         return output
 
 
-@experimental(
-    reason="`#649 <https://github.com/stellargraph/stellargraph/issues/649>`_ is a severe known bug"
-)
+@experimental(reason="it has severe known bugs", issues=[649, 677])
 class RGCN:
     """
     A stack of Relational Graph Convolutional layers that implement a relational graph

--- a/stellargraph/layer/rgcn.py
+++ b/stellargraph/layer/rgcn.py
@@ -20,8 +20,12 @@ from tensorflow.keras.layers import Layer, Lambda, Dropout, Input
 from tensorflow.keras import activations, initializers, constraints, regularizers
 from .misc import SqueezedSparseConversion
 from ..mapper.full_batch_generators import RelationalFullBatchNodeGenerator
+from ..core.experimental import experimental
 
 
+@experimental(
+    reason="`#649 <https://github.com/stellargraph/stellargraph/issues/649>`_ is a severe known bug"
+)
 class RelationalGraphConvolution(Layer):
     """
         Relational Graph Convolution (RGCN) Keras layer.
@@ -340,6 +344,9 @@ class RelationalGraphConvolution(Layer):
         return output
 
 
+@experimental(
+    reason="`#649 <https://github.com/stellargraph/stellargraph/issues/649>`_ is a severe known bug"
+)
 class RGCN:
     """
     A stack of Relational Graph Convolutional layers that implement a relational graph

--- a/stellargraph/mapper/full_batch_generators.py
+++ b/stellargraph/mapper/full_batch_generators.py
@@ -243,9 +243,7 @@ class FullBatchNodeGenerator:
             )
 
 
-@experimental(
-    reason="`#649 <https://github.com/stellargraph/stellargraph/issues/649>`_ is a severe known bug"
-)
+@experimental(reason="it has severe known bugs", issues=[649, 677])
 class RelationalFullBatchNodeGenerator:
     """
     A data generator for use with full-batch models on relational graphs e.g. RGCN.

--- a/stellargraph/mapper/full_batch_generators.py
+++ b/stellargraph/mapper/full_batch_generators.py
@@ -36,6 +36,7 @@ from . import (
     SparseFullBatchNodeSequence,
     RelationalFullBatchNodeSequence,
 )
+from ..core.experimental import experimental
 from ..core.graph import StellarGraph
 from ..core.utils import is_real_iterable
 from ..core.utils import GCN_Aadj_feats_op, PPNP_Aadj_feats_op
@@ -242,6 +243,9 @@ class FullBatchNodeGenerator:
             )
 
 
+@experimental(
+    reason="`#649 <https://github.com/stellargraph/stellargraph/issues/649>`_ is a severe known bug"
+)
 class RelationalFullBatchNodeGenerator:
     """
     A data generator for use with full-batch models on relational graphs e.g. RGCN.

--- a/stellargraph/mapper/sequences.py
+++ b/stellargraph/mapper/sequences.py
@@ -40,6 +40,7 @@ from tensorflow.keras import backend as K
 from functools import reduce
 from tensorflow.keras.utils import Sequence
 from ..data.unsupervised_sampler import UnsupervisedSampler
+from ..core.experimental import experimental
 from ..core.utils import is_real_iterable
 
 
@@ -463,6 +464,9 @@ class SparseFullBatchNodeSequence(Sequence):
         return self.inputs, self.targets
 
 
+@experimental(
+    reason="`#649 <https://github.com/stellargraph/stellargraph/issues/649>`_ is a severe known bug"
+)
 class RelationalFullBatchNodeSequence(Sequence):
     """
     Keras-compatible data generator for for node inference models on relational graphs

--- a/stellargraph/mapper/sequences.py
+++ b/stellargraph/mapper/sequences.py
@@ -464,9 +464,7 @@ class SparseFullBatchNodeSequence(Sequence):
         return self.inputs, self.targets
 
 
-@experimental(
-    reason="`#649 <https://github.com/stellargraph/stellargraph/issues/649>`_ is a severe known bug"
-)
+@experimental(reason="it has severe known bugs", issues=[649, 677])
 class RelationalFullBatchNodeSequence(Sequence):
     """
     Keras-compatible data generator for for node inference models on relational graphs


### PR DESCRIPTION
This adds a lightweight annotation that can be placed on a function, method or class to automatically adjusts the documentation to include a big warning at the top. The annotation requires a `reason=...` argument to be more specific about why something is experimental, and (optionally) takes a list of issue numbers to link in the `issues=...` argument.

https://external-builds.readthedocs.io/html/stellargraph/685/api.html#stellargraph.core.StellarGraph.adjacency_types

![image](https://user-images.githubusercontent.com/1203825/72483141-1c370e80-3854-11ea-9764-beb552e147bc.png)

https://external-builds.readthedocs.io/html/stellargraph/685/api.html#module-stellargraph.layer.rgcn

![image](https://user-images.githubusercontent.com/1203825/72483762-41c51780-3856-11ea-8df4-8b4787168c0b.png)


This change also spells out a basic checklist for promoting something out of "experimental".

Finally, to serve as examples, the annotation is used on some `StellarGraph` methods, and also on the RGCN layers and generators (due to #649 and #677).

Why use an annotation? There's two basic approaches that we discussed on #617:

1. annotation (+ documentation)
2. `experimental` submodules (e.g. `stellargraph.layers.experimental`)

Despite some consensus on approach 2, this PR takes approach 1, because it can be applied to individual methods, require fewer changes and file movements than 2 (as code moves in and out of experimental-ness), and, even if we take approach 2, having this annotation to automatically fill out the docs would still be nice. =

However, approach 2 is more visible in code, as a reminder that things may break: for example, `from stellargraph.layers.experimental import RGCN`. The approach here relies on users noticing the annotation in the documentation.


See: #617