### PR TITLE
Use an integer-typed array for isolated nodes in new StellarGraph

### DIFF
--- a/stellargraph/core/element_data.py
+++ b/stellargraph/core/element_data.py
@@ -306,7 +306,11 @@ class EdgeData(ElementData):
         self._edges_in_dict = _numpyise(in_dict)
         self._edges_out_dict = _numpyise(out_dict)
         self._edges_dict = _numpyise(undirected)
-        self._empty_ids = self.sources[0:0]
+
+        # when there's no neighbors for something, an empty array should be returned; this uses a
+        # tiny dtype to minimise unnecessary type promotion (e.g. if this is used with an int32
+        # array, the result will still be int32).
+        self._empty_ilocs = np.array([], dtype=np.uint8)
 
     def _adj_lookup(self, *, ins, outs):
         if ins and outs:
@@ -371,4 +375,4 @@ class EdgeData(ElementData):
             The integer locations of the edges for the given node_id.
         """
 
-        return self._adj_lookup(ins=ins, outs=outs).get(node_id, self._empty_ids)
+        return self._adj_lookup(ins=ins, outs=outs).get(node_id, self._empty_ilocs)

--- a/tests/core/test_stellargraph.py
+++ b/tests/core/test_stellargraph.py
@@ -715,6 +715,17 @@ def test_out_nodes_unweighted_hom():
     )
 
 
+@pytest.mark.parametrize("is_directed", [False, True])
+def test_isolated_node_neighbor_methods(is_directed):
+    cls = StellarDiGraph if is_directed else StellarGraph
+    graph = cls(
+        nodes=pd.DataFrame(index=[1]), edges=pd.DataFrame(columns=["source", "target"])
+    )
+    assert graph.neighbors(1) == []
+    assert graph.in_nodes(1) == []
+    assert graph.out_nodes(1) == []
+
+
 def test_stellargraph_experimental():
     nodes = pd.DataFrame([], index=[0])
     edges = pd.DataFrame([], columns=["source", "target"])


### PR DESCRIPTION
The old form was from before the new `StellarGraph` element-data storage switched to using "ilocs" everywhere, and so was set to have the same type as the IDs themselves. However, now that the code has switched to ilocs, the `edge_ilocs` method should always return an array with an iloc-esque dtype, that is, an array that can be used to index other arrays.

The choice of `np.uint8` as the dtype is to be as compatible as possible, require minimal type promotions when two arrays of integer dtypes are used together, e.g. the following example does an operation on an "empty_iloc" array, with other arrays of different types, and we can see the resulting dtypes:

```python
>>> empty_ilocs = np.array([], dtype=np.uint8)
>>> np.intersect1d(empty_ilocs, np.array([], dtype=np.uint16))
array([], dtype=uint16)
>>> np.intersect1d(empty_ilocs, np.array([], dtype=np.int64))
array([], dtype=int64)
```

See: #770