### PR TITLE
Compute the correct adjacency matrix for undirected graphs

### DIFF
--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -810,7 +810,7 @@ class StellarGraph:
         n = len(index)
 
         adj = sps.csr_matrix((weights, (src_idx, tgt_idx)), shape=(n, n))
-        if not self.is_directed:
+        if not self.is_directed():
             # in an undirected graph, the adjacency matrix should be symmetric: which means counting
             # weights from either "incoming" or "outgoing" edges, but not double-counting self loops
             backward = sps.csr_matrix((weights, (tgt_idx, src_idx)), shape=(n, n))

--- a/tests/core/test_stellargraph.py
+++ b/tests/core/test_stellargraph.py
@@ -761,3 +761,55 @@ def test_adjacency_types_directed():
         ("B", "R", "A"): {4: [0], 5: [3]},
         ("B", "F", "B"): {4: [5]},
     }
+
+
+def test_to_adjacency_matrix_undirected():
+    g = example_hin_1(is_directed=False, self_loop=True, weights=True)
+
+    matrix = g.to_adjacency_matrix().todense()
+    actual = np.zeros((7, 7), dtype=matrix.dtype)
+    actual[0, 4] = actual[4, 0] = 1
+    actual[1, 5] = actual[5, 1] = 1
+    actual[1, 4] = actual[4, 1] = 1
+    actual[2, 4] = actual[4, 2] = 1
+    actual[3, 5] = actual[5, 3] = 1
+    actual[4, 5] = actual[5, 4] = 10
+    actual[5, 5] = 11 + 12
+    assert np.array_equal(matrix, actual)
+
+    # just to confirm, it should be symmetric
+    assert np.array_equal(matrix, matrix.T)
+
+    # use a funny order to verify order
+    subgraph = g.to_adjacency_matrix([1, 6, 5]).todense()
+    # indices are relative to the specified list
+    one, six, five = 0, 1, 2
+    actual = np.zeros((3, 3), dtype=subgraph.dtype)
+    actual[one, five] = actual[five, one] = 1
+    actual[five, five] = 11 + 12
+    assert np.array_equal(subgraph, actual)
+
+
+def test_to_adjacency_matrix_directed():
+    g = example_hin_1(is_directed=True, self_loop=True, weights=True)
+
+    matrix = g.to_adjacency_matrix().todense()
+    actual = np.zeros((7, 7))
+    actual[4, 0] = 1
+    actual[1, 5] = 1
+    actual[1, 4] = 1
+    actual[2, 4] = 1
+    actual[5, 3] = 1
+    actual[4, 5] = 10
+    actual[5, 5] = 11 + 12
+
+    assert np.array_equal(matrix, actual)
+
+    # use a funny order to verify order
+    subgraph = g.to_adjacency_matrix([1, 6, 5]).todense()
+    # indices are relative to the specified list
+    one, six, five = 0, 1, 2
+    actual = np.zeros((3, 3), dtype=subgraph.dtype)
+    actual[one, five] = 1
+    actual[five, five] = 11 + 12
+    assert np.array_equal(subgraph, actual)

--- a/tests/core/test_stellargraph.py
+++ b/tests/core/test_stellargraph.py
@@ -764,7 +764,7 @@ def test_adjacency_types_directed():
 
 
 def test_to_adjacency_matrix_undirected():
-    g = example_hin_1(is_directed=False, self_loop=True, weights=True)
+    g = example_hin_1(is_directed=False, self_loop=True)
 
     matrix = g.to_adjacency_matrix().todense()
     actual = np.zeros((7, 7), dtype=matrix.dtype)
@@ -791,7 +791,7 @@ def test_to_adjacency_matrix_undirected():
 
 
 def test_to_adjacency_matrix_directed():
-    g = example_hin_1(is_directed=True, self_loop=True, weights=True)
+    g = example_hin_1(is_directed=True, self_loop=True)
 
     matrix = g.to_adjacency_matrix().todense()
     actual = np.zeros((7, 7))

--- a/tests/core/test_stellargraph.py
+++ b/tests/core/test_stellargraph.py
@@ -464,7 +464,7 @@ def test_to_networkx(has_features):
 
     edge_def = {"R": [(0, 4), (1, 4), (1, 5), (2, 4), (3, 5)], "F": [(4, 5)]}
     expected_edges = [
-        (src, tgt, {"label": label, "weight": 1.0})
+        (src, tgt, {"label": label, "weight": 1.0 if label == "R" else 10.0})
         for label, pairs in edge_def.items()
         for src, tgt in pairs
     ]

--- a/tests/test_utils/graphs.py
+++ b/tests/test_utils/graphs.py
@@ -127,7 +127,9 @@ def example_hin_1_nx(feature_name=None, for_nodes=None, feature_sizes=None):
     return graph
 
 
-def example_hin_1(feature_sizes=None, is_directed=False) -> StellarGraph:
+def example_hin_1(
+    feature_sizes=None, is_directed=False, self_loop=False, weights=True
+) -> StellarGraph:
     def features(label, ids):
         if feature_sizes is None:
             return []
@@ -144,7 +146,21 @@ def example_hin_1(feature_sizes=None, is_directed=False) -> StellarGraph:
     r = pd.DataFrame(
         [(4, 0), (1, 5), (1, 4), (2, 4), (5, 3)], columns=["source", "target"]
     )
-    f = pd.DataFrame([(4, 5)], columns=["source", "target"], index=[6])
+    f_edges, f_index = [(4, 5)], [6]
+    if self_loop:
+        # make it a multigraph
+        f_edges.extend([(5, 5), (5, 5)])
+        f_index.extend([7, 8])
+
+    # add some weights for the f edges, but not others
+    if weights:
+        f_columns = ["source", "target", "weight"]
+        for i, src_tgt in enumerate(f_edges):
+            f_edges[i] = src_tgt + (10 + i,)
+    else:
+        f_columns = ["source", "target"]
+
+    f = pd.DataFrame(f_edges, columns=f_columns, index=f_index)
 
     cls = StellarDiGraph if is_directed else StellarGraph
     return cls(nodes={"A": a, "B": b}, edges={"R": r, "F": f})

--- a/tests/test_utils/graphs.py
+++ b/tests/test_utils/graphs.py
@@ -128,7 +128,7 @@ def example_hin_1_nx(feature_name=None, for_nodes=None, feature_sizes=None):
 
 
 def example_hin_1(
-    feature_sizes=None, is_directed=False, self_loop=False, weights=True
+    feature_sizes=None, is_directed=False, self_loop=False
 ) -> StellarGraph:
     def features(label, ids):
         if feature_sizes is None:
@@ -153,12 +153,9 @@ def example_hin_1(
         f_index.extend([7, 8])
 
     # add some weights for the f edges, but not others
-    if weights:
-        f_columns = ["source", "target", "weight"]
-        for i, src_tgt in enumerate(f_edges):
-            f_edges[i] = src_tgt + (10 + i,)
-    else:
-        f_columns = ["source", "target"]
+    f_columns = ["source", "target", "weight"]
+    for i, src_tgt in enumerate(f_edges):
+        f_edges[i] = src_tgt + (10 + i,)
 
     f = pd.DataFrame(f_edges, columns=f_columns, index=f_index)
 


### PR DESCRIPTION
A function is always truthy (e.g. `bool(lambda: None)` => `True`), so missing the method call parentheses in `self.is_directed()` meant we were treating all graphs as directed.

This adds tests for both undirected and directed graphs, and verifies the behaviour of:

- weighted edges: appear in the adjacency matrix as the weights, not 1s
- self-loops: only counted once, in undirected graphs
- repeated edges: weights are summed

See: #763 