### PR TITLE
pin to tensorflow<2.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ URL = "https://github.com/stellargraph/stellargraph"
 # full tensorflow is too big for readthedocs's builder
 tensorflow = "tensorflow-cpu" if "READTHEDOCS" in os.environ else "tensorflow"
 REQUIRES = [
-    f"{tensorflow}>=2.0.0",
+    f"{tensorflow}>=2.0.0, <2.1.0",
     "numpy>=1.14",
     "scipy>=1.1.0",
     "networkx>=2.2",

--- a/setup.py
+++ b/setup.py
@@ -21,10 +21,8 @@ DESCRIPTION = "Python library for machine learning on graphs"
 URL = "https://github.com/stellargraph/stellargraph"
 
 # Required packages
-# full tensorflow is too big for readthedocs's builder
-tensorflow = "tensorflow-cpu" if "READTHEDOCS" in os.environ else "tensorflow"
 REQUIRES = [
-    f"{tensorflow}>=2.0.0, <2.1.0",
+    "tensorflow>=2.0.0, <2.1.0",
     "numpy>=1.14",
     "scipy>=1.1.0",
     "networkx>=2.2",


### PR DESCRIPTION
While we investigate bugs related to tensorflow 2.1 (#692 and #626), we should release with tensorflow 2.0.x

Note: this PR has to remove the change for #631 since there's no tensorflow-cpu package for 2.0.x