### PR TITLE
Remove GraphSchema node-type look-ups

### DIFF
--- a/stellargraph/core/graph_networkx.py
+++ b/stellargraph/core/graph_networkx.py
@@ -700,9 +700,9 @@ class NetworkXStellarGraph(StellarGraph):
             edge_type_map = {
                 (src, tgt, key): edge_types.index(
                     EdgeType(
-                        node_types[node_type_map[src]],
+                        self.node_type(src),
                         self._get_edge_type(data),
-                        node_types[node_type_map[tgt]],
+                        self.node_type(tgt),
                     )
                 )
                 for src, tgt, key, data in self._graph.edges(keys=True, data=True)

--- a/stellargraph/core/graph_networkx.py
+++ b/stellargraph/core/graph_networkx.py
@@ -711,11 +711,7 @@ class NetworkXStellarGraph(StellarGraph):
             edge_type_map = None
 
         return GraphSchema(
-            self.is_directed(),
-            node_types,
-            edge_types,
-            schema,
-            edge_type_map,
+            self.is_directed(), node_types, edge_types, schema, edge_type_map,
         )
 
     ######################################################################

--- a/stellargraph/core/graph_networkx.py
+++ b/stellargraph/core/graph_networkx.py
@@ -697,9 +697,6 @@ class NetworkXStellarGraph(StellarGraph):
         # Note: we encode the type index, in the assumption it will take
         # less storage.
         if create_type_maps:
-            node_type_map = {
-                n: node_types.index(self.node_type(n)) for n in self.nodes()
-            }
             edge_type_map = {
                 (src, tgt, key): edge_types.index(
                     EdgeType(
@@ -711,14 +708,13 @@ class NetworkXStellarGraph(StellarGraph):
                 for src, tgt, key, data in self._graph.edges(keys=True, data=True)
             }
         else:
-            node_type_map = edge_type_map = None
+            edge_type_map = None
 
         return GraphSchema(
             self.is_directed(),
             node_types,
             edge_types,
             schema,
-            node_type_map,
             edge_type_map,
         )
 

--- a/stellargraph/core/schema.py
+++ b/stellargraph/core/schema.py
@@ -21,6 +21,7 @@ from ..core.utils import is_real_iterable
 
 EdgeType = namedtuple("EdgeType", "n1 rel n2")
 
+
 class GraphSchema:
     """
     Class to encapsulate the schema information for a heterogeneous graph.
@@ -29,9 +30,7 @@ class GraphSchema:
     :func:`~stellargraph.core.graph.create_graph_schema` method.
     """
 
-    def __init__(
-        self, is_directed, node_types, edge_types, schema, edge_type_map
-    ):
+    def __init__(self, is_directed, node_types, edge_types, schema, edge_type_map):
         self._is_directed = is_directed
         self.node_types = node_types
         self.edge_types = edge_types

--- a/stellargraph/core/schema.py
+++ b/stellargraph/core/schema.py
@@ -37,13 +37,13 @@ class GraphSchema:
         self.schema = schema
         self.edge_type_map = edge_type_map
 
-    def __getattr__(self, attr):
+    def __getattr__(self, item):
         try:
             return super().__getattribute__(item)
         except AttributeError as e:
             if attr in ("node_type_map", "get_node_type"):
                 raise AttributeError(
-                    f"{e.args[0]}. Access node types through 'StellarGraph.node_type'."
+                    f"{e.args[0]}. This has been replaced by accessing node types through 'StellarGraph.node_type'."
                 )
             # not something we know about
             raise

--- a/stellargraph/core/schema.py
+++ b/stellargraph/core/schema.py
@@ -41,7 +41,7 @@ class GraphSchema:
         try:
             return super().__getattribute__(item)
         except AttributeError as e:
-            if attr in ("node_type_map", "get_node_type"):
+            if item in ("node_type_map", "get_node_type"):
                 raise AttributeError(
                     f"{e.args[0]}. This has been replaced by accessing node types through 'StellarGraph.node_type'."
                 )

--- a/stellargraph/core/schema.py
+++ b/stellargraph/core/schema.py
@@ -21,7 +21,6 @@ from ..core.utils import is_real_iterable
 
 EdgeType = namedtuple("EdgeType", "n1 rel n2")
 
-
 class GraphSchema:
     """
     Class to encapsulate the schema information for a heterogeneous graph.
@@ -31,14 +30,24 @@ class GraphSchema:
     """
 
     def __init__(
-        self, is_directed, node_types, edge_types, schema, node_type_map, edge_type_map
+        self, is_directed, node_types, edge_types, schema, edge_type_map
     ):
         self._is_directed = is_directed
         self.node_types = node_types
         self.edge_types = edge_types
         self.schema = schema
-        self.node_type_map = node_type_map
         self.edge_type_map = edge_type_map
+
+    def __getattr__(self, attr):
+        try:
+            return super().__getattribute__(item)
+        except AttributeError as e:
+            if attr in ("node_type_map", "get_node_type"):
+                raise AttributeError(
+                    f"{e.args[0]}. Access node types through 'StellarGraph.node_type'."
+                )
+            # not something we know about
+            raise
 
     def __repr__(self):
         s = "{}:\n".format(type(self).__name__)
@@ -85,34 +94,6 @@ class GraphSchema:
             raise ValueError("Edge key '{}' not found.".format(edge_type))
 
         return index
-
-    def get_node_type(self, node, index=False):
-        """
-        Returns the type of the node specified either by
-        node ID.
-
-        Args:
-            node: The node ID from the original graph
-            index: Return a numeric type index if True,
-                otherwise return the type name.
-
-        Returns:
-            A node type name or index
-        """
-        # TODO: deprecate this function
-        if self.node_type_map is None:
-            raise RuntimeError("Node type maps not enabled")
-
-        try:
-            nt = self.node_type_map[node]
-            node_type = nt if index else self.node_types[nt]
-
-        except IndexError:
-            warnings.warn(
-                "Node key '{}' not found in type map.".format(node), RuntimeWarning
-            )
-            node_type = None
-        return node_type
 
     def is_of_edge_type(self, edge, edge_type, index=False):
         """

--- a/stellargraph/data/explorer.py
+++ b/stellargraph/data/explorer.py
@@ -604,7 +604,7 @@ class SampledHeterogeneousBreadthFirstWalk(GraphWalk):
                 walk = list()  # the list of nodes in the subgraph of node
 
                 # Start the walk by adding the head node, and node type to the frontier list q
-                node_type = self.graph_schema.get_node_type(node)
+                node_type = self.graph.node_type(node)
                 q.extend([(node, node_type, 0)])
 
                 # add the root node to the walks

--- a/tests/core/test_schema.py
+++ b/tests/core/test_schema.py
@@ -38,7 +38,6 @@ def example_graph_schema():
             node_types=sorted(schema.keys()),
             edge_types=sorted(set(it.chain(*schema.values()))),
             schema=schema,
-            node_type_map=None,
             edge_type_map=None,
         )
 

--- a/tests/core/test_stellargraph.py
+++ b/tests/core/test_stellargraph.py
@@ -141,10 +141,6 @@ def test_graph_schema():
     assert len(schema.schema["movie"]) == 1
     assert len(schema.schema["user"]) == 1
 
-    # Test node type lookup
-    for n, ndata in g.nodes(data=True):
-        assert ndata["label"] == schema.get_node_type(n)
-
     # Test edge type lookup
     node_labels = nx.get_node_attributes(g, "label")
     for n1, n2, k, edata in g.edges(keys=True, data=True):
@@ -171,10 +167,6 @@ def test_graph_schema_sampled():
     assert len(schema.schema["movie"]) == 1
     assert len(schema.schema["user"]) == 1
 
-    # Node and edge type lookups will fail with no type maps
-    with pytest.raises(RuntimeError):
-        schema.get_node_type(0)
-
     with pytest.raises(RuntimeError):
         schema.get_edge_type((4, 0, 0))
 
@@ -189,10 +181,6 @@ def test_digraph_schema():
     assert len(schema.schema["user"]) == 1
     assert len(schema.schema["movie"]) == 0
 
-    # Test node type lookup
-    for n, ndata in g.nodes(data=True):
-        assert ndata["label"] == schema.get_node_type(n)
-
     # Test edge type lookup
     node_labels = nx.get_node_attributes(g, "label")
     for n1, n2, k, edata in g.edges(keys=True, data=True):
@@ -203,6 +191,17 @@ def test_digraph_schema():
     assert schema.get_edge_type((4, 0, 0)) == ("user", "rating", "movie")
     with pytest.raises(IndexError):
         schema.get_edge_type((0, 4, 0))
+
+
+def test_schema_removals():
+    sg = create_graph_1()
+    schema = sg.create_graph_schema(create_type_maps=True)
+
+    with pytest.raises(AttributeError, match="'StellarGraph.node_type'"):
+        _ = schema.node_type_maps
+
+    with pytest.raises(AttributeError, match="'StellarGraph.node_type'"):
+        _ = schema.get_node_type
 
 
 def test_get_index_for_nodes():

--- a/tests/core/test_stellargraph.py
+++ b/tests/core/test_stellargraph.py
@@ -198,7 +198,7 @@ def test_schema_removals():
     schema = sg.create_graph_schema(create_type_maps=True)
 
     with pytest.raises(AttributeError, match="'StellarGraph.node_type'"):
-        _ = schema.node_type_maps
+        _ = schema.node_type_map
 
     with pytest.raises(AttributeError, match="'StellarGraph.node_type'"):
         _ = schema.get_node_type

--- a/tests/mapper/test_node_mappers.py
+++ b/tests/mapper/test_node_mappers.py
@@ -453,7 +453,7 @@ def test_hinnodemapper_level_2():
         assert bf.shape[0] == batch_size
         assert bf.shape[2] == feature_sizes[nt]
 
-        batch_node_types = {schema.get_node_type(n) for n in np.ravel(bf)}
+        batch_node_types = {G.node_type(n) for n in np.ravel(bf)}
 
         assert len(batch_node_types) == 1
         assert nt in batch_node_types


### PR DESCRIPTION
There's basically the same amount of indirection for `StellarGraph.node_type` as there was for `GraphSchema.get_node_type`, so this is not much slower. It makes construction of a type like `GraphSAGELinkGenerator` ~20% slower than `develop`, likely because the computation of the `edge_type_map` has to do two `dict` look-ups rather than `dict`+`list`; as such, this slowdown is completely recovered (and more) in #703 (the setup benchmarks end up ~30% faster than `develop`). It seems to otherwise have no effect even on other benchmarks of functionality that uses node-types, like `SampledHeterogeneousBreadthFirstWalk`.

In addition, the "GraphSchema" seems like it should be a summary of the graph, rather than containing information about individual elements, and thus having this per-node API in it is suboptimal.

This applies a "deprecation"/removal notice to future look-ups of these attributes.

This simplification helps with #662, by reducing the API surface that has to be reimplemented.