### PR TITLE
Add include_edge_weight to StellarGraph.edges

### DIFF
--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -221,7 +221,7 @@ class StellarGraph:
             self._is_directed = is_directed
 
             self._nodes = convert.convert_nodes(
-                nodes, name="nodes", default_type=node_type_default, dtype=dtype
+                nodes, name="nodes", default_type=node_type_default, dtype=dtype,
             )
             self._edges = convert.convert_edges(
                 edges,
@@ -869,7 +869,9 @@ class StellarGraph:
             features = self.node_features(node_ids, node_type=ty)
 
             for node_id, node_features in zip(node_ids, features):
-                graph.add_node(node_id, **ty_dict, **{feature_name: node_features})
+                graph.add_node(
+                    node_id, **ty_dict, **{feature_name: node_features},
+                )
 
         iterator = zip(
             self._edges.sources,

--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -221,7 +221,7 @@ class StellarGraph:
             self._is_directed = is_directed
 
             self._nodes = convert.convert_nodes(
-                nodes, name="nodes", default_type=node_type_default, dtype=dtype,
+                nodes, name="nodes", default_type=node_type_default, dtype=dtype
             )
             self._edges = convert.convert_edges(
                 edges,
@@ -303,19 +303,31 @@ class StellarGraph:
 
         return self._nodes.ids.pandas_index
 
-    def edges(self, include_edge_type=False) -> Iterable[Any]:
+    def edges(
+        self, include_edge_type=False, include_edge_weight=False
+    ) -> Iterable[Any]:
         """
         Obtains the collection of edges in the graph.
 
         Args:
-            include_edge_type (bool): A flag that indicates whether to return edge triples
+            include_edge_type (bool): A flag that indicates whether to return edge types
             of format (node 1, node 2, edge type) or edge pairs of format (node 1, node 2).
+            include_edge_weight (bool): A flag that indicates whether to return edge weights.
+            Weights are returned in a separate list.
 
         Returns:
-            The graph edges.
+            The graph edges. If edge weights are included then a tuple of (edges, weights)
         """
         if self._graph is not None:
-            return self._graph.edges(include_edge_type)
+            return self._graph.edges(
+                include_edge_weight=include_edge_weight,
+                include_edge_type=include_edge_type,
+            )
+
+        if include_edge_weight:
+            raise NotImplementedError(
+                "see https://github.com/stellargraph/stellargraph/issues/716"
+            )
 
         # FIXME: these would be better returned as the 2 or 3 arrays directly, rather than tuple-ing
         # (the same applies to all other instances of zip in this file)
@@ -852,9 +864,7 @@ class StellarGraph:
             features = self.node_features(node_ids, node_type=ty)
 
             for node_id, node_features in zip(node_ids, features):
-                graph.add_node(
-                    node_id, **ty_dict, **{feature_name: node_features},
-                )
+                graph.add_node(node_id, **ty_dict, **{feature_name: node_features})
 
         iterator = zip(
             self._edges.sources,

--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -332,15 +332,20 @@ class StellarGraph:
         # FIXME: these would be better returned as the 2 or 3 arrays directly, rather than tuple-ing
         # (the same applies to all other instances of zip in this file)
         if include_edge_type:
-            return list(
+            edges = list(
                 zip(
                     self._edges.sources,
                     self._edges.targets,
                     self._edges.type_of_iloc(slice(None)),
                 )
             )
+        else:
+            edges = list(zip(self._edges.sources, self._edges.targets))
 
-        return list(zip(self._edges.sources, self._edges.targets))
+        if include_edge_weight:
+            return edges, self._edges.weights
+
+        return edges
 
     def has_node(self, node: Any) -> bool:
         """

--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -324,11 +324,6 @@ class StellarGraph:
                 include_edge_type=include_edge_type,
             )
 
-        if include_edge_weight:
-            raise NotImplementedError(
-                "see https://github.com/stellargraph/stellargraph/issues/716"
-            )
-
         # FIXME: these would be better returned as the 2 or 3 arrays directly, rather than tuple-ing
         # (the same applies to all other instances of zip in this file)
         if include_edge_type:

--- a/stellargraph/core/graph_networkx.py
+++ b/stellargraph/core/graph_networkx.py
@@ -709,16 +709,29 @@ class NetworkXStellarGraph(StellarGraph):
     def nodes(self) -> Iterable[Any]:
         return self._graph.nodes()
 
-    def edges(self, include_edge_type=False) -> Iterable[Any]:
+    def edges(
+        self, include_edge_type=False, include_edge_weight=False
+    ) -> Iterable[Any]:
         if include_edge_type:
             # returns triples of format (node 1, node 2, edge type)
-            return (
+            edges = (
                 (src, dst, self._get_edge_type(data))
                 for src, dst, data in self._graph.edges(data=True)
             )
         else:
             # returns pairs of format (node 1, node 2)
-            return self._graph.edges()
+            edges = self._graph.edges()
+
+        if include_edge_weight:
+            return (
+                edges,
+                [
+                    data.get(self._edge_weight_label)
+                    for _, _, data in self._graph.edges(data=True)
+                ],
+            )
+        else:
+            return edges
 
     def has_node(self, node: Any) -> bool:
         return self._graph.__contains__(node)

--- a/stellargraph/core/graph_networkx.py
+++ b/stellargraph/core/graph_networkx.py
@@ -723,13 +723,13 @@ class NetworkXStellarGraph(StellarGraph):
             edges = self._graph.edges()
 
         if include_edge_weight:
-            return (
-                edges,
+            weights = np.array(
                 [
                     data.get(self._edge_weight_label)
                     for _, _, data in self._graph.edges(data=True)
-                ],
+                ]
             )
+            return edges, weights
         else:
             return edges
 

--- a/tests/core/test_stellargraph.py
+++ b/tests/core/test_stellargraph.py
@@ -738,3 +738,13 @@ def test_info_heterogeneous():
 
     assert " A-R->B: [5]"
     assert " B-F->B: [1]"
+
+
+def test_edges_include_weights():
+    g = example_weighted_hin()
+    edges, weights = g.edges(include_edge_weight=True)
+    nxg = g.to_networkx()
+    assert len(edges) == len(weights) == len(nxg.edges())
+    for (src, dst), w in zip(edges, weights):
+        # check weight matches an edge in multi-edges
+        assert w in {data["weight"] for data in nxg.get_edge_data(src, dst).values()}


### PR DESCRIPTION
Some unrelated trailing commas got removed by black, it still seems to pass our black format CI step, so not really sure what's going on there but I'll look into it further.

Given this FIXME in `StellarGraph.edges` currently:
```
        # FIXME: these would be better returned as the 2 or 3 arrays directly, rather than tuple-ing
        # (the same applies to all other instances of zip in this file)
```
I decided it might be best to just return weights as a separate list - it should have no impact on existing code, and avoids the weirdness of returning longer tuples described in #751 