### PR TITLE
Add cell timeout option and correct documentation for scripts/format_notebooks

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -17,42 +17,14 @@ pip install .[test]
 
 The script `format_notebooks.py` uses `nbconvert` to process all code and output cells in the specified locations optionally remove Tensorflow warnings and stderr outputs, format and number the code cells, and set the kernel to the default of "Python 3".
 
-The usage is available with the `--help` command line argument:
-
+The usage options are available with the `--help` command line argument:
 ```
 > format_notebooks.py --help
-
-usage: format_notebooks.py [-h] [-w] [-c] [-e [EXECUTE]] [-t CELL_TIMEOUT]
-                           [-n] [-k] [-d] [-o] [--html]
-                           locations [locations ...]
-
-Format and clean Jupyter notebooks by removing Tensorflow warnings and stderr
-outputs, formatting and numbering the code cells, and setting the kernel. See
-the options below to select which of these operations is performed.
-
-positional arguments:
-  locations             Paths(s) to search for Jupyter notebooks to format
-
-optional arguments:
-  -h, --help            show this help message and exit
-  -w, --clear_warnings  Clear Tensorflow warnings and stderr in output
-  -c, --format_code     Format all code cells (currently uses black)
-  -e [EXECUTE], --execute [EXECUTE]
-                        Execute notebook before export with specified kernel
-                        (default if not given)
-  -t CELL_TIMEOUT, --cell_timeout CELL_TIMEOUT
-                        Set the execution cell timeout in seconds (default is
-                        timeout disabled)
-  -n, --renumber        Renumber all code cells from the top, regardless of
-                        execution order
-  -k, --set_kernel      Set kernel spec to default 'Python 3'
-  -d, --default         Perform default formatting, equivalent to -wcnk
-  -o, --overwrite       Overwrite original notebooks, otherwise a copy will be
-                        made with a .mod suffix
-  --html                Save HTML as well as notebook output
 ```
 
-For example, to perform all formatting on all Jupyter notebooks found in the demos directory, execute the following command in the top-level stellargraph directory:
+#### Example usage
+
+To perform all formatting on all Jupyter notebooks found in the demos directory, execute the following command in the top-level stellargraph directory:
 ```
 > python scripts/format_notebooks.py -d demos
 ```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -22,7 +22,8 @@ The usage is available with the `--help` command line argument:
 ```
 > format_notebooks.py --help
 
-usage: format_notebooks.py [-h] [-w] [-c] [-n] [-k] [-a] [-o] [--html]
+usage: format_notebooks.py [-h] [-w] [-c] [-e [EXECUTE]] [-t CELL_TIMEOUT]
+                           [-n] [-k] [-d] [-o] [--html]
                            locations [locations ...]
 
 Format and clean Jupyter notebooks by removing Tensorflow warnings and stderr
@@ -36,10 +37,16 @@ optional arguments:
   -h, --help            show this help message and exit
   -w, --clear_warnings  Clear Tensorflow warnings and stderr in output
   -c, --format_code     Format all code cells (currently uses black)
+  -e [EXECUTE], --execute [EXECUTE]
+                        Execute notebook before export with specified kernel
+                        (default if not given)
+  -t CELL_TIMEOUT, --cell_timeout CELL_TIMEOUT
+                        Set the execution cell timeout in seconds (default is
+                        timeout disabled)
   -n, --renumber        Renumber all code cells from the top, regardless of
                         execution order
   -k, --set_kernel      Set kernel spec to default 'Python 3'
-  -a, --all             Perform all formatting, equivalent to -wcnk
+  -d, --default         Perform default formatting, equivalent to -wcnk
   -o, --overwrite       Overwrite original notebooks, otherwise a copy will be
                         made with a .mod suffix
   --html                Save HTML as well as notebook output
@@ -48,12 +55,12 @@ optional arguments:
 For example, to perform all formatting on all Jupyter notebooks found in the demos directory, execute the following command in the top-level stellargraph directory:
 
 ```
-> python scripts/format_notebooks.py -a demos
+> python scripts/format_notebooks.py -d demos
 ```
 
 To additionally output HTML files:
 ```
-> python scripts/format_notebooks.py -a --html demos
+> python scripts/format_notebooks.py -d --html demos
 ```
 
 ### Testing demo Jupyter notebooks

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -15,7 +15,7 @@ pip install .[test]
 
 ### Format and clean up demo Jupyter notebooks
 
-The script `format_notebooks.py` uses `nbconvert` to process all code and output cells in the specified locations optionally remove Tensorflow warnings and stderr outputs, format and number the code cells, and set the kernel to the default of "Python 3".
+The script `format_notebooks.py` uses `nbconvert` to process all code and output cells in the specified locations, optionally remove Tensorflow warnings and stderr outputs, format and number the code cells, and set the kernel to the default of "Python 3".
 
 The usage options are available with the `--help` command line argument:
 ```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -53,7 +53,6 @@ optional arguments:
 ```
 
 For example, to perform all formatting on all Jupyter notebooks found in the demos directory, execute the following command in the top-level stellargraph directory:
-
 ```
 > python scripts/format_notebooks.py -d demos
 ```
@@ -61,6 +60,11 @@ For example, to perform all formatting on all Jupyter notebooks found in the dem
 To additionally output HTML files:
 ```
 > python scripts/format_notebooks.py -d --html demos
+```
+
+To format and execute all Jupyter notebooks found in the demos directory, overwriting them with the updated versions:
+```
+> python scripts/format_notebooks.py -e -o -d demos
 ```
 
 ### Testing demo Jupyter notebooks

--- a/scripts/format_notebooks.py
+++ b/scripts/format_notebooks.py
@@ -148,9 +148,15 @@ if __name__ == "__main__":
         "-e",
         "--execute",
         nargs="?",
-        default=None,
         const="default",
         help="Execute notebook before export with specified kernel (default if not given)",
+    )
+    parser.add_argument(
+        "-t",
+        "--cell_timeout",
+        default=-1,
+        type=int,
+        help="Set the execution cell timeout in seconds (default is timeout disabled)",
     )
     parser.add_argument(
         "-n",
@@ -194,6 +200,7 @@ if __name__ == "__main__":
     renumber_code = args.renumber or args.default
     set_kernel = args.set_kernel or args.default
     execute_code = args.execute
+    cell_timeout = args.cell_timeout
 
     # Add preprocessors
     preprocessor_list = []
@@ -217,8 +224,10 @@ if __name__ == "__main__":
     c.NotebookExporter.preprocessors = preprocessor_list
     c.HTMLExporter.preprocessors = preprocessor_list
 
-    if execute_code and execute_code != "default":
-        c.ExecutePreprocessor.kernel_name = execute_code
+    if execute_code:
+        c.ExecutePreprocessor.timeout = cell_timeout
+        if execute_code != "default":
+            c.ExecutePreprocessor.kernel_name = execute_code
 
     nb_exporter = NotebookExporter(c)
     html_exporter = HTMLExporter(c)


### PR DESCRIPTION
The documentation for `scripts/format_notebooks.py` incorrectly documented the -a option, which should be -d . (also the embedded output from --help was outdated).  

In addition, the 'execute' option didn't work for any of the demo notebooks, which would timeout and fail due to a default execution timeout of 30s per cell.  This is now unlimited by default (even 600s is too short for some of our demo notebooks), but can be configured via an option.