### PR TITLE
Remove some now unnecessary create_graph_schema calls

### DIFF
--- a/stellargraph/mapper/full_batch_generators.py
+++ b/stellargraph/mapper/full_batch_generators.py
@@ -148,11 +148,8 @@ class FullBatchNodeGenerator:
         else:
             self.use_sparse = sparse
 
-        # We need a schema to check compatibility with GAT, GCN
-        self.schema = G.create_graph_schema(create_type_maps=True)
-
         # Check that there is only a single node type for GAT or GCN
-        if len(self.schema.node_types) > 1:
+        if len(G.node_types) > 1:
             raise TypeError(
                 "{}: node generator requires graph with single node type; "
                 "a graph with multiple node types is passed. Stopping.".format(

--- a/stellargraph/mapper/mini_batch_node_generators.py
+++ b/stellargraph/mapper/mini_batch_node_generators.py
@@ -115,11 +115,8 @@ class ClusterNodeGenerator:
 
         self.node_list = list(G.nodes())
 
-        # We need a schema to check compatibility with ClusterGCN
-        self.schema = G.create_graph_schema(create_type_maps=True)
-
         # Check that there is only a single node type
-        if len(self.schema.node_types) > 1:
+        if len(G.node_types) > 1:
             raise ValueError(
                 "{}: node generator requires graph with single node type; "
                 "a graph with multiple node types is passed. Stopping.".format(


### PR DESCRIPTION
The list of node types is now directly available on a graph and so we do not need to construct a schema to query it. For our current networkx graphs, this is a full scan over all the nodes, which is suboptimal... but computing the graph schema was strictly worse (multiple full scans over all nodes and all edges).