### PR TITLE
Use numpy to accelerate create_graph_schema()

### DIFF
--- a/tests/core/test_stellargraph.py
+++ b/tests/core/test_stellargraph.py
@@ -211,10 +211,13 @@ def test_schema_removals():
     ):
         sg.create_graph_schema(create_type_maps=True)
 
+
 @pytest.mark.benchmark(group="StellarGraph create_graph_schema")
 @pytest.mark.parametrize("num_types", [1, 4])
 def test_benchmark_graph_schema(benchmark, num_types):
-    nodes, edges = example_benchmark_graph(n_nodes=1000, n_edges=5000, n_types=num_types)
+    nodes, edges = example_benchmark_graph(
+        n_nodes=1000, n_edges=5000, n_types=num_types
+    )
     sg = StellarGraph(nodes=nodes, edges=edges)
 
     benchmark(sg.create_graph_schema)

--- a/tests/core/test_stellargraph.py
+++ b/tests/core/test_stellargraph.py
@@ -211,6 +211,14 @@ def test_schema_removals():
     ):
         sg.create_graph_schema(create_type_maps=True)
 
+@pytest.mark.benchmark(group="StellarGraph create_graph_schema")
+@pytest.mark.parametrize("num_types", [1, 4])
+def test_benchmark_graph_schema(benchmark, num_types):
+    nodes, edges = example_benchmark_graph(n_nodes=1000, n_edges=5000, n_types=num_types)
+    sg = StellarGraph(nodes=nodes, edges=edges)
+
+    benchmark(sg.create_graph_schema)
+
 
 def test_get_index_for_nodes():
     sg = example_graph_2(feature_size=8)


### PR DESCRIPTION
`create_graph_schema()` is a core method that powers a lot of other code, so it's nice if it goes as fast as possible. We can do the same numpy analytics that we did in `info` in #710. This now shares a lot of code with `info`.

It would probably be best to just have the `GraphSchema` store the counts directly (rather than have `info` have to recompute them), however, doing this now would require updating both the new StellarGraph and the NetworkX one, so this improvement can wait for #715 and the removal of the latter.

The included benchmark uses on 1k nodes, 5k edges and says (times in milliseconds):

| # types | code    |  min |   max | mean | stddev | median |  iqr |
|--------:|---------|-----:|------:|-----:|-------:|-------:|-----:|
|       1 | this PR |  967 |  2410 | 1160 |    140 |   1150 |  113 |
|         | develop | 7840 | 11300 | 8920 |    640 |   8980 | 1000 |
|       4 | this PR | 3450 |  4620 | 4080 |    179 |   4100 |  143 |
|         | develop | 7730 |  9900 | 8740 |    544 |   8680 |  650 |

That is, it's ~8× faster for homogeneous graphs, and 2× for a graph with 4 node types (and thus likely `4 * 1 * 4 = 16` edge type triples, since the edges are completely random).