### PR TITLE
Update meta.yml with hash for 0.9.0

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -10,7 +10,7 @@ package:
 
 source:
   url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
-  sha256: c9e5a69bb94e4edcbde544fed1c07861b432c6b07b1d8a7d63ca8f40892a246e
+  sha256: caecc5eab0e8dcd0949435446573bfb019dd73c80df6cfedadce69e6664fb50c
 
 build:
   noarch: python


### PR DESCRIPTION
This was updated in order for conda build to work correctly with
the new release.