### PR TITLE
Switch back to better `not <list>` instead of `not len(<list>)`

### DIFF
--- a/stellargraph/data/explorer.py
+++ b/stellargraph/data/explorer.py
@@ -203,7 +203,7 @@ class UniformRandomWalk(GraphWalk):
         current_node = start_node
         for _ in range(length - 1):
             neighbours = self.neighbors(current_node)
-            if not len(neighbours):
+            if not neighbours:
                 # dead end, so stop
                 break
             else:


### PR DESCRIPTION
This was originally introduced when neighbors switched to returning a numpy
array in #719, but that change was reverted. Unfortunately it wasn't correctly
reverted in #710 too, so it ended up landing anyway. This undoes that mistake.