### PR TITLE
Rename `triple` arg to `include_edge_type`, in StellarGraph.edges

### DIFF
--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -265,23 +265,23 @@ class StellarGraph:
 
         return self._nodes.ids.pandas_index
 
-    def edges(self, triple=False) -> Iterable[Any]:
+    def edges(self, include_edge_type=False) -> Iterable[Any]:
         """
         Obtains the collection of edges in the graph.
 
         Args:
-            triple (bool): A flag that indicates whether to return edge triples
+            include_edge_type (bool): A flag that indicates whether to return edge triples
             of format (node 1, node 2, edge type) or edge pairs of format (node 1, node 2).
 
         Returns:
             The graph edges.
         """
         if self._graph is not None:
-            return self._graph.edges(triple)
+            return self._graph.edges(include_edge_type)
 
         # FIXME: these would be better returned as the 2 or 3 arrays directly, rather than tuple-ing
         # (the same applies to all other instances of zip in this file)
-        if triple:
+        if include_edge_type:
             return list(
                 zip(
                     self._edges.sources,

--- a/stellargraph/core/graph_networkx.py
+++ b/stellargraph/core/graph_networkx.py
@@ -650,7 +650,7 @@ class NetworkXStellarGraph(StellarGraph):
         """
         if nodes is None:
             nodes = self.nodes()
-            edges = self.edges(triple=True)
+            edges = self.edges(include_edge_type=True)
         else:
             edges = (
                 (src, dst, self._get_edge_type(data))
@@ -709,8 +709,8 @@ class NetworkXStellarGraph(StellarGraph):
     def nodes(self) -> Iterable[Any]:
         return self._graph.nodes()
 
-    def edges(self, triple=False) -> Iterable[Any]:
-        if triple:
+    def edges(self, include_edge_type=False) -> Iterable[Any]:
+        if include_edge_type:
             # returns triples of format (node 1, node 2, edge type)
             return (
                 (src, dst, self._get_edge_type(data))

--- a/stellargraph/mapper/full_batch_generators.py
+++ b/stellargraph/mapper/full_batch_generators.py
@@ -428,7 +428,7 @@ class RelationalFullBatchNodeGenerator:
 
         self.features = G.node_features(self.node_list)
 
-        edge_types = sorted(set(e[-1] for e in G.edges(triple=True)))
+        edge_types = sorted(set(e[-1] for e in G.edges(include_edge_type=True)))
         self.node_index = dict(zip(self.node_list, range(len(self.node_list))))
 
         # create a list of adjacency matrices - one adj matrix for each edge type
@@ -439,12 +439,12 @@ class RelationalFullBatchNodeGenerator:
 
             col_index = [
                 self.node_index[n1]
-                for n1, n2, etype in G.edges(triple=True)
+                for n1, n2, etype in G.edges(include_edge_type=True)
                 if etype == edge_type
             ]
             row_index = [
                 self.node_index[n2]
-                for n1, n2, etype in G.edges(triple=True)
+                for n1, n2, etype in G.edges(include_edge_type=True)
                 if etype == edge_type
             ]
             data = np.ones(len(col_index), np.float64)

--- a/tests/core/test_stellargraph.py
+++ b/tests/core/test_stellargraph.py
@@ -431,12 +431,12 @@ def test_feature_conversion_from_iterator():
     assert ab[:, 0] == pytest.approx([4, 5])
 
 
-def test_edges_triple():
+def test_edges_include_edge_type():
     g = example_hin_1()
 
     r = {(src, dst, "R") for src, dst in [(0, 4), (1, 4), (1, 5), (2, 4), (3, 5)]}
     f = {(4, 5, "F")}
-    assert set(g.edges(triple=True)) == r | f
+    assert set(g.edges(include_edge_type=True)) == r | f
 
 
 def normalise_nodes(g, default_label=False):

--- a/tests/layer/test_rgcn.py
+++ b/tests/layer/test_rgcn.py
@@ -360,7 +360,7 @@ def test_RelationalGraphConvolution_edge_cases():
 
 def get_edge_types(G):
     assert isinstance(G, StellarGraph)
-    return sorted(set(etype for _, _, etype in G.edges(triple=True)))
+    return sorted(set(etype for _, _, etype in G.edges(include_edge_type=True)))
 
 
 def get_As(G):
@@ -372,12 +372,12 @@ def get_As(G):
     for edge_type in edge_types:
         col_index = [
             node_index[n1]
-            for n1, n2, etype in G.edges(triple=True)
+            for n1, n2, etype in G.edges(include_edge_type=True)
             if etype == edge_type
         ]
         row_index = [
             node_index[n2]
-            for n1, n2, etype in G.edges(triple=True)
+            for n1, n2, etype in G.edges(include_edge_type=True)
             if etype == edge_type
         ]
         data = np.ones(len(col_index), np.float64)

--- a/tests/mapper/test_relational_node_mappers.py
+++ b/tests/mapper/test_relational_node_mappers.py
@@ -46,7 +46,7 @@ class Test_RelationalFullBatchNodeGenerator:
 
     G, features = create_graph_features()
     N = len(G.nodes())
-    edge_types = sorted(set(e[-1] for e in G.edges(triple=True)))
+    edge_types = sorted(set(e[-1] for e in G.edges(include_edge_type=True)))
     num_relationships = len(edge_types)
 
     def test_generator_constructor(self):
@@ -168,18 +168,18 @@ class Test_RelationalFullBatchNodeGenerator:
         assert generator.name == "test"
 
         As = []
-        edge_types = sorted(set(e[-1] for e in G.edges(triple=True)))
+        edge_types = sorted(set(e[-1] for e in G.edges(include_edge_type=True)))
         node_list = list(G.nodes())
         node_index = dict(zip(node_list, range(len(node_list))))
         for edge_type in edge_types:
             col_index = [
                 node_index[n1]
-                for n1, n2, etype in G.edges(triple=True)
+                for n1, n2, etype in G.edges(include_edge_type=True)
                 if etype == edge_type
             ]
             row_index = [
                 node_index[n2]
-                for n1, n2, etype in G.edges(triple=True)
+                for n1, n2, etype in G.edges(include_edge_type=True)
                 if etype == edge_type
             ]
             data = np.ones(len(col_index), np.float64)


### PR DESCRIPTION
`triple` is somewhat of a term of art, but it's a bit generic, which means it is both:

- ambiguous: it could be read as referring to the edge-weight, and
- non-extensible: it is unclear how we'd generalise to returning both edge-type and edge-weight (one possibility would be to specify both `triple=True` and `include_edge_weight=True`, but returning "quadruples" when `triple=True` is a bit misleading)

This renames the argument to be specific to remove the ambiguity.