### PR TITLE
Convert two more test graphs to use new StellarGraph

### DIFF
--- a/stellargraph/core/element_data.py
+++ b/stellargraph/core/element_data.py
@@ -59,11 +59,11 @@ class ExternalIdIndex:
         """
         return id in self._index
 
-    def is_missing(self, ilocs: np.ndarray) -> np.ndarray:
+    def is_valid(self, ilocs: np.ndarray) -> np.ndarray:
         """
-        Flags the locations of any ilocs that are missing (that is, to_iloc failed).
+        Flags the locations of all the ilocs that are valid (that is, where to_iloc didn't fail).
         """
-        return (ilocs < 0) | (ilocs >= len(self))
+        return (0 <= ilocs) & (ilocs < len(self))
 
     def to_iloc(self, ids, smaller_type=True) -> np.ndarray:
         """

--- a/stellargraph/core/element_data.py
+++ b/stellargraph/core/element_data.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import itertools
+from collections import defaultdict
 
 import numpy as np
 import pandas as pd

--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -437,8 +437,9 @@ class StellarGraph:
         return self._nodes.ids.from_iloc(ilocs)
 
     def _key_error_for_missing(self, query_ids, node_ilocs):
-        missing_indices = np.where(self._nodes.ids.is_missing(node_ilocs))
-        missing_values = comma_sep(np.asarray(query_ids)[missing_indices])
+        valid = self._nodes.ids.is_valid(node_ilocs)
+        missing_indices = np.where(~valid)
+        missing_values = np.asarray(query_ids)[missing_indices]
         return KeyError(missing_values)
 
     def node_type(self, node):
@@ -475,7 +476,7 @@ class StellarGraph:
         if self._graph is not None:
             return self._graph.node_types
 
-        return list(self._nodes.types.pandas_index)
+        return set(self._nodes.types.pandas_index)
 
     def node_feature_sizes(self, node_types=None):
         """
@@ -535,12 +536,16 @@ class StellarGraph:
         if self._graph is not None:
             return self._graph.node_features(nodes, node_type)
 
+        nodes = np.asarray(nodes)
+
         node_ilocs = self._nodes.ids.to_iloc(nodes)
+        valid = self._nodes.ids.is_valid(node_ilocs)
+        all_valid = valid.all()
+        valid_ilocs = node_ilocs if all_valid else node_ilocs[valid]
+
         if node_type is None:
-            try:
-                types = np.unique(self._nodes.type_of_iloc(node_ilocs))
-            except IndexError:
-                raise self._key_error_for_missing(nodes, node_ilocs)
+            # infer the type based on the valid nodes
+            types = np.unique(self._nodes.type_of_iloc(valid_ilocs))
 
             if len(types) == 0:
                 raise ValueError(
@@ -551,7 +556,26 @@ class StellarGraph:
 
             node_type = types[0]
 
-        return self._nodes.features(node_type, node_ilocs)
+        if all_valid:
+            return self._nodes.features(node_type, valid_ilocs)
+
+        # If there's some invalid values, they get replaced by zeros; this is designed to allow
+        # models that build fixed-size structures (e.g. GraphSAGE) based on neighbours to fill out
+        # missing neighbours with zeros automatically, using None as a sentinel.
+
+        # FIXME: None as a sentinel forces nodes to have dtype=object even with integer IDs, could
+        # instead use an impossible integer (e.g. 2**64 - 1)
+
+        nones = nodes == None
+        if not (nones | valid).all():
+            # every ID should be either valid or None, otherwise it was a completely unknown ID
+            raise self._key_error_for_missing(nodes[~nones], node_ilocs[~nones])
+
+        sampled = self._nodes.features(node_type, valid_ilocs)
+        features = np.zeros((len(nodes), sampled.shape[1]))
+        features[valid] = sampled
+
+        return features
 
     ##################################################################
     # Computationally intensive methods:
@@ -639,7 +663,9 @@ class StellarGraph:
             for node_label, node_data in graph_schema.items()
         }
 
-        return GraphSchema(self.is_directed(), self.node_types, edge_types, schema)
+        return GraphSchema(
+            self.is_directed(), sorted(self.node_types), edge_types, schema
+        )
 
     def node_degrees(self) -> Mapping[Any, int]:
         """

--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -325,13 +325,14 @@ class StellarGraph:
             if weights is not None:
                 weights = weights[correct_type]
 
+        # FIXME(#718): it would be better to return these as ndarrays, instead of (zipped) lists
         if weights is not None:
             return [
                 NeighbourWithWeight(node, weight)
                 for node, weight in zip(other_node_id, weights)
             ]
 
-        return other_node_id
+        return list(other_node_id)
 
     def neighbors(
         self, node: Any, include_edge_weight=False, edge_types=None

--- a/stellargraph/data/explorer.py
+++ b/stellargraph/data/explorer.py
@@ -203,7 +203,7 @@ class UniformRandomWalk(GraphWalk):
         current_node = start_node
         for _ in range(length - 1):
             neighbours = self.neighbors(current_node)
-            if not neighbours:
+            if not len(neighbours):
                 # dead end, so stop
                 break
             else:

--- a/stellargraph/data/explorer.py
+++ b/stellargraph/data/explorer.py
@@ -203,7 +203,7 @@ class UniformRandomWalk(GraphWalk):
         current_node = start_node
         for _ in range(length - 1):
             neighbours = self.neighbors(current_node)
-            if not len(neighbours):
+            if not neighbours:
                 # dead end, so stop
                 break
             else:

--- a/tests/core/test_stellargraph.py
+++ b/tests/core/test_stellargraph.py
@@ -212,69 +212,45 @@ def test_schema_removals():
 
 
 def test_get_index_for_nodes():
-    sg = example_graph_2(feature_name="feature", feature_size=8)
+    sg = example_graph_2(feature_size=8)
     aa = sg._get_index_for_nodes([1, 2, 3, 4])
-    assert aa == [0, 1, 2, 3]
+    assert list(aa) == [0, 1, 2, 3]
 
-    sg = example_hin_1(feature_name="feature")
+    sg = example_hin_1(feature_sizes={})
     aa = sg._get_index_for_nodes([0, 1, 2, 3])
-    assert aa == [0, 1, 2, 3]
+    assert list(aa) == [0, 1, 2, 3]
     aa = sg._get_index_for_nodes([0, 1, 2, 3], "A")
-    assert aa == [0, 1, 2, 3]
+    assert list(aa) == [0, 1, 2, 3]
     aa = sg._get_index_for_nodes([4, 5, 6])
-    assert aa == [0, 1, 2]
+    assert list(aa) == [4, 5, 6]
     aa = sg._get_index_for_nodes([4, 5, 6], "B")
-    assert aa == [0, 1, 2]
-    with pytest.raises(ValueError):
-        aa = sg._get_index_for_nodes([1, 2, 5])
+    assert list(aa) == [4, 5, 6]
+    aa = sg._get_index_for_nodes([1, 2, 5])
+    assert list(aa) == [1, 2, 5]
 
 
 def test_feature_conversion_from_nodes():
-    sg = example_graph_2(feature_name="feature", feature_size=8)
+    sg = example_graph_2(feature_size=8)
     aa = sg.node_features([1, 2, 3, 4])
     assert aa[:, 0] == pytest.approx([1, 2, 3, 4])
 
     assert aa.shape == (4, 8)
     assert sg.node_feature_sizes()["default"] == 8
 
-    sg = example_hin_1(
-        feature_name="feature",
-        for_nodes=[0, 1, 2, 3, 4, 5],
-        feature_sizes={"A": 4, "B": 2},
-    )
-    aa = sg.node_features([0, 1, 2, 3], "A")
-    assert aa[:, 0] == pytest.approx([0, 1, 2, 3])
-    assert aa.shape == (4, 4)
 
-    fs = sg.node_feature_sizes()
-    assert fs["A"] == 4
-    assert fs["B"] == 2
-
-    ab = sg.node_features([4, 5], "B")
-    assert ab.shape == (2, 2)
-    assert ab[:, 0] == pytest.approx([4, 5])
-
-    # Test mixed types
-    with pytest.raises(ValueError):
-        ab = sg.node_features([1, 5])
-
-    # Test incorrect manual node_type
-    with pytest.raises(ValueError):
-        ab = sg.node_features([4, 5], "A")
-
-    # Test feature for node with no set attributes
-    ab = sg.node_features([4, 5, 6], "B")
-    assert ab.shape == (3, 2)
-    assert ab[:, 0] == pytest.approx([4, 5, 0])
+def test_node_features_missing_id():
+    sg = example_graph_2(feature_size=6)
+    with pytest.raises(KeyError, match=r"\[1000, 2000\]"):
+        sg.node_features([1, 1000, None, 2000])
 
 
 def test_null_node_feature():
-    sg = example_graph_2(feature_name="feature", feature_size=6)
+    sg = example_graph_2(feature_size=6)
     aa = sg.node_features([1, None, 2, None])
     assert aa.shape == (4, 6)
     assert aa[:, 0] == pytest.approx([1, 0, 2, 0])
 
-    sg = example_hin_1(feature_name="feature", feature_sizes={"A": 4, "B": 2})
+    sg = example_hin_1(feature_sizes={"A": 4, "B": 2})
 
     # Test feature for null node, without node type
     ab = sg.node_features([None, 5, None])
@@ -296,10 +272,10 @@ def test_null_node_feature():
 
 
 def test_node_types():
-    sg = example_graph_2(feature_name="feature", feature_size=6)
+    sg = example_graph_2(feature_size=6)
     assert sg.node_types == {"default"}
 
-    sg = example_hin_1(feature_name="feature", feature_sizes={"A": 4, "B": 2})
+    sg = example_hin_1(feature_sizes={"A": 4, "B": 2})
     assert sg.node_types == {"A", "B"}
 
     sg = example_hin_1()

--- a/tests/mapper/test_node_mappers.py
+++ b/tests/mapper/test_node_mappers.py
@@ -363,7 +363,7 @@ def test_nodemapper_incorrect_targets():
 
 def test_hinnodemapper_constructor():
     feature_sizes = {"A": 10, "B": 10}
-    G = example_hin_1(feature_sizes=feature_sizes, feature_name="feature")
+    G = example_hin_1(feature_sizes=feature_sizes)
 
     # Should fail when head nodes are of different type
     with pytest.raises(ValueError):
@@ -380,7 +380,7 @@ def test_hinnodemapper_constructor():
 
 def test_hinnodemapper_constructor_all_options():
     feature_sizes = {"A": 10, "B": 10}
-    G = example_hin_1(feature_sizes=feature_sizes, feature_name="feature")
+    G = example_hin_1(feature_sizes=feature_sizes)
 
     gen = HinSAGENodeGenerator(G, batch_size=2, num_samples=[2, 2], head_node_type="A")
 

--- a/tests/test_utils/graphs.py
+++ b/tests/test_utils/graphs.py
@@ -67,13 +67,18 @@ def example_graph_1_nx(
     return graph
 
 
+def _repeated_features(values_to_repeat, width):
+    column = np.expand_dims(values_to_repeat, axis=1)
+    return column.repeat(width, axis=1)
+
+
 def example_graph_1(
     feature_size=None, label="default", feature_name="feature", is_directed=False
 ):
     # attr2vec, graphattention, graphsage, node mappers (2), link mappers, types, stellargraph, unsupervised sampler
     elist = pd.DataFrame([(1, 2), (2, 3), (1, 4), (3, 2)], columns=["source", "target"])
     if feature_size is not None:
-        features = np.ones((4, feature_size))
+        features = _repeated_features(np.ones(4), feature_size)
     else:
         features = []
 
@@ -83,21 +88,17 @@ def example_graph_1(
     return cls(nodes={label: nodes}, edges={label: elist})
 
 
-def example_graph_2(feature_size=None, label="default", feature_name="feature"):
+def example_graph_2(feature_size=None, label="default") -> StellarGraph:
     # unsupervised sampler, link mapper
-    graph = nx.Graph()
-    elist = [(1, 2), (2, 3), (1, 4), (4, 2)]
-    graph.add_edges_from(elist)
-    graph.add_nodes_from([1, 2, 3, 4], label=label)
-    graph.add_edges_from(elist, label=label)
-
-    # Add example features
+    elist = pd.DataFrame([(1, 2), (2, 3), (1, 4), (4, 2)], columns=["source", "target"])
+    nodes = [1, 2, 3, 4]
     if feature_size is not None:
-        for v in graph.nodes():
-            graph.nodes[v][feature_name] = int(v) * np.ones(feature_size)
+        features = _repeated_features(nodes, feature_size)
+    else:
+        features = []
 
-    graph = StellarGraph(graph, node_features=feature_name)
-    return graph
+    nodes = pd.DataFrame(features, index=nodes)
+    return StellarGraph(nodes={label: nodes}, edges={label: elist})
 
 
 def example_hin_1_nx(feature_name=None, for_nodes=None, feature_sizes=None):
@@ -122,15 +123,26 @@ def example_hin_1_nx(feature_name=None, for_nodes=None, feature_sizes=None):
     return graph
 
 
-def example_hin_1(feature_name=None, for_nodes=None, feature_sizes=None):
-    # stellargraph, hinsage
-    graph = example_hin_1_nx(feature_name, for_nodes, feature_sizes)
+def example_hin_1(feature_sizes=None) -> StellarGraph:
+    def features(label, ids):
+        if feature_sizes is None:
+            return []
+        else:
+            feature_size = feature_sizes.get(label, 10)
+            return _repeated_features(ids, feature_size)
 
-    # Add some numeric node attributes
-    if feature_name is not None:
-        return StellarGraph(graph, node_features=feature_name)
-    else:
-        return StellarGraph(graph)
+    a_ids = [0, 1, 2, 3]
+    a = pd.DataFrame(features("A", a_ids), index=a_ids)
+
+    b_ids = [4, 5, 6]
+    b = pd.DataFrame(features("B", b_ids), index=b_ids)
+
+    r = pd.DataFrame(
+        [(0, 4), (1, 4), (1, 5), (2, 4), (3, 5)], columns=["source", "target"]
+    )
+    f = pd.DataFrame([(4, 5)], columns=["source", "target"], index=[6])
+
+    return StellarGraph(nodes={"A": a, "B": b}, edges={"R": r, "F": f})
 
 
 def create_test_graph_nx(is_directed=False):


### PR DESCRIPTION
There's a few adjustments required here to make this work by matching the existing behaviour:

- `node_types` needs to return a `set`
- `node_features` needs to support `None` as an ID, which gets filled out as a zero vector
- the node types in `GraphSchema` should be a sorted list
- `neighbours`, `in_nodes` and `out_nodes` should return a `list`, not an `numpy.ndarray` (changing this is #718)

See: #717