### PR TITLE
Implement _adjacency_types for the new StellarGraph

### DIFF
--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -924,9 +924,9 @@ class StellarGraph:
                 triples[other_triple][tgt].append(src)
 
         for subdict in triples.values():
-            for k, v in subdict.items():
+            for v in subdict.values():
                 # each list should be in order, to ensure sampling methods are deterministic
-                subdict[k] = sorted(v, key=str)
+                v.sort(key=str)
 
         return triples
 

--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -931,6 +931,11 @@ class StellarGraph:
                     other_triple_dict[src].append(tgt)
                     other_triple_dict[tgt].append(src)
 
+        for subdict in triples.values():
+            for k, v in subdict.items():
+                # each list should be in order, to ensure sampling methods are deterministic
+                subdict[k] = sorted(v, key=str)
+
         return triples
 
     def _edge_weights(self, source_node: Any, target_node: Any) -> List[Any]:

--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -917,19 +917,11 @@ class StellarGraph:
         )
         for src_type, rel_type, tgt_type, src, tgt in iterator:
             triple = EdgeType(src_type, rel_type, tgt_type)
-            triple_dict = triples[triple]
-            triple_dict[src].append(tgt)
+            triples[triple][src].append(tgt)
 
             if not self.is_directed() and src != tgt:
-                # non-self loop in an undirected graph, so we should add the other direction too
-                triple_dict[tgt].append(src)
-
                 other_triple = EdgeType(tgt_type, rel_type, src_type)
-                if other_triple != triple:
-                    # the edge type differs too, so we need to add its other direction
-                    other_triple_dict = triples[other_triple]
-                    other_triple_dict[src].append(tgt)
-                    other_triple_dict[tgt].append(src)
+                triples[other_triple][tgt].append(src)
 
         for subdict in triples.values():
             for k, v in subdict.items():

--- a/tests/core/test_stellargraph.py
+++ b/tests/core/test_stellargraph.py
@@ -745,17 +745,9 @@ def test_adjacency_types_undirected():
     g = example_hin_1(is_directed=False)
     adj = g._adjacency_types(g.create_graph_schema(create_type_maps=True))
 
-    arb_bra = {
-        0: [4],
-        1: [4, 5],
-        2: [4],
-        3: [5],
-        4: [0, 1, 2],
-        5: [1, 3],
-    }
     assert adj == {
-        ("A", "R", "B"): arb_bra,
-        ("B", "R", "A"): arb_bra,
+        ("A", "R", "B"): {0: [4], 1: [4, 5], 2: [4], 3: [5]},
+        ("B", "R", "A"): {4: [0, 1, 2], 5: [1, 3]},
         ("B", "F", "B"): {4: [5], 5: [4]},
     }
 

--- a/tests/core/test_stellargraph.py
+++ b/tests/core/test_stellargraph.py
@@ -413,7 +413,8 @@ def test_edges_include_edge_type():
 
     r = {(src, dst, "R") for src, dst in [(0, 4), (1, 4), (1, 5), (2, 4), (3, 5)]}
     f = {(4, 5, "F")}
-    assert set(g.edges(include_edge_type=True)) == r | f
+    expected = normalize_edges(r | f, directed=False)
+    assert normalize_edges(g.edges(include_edge_type=True), directed=False) == expected
 
 
 def numpy_to_list(x):
@@ -757,6 +758,7 @@ def test_adjacency_types_undirected():
         ("B", "R", "A"): arb_bra,
         ("B", "F", "B"): {4: [5], 5: [4]},
     }
+
 
 def test_adjacency_types_directed():
     g = example_hin_1(is_directed=True)

--- a/tests/core/test_stellargraph.py
+++ b/tests/core/test_stellargraph.py
@@ -738,3 +738,32 @@ def test_info_heterogeneous():
 
     assert " A-R->B: [5]"
     assert " B-F->B: [1]"
+
+
+def test_adjacency_types_undirected():
+    g = example_hin_1(is_directed=False)
+    adj = g._adjacency_types(g.create_graph_schema(create_type_maps=True))
+
+    arb_bra = {
+        0: [4],
+        1: [4, 5],
+        2: [4],
+        3: [5],
+        4: [0, 1, 2],
+        5: [1, 3],
+    }
+    assert adj == {
+        ("A", "R", "B"): arb_bra,
+        ("B", "R", "A"): arb_bra,
+        ("B", "F", "B"): {4: [5], 5: [4]},
+    }
+
+def test_adjacency_types_directed():
+    g = example_hin_1(is_directed=True)
+    adj = g._adjacency_types(g.create_graph_schema(create_type_maps=True))
+
+    assert adj == {
+        ("A", "R", "B"): {1: [4, 5], 2: [4]},
+        ("B", "R", "A"): {4: [0], 5: [3]},
+        ("B", "F", "B"): {4: [5]},
+    }

--- a/tests/test_utils/graphs.py
+++ b/tests/test_utils/graphs.py
@@ -142,7 +142,7 @@ def example_hin_1(feature_sizes=None, is_directed=False) -> StellarGraph:
     b = pd.DataFrame(features("B", b_ids), index=b_ids)
 
     r = pd.DataFrame(
-        [(4, 0), (1, 4), (1, 5), (2, 4), (5, 3)], columns=["source", "target"]
+        [(4, 0), (1, 5), (1, 4), (2, 4), (5, 3)], columns=["source", "target"]
     )
     f = pd.DataFrame([(4, 5)], columns=["source", "target"], index=[6])
 

--- a/tests/test_utils/graphs.py
+++ b/tests/test_utils/graphs.py
@@ -127,7 +127,7 @@ def example_hin_1_nx(feature_name=None, for_nodes=None, feature_sizes=None):
     return graph
 
 
-def example_hin_1(feature_sizes=None) -> StellarGraph:
+def example_hin_1(feature_sizes=None, is_directed=False) -> StellarGraph:
     def features(label, ids):
         if feature_sizes is None:
             return []
@@ -142,11 +142,12 @@ def example_hin_1(feature_sizes=None) -> StellarGraph:
     b = pd.DataFrame(features("B", b_ids), index=b_ids)
 
     r = pd.DataFrame(
-        [(0, 4), (1, 4), (1, 5), (2, 4), (3, 5)], columns=["source", "target"]
+        [(4, 0), (1, 4), (1, 5), (2, 4), (5, 3)], columns=["source", "target"]
     )
     f = pd.DataFrame([(4, 5)], columns=["source", "target"], index=[6])
 
-    return StellarGraph(nodes={"A": a, "B": b}, edges={"R": r, "F": f})
+    cls = StellarDiGraph if is_directed else StellarGraph
+    return cls(nodes={"A": a, "B": b}, edges={"R": r, "F": f})
 
 
 def create_test_graph_nx(is_directed=False):


### PR DESCRIPTION
This function is used by `SampledHeterogeneousBreadthFirstWalk`. I've manually verified that this matches the existing behaviour (the test doesn't pass with the old type because it has explicit entries for the ones with a `[]` list whereas the new form leaves those implicit, as part of the `defaultdict` lookup).

See: #716