### PR TITLE
Move shebang to first line of format_notebooks.py

### DIFF
--- a/scripts/format_notebooks.py
+++ b/scripts/format_notebooks.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # -*- coding: utf-8 -*-
 #
 # Copyright 2019-2020 Data61, CSIRO
@@ -19,7 +21,6 @@ The StellarGraph class that encapsulates information required for
 a machine-learning ready graph used by models.
 
 """
-#!/usr/bin/env python3
 import argparse
 import nbformat
 import re


### PR DESCRIPTION
A shebang only works if it's the very first line of the file.