### PR TITLE
All neighbours are in- and out-neighbours in undirected new StellarGraphs

### DIFF
--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -425,6 +425,12 @@ class StellarGraph:
                 node, include_edge_weight=include_edge_weight, edge_types=edge_types
             )
 
+        if not self.is_directed():
+            # all edges are both incoming and outgoing for undirected graphs
+            return self.neighbors(
+                node, include_edge_weight=include_edge_weight, edge_types=edge_types
+            )
+
         ilocs = self._edges.edge_ilocs(node, ins=True, outs=False)
         source = self._edges.sources[ilocs]
         return self._transform_edges(source, ilocs, include_edge_weight, edge_types)
@@ -449,6 +455,12 @@ class StellarGraph:
         """
         if self._graph is not None:
             return self._graph.out_nodes(
+                node, include_edge_weight=include_edge_weight, edge_types=edge_types
+            )
+
+        if not self.is_directed():
+            # all edges are both incoming and outgoing for undirected graphs
+            return self.neighbors(
                 node, include_edge_weight=include_edge_weight, edge_types=edge_types
             )
 

--- a/tests/core/test_stellargraph.py
+++ b/tests/core/test_stellargraph.py
@@ -608,12 +608,19 @@ def test_allocation_benchmark_creation(
 
 
 def example_weighted_hin(is_directed=True):
-    graph = nx.MultiDiGraph() if is_directed else nx.MultiGraph()
-    graph.add_nodes_from([0, 1], label="A")
-    graph.add_nodes_from([2, 3], label="B")
-    graph.add_weighted_edges_from([(0, 1, 0.0), (0, 1, 1.0)], label="AA")
-    graph.add_weighted_edges_from([(1, 2, 10.0), (1, 3, 10.0)], label="AB")
-    return StellarDiGraph(graph) if is_directed else StellarGraph(graph)
+    edge_cols = ["source", "target", "weight"]
+    cls = StellarDiGraph if is_directed else StellarGraph
+    return cls(
+        nodes={"A": pd.DataFrame(index=[0, 1]), "B": pd.DataFrame(index=[2, 3])},
+        edges={
+            "AA": pd.DataFrame(
+                [(0, 1, 0.0), (0, 1, 1.0)], columns=edge_cols, index=[0, 1]
+            ),
+            "AB": pd.DataFrame(
+                [(1, 2, 10.0), (1, 3, 10.0)], columns=edge_cols, index=[2, 3]
+            ),
+        },
+    )
 
 
 def example_unweighted_hom(is_directed=True):


### PR DESCRIPTION
The docs for `in_nodes` and `out_nodes` explicitly state

> For an undirected graph, neighbours are treated as both in-nodes and out-nodes.

but the new `StellarGraph` class did not match this.

See: #766