### PR TITLE
Build the package in the conda section of release procedure

### DIFF
--- a/RELEASE_PROCEDURE.md
+++ b/RELEASE_PROCEDURE.md
@@ -78,10 +78,11 @@
      ```
    - Build package
      ```shell
-     conda build . --output
+     conda build .
      ```
    - Upload to Anaconda Cloud in the “stellargraph” organization
      ```shell
+     conda build . --output # find the path to the package
      anaconda login
      anaconda upload -u stellargraph /path/to/conda-package.tar.bz2
      ```


### PR DESCRIPTION
The `--output` argument to `conda build` switches it from "build the package" to "just print the path to the package", meaning the procedure hadn't done the build step.