### PR TITLE
Only accept one node in new StellarGraph.node_type

### DIFF
--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -501,8 +501,11 @@ class StellarGraph:
 
     def _key_error_for_missing(self, query_ids, node_ilocs):
         valid = self._nodes.ids.is_valid(node_ilocs)
-        missing_indices = np.where(~valid)
-        missing_values = np.asarray(query_ids)[missing_indices]
+        missing_values = np.asarray(query_ids)[~valid]
+
+        if len(missing_values) == 1:
+            return KeyError(missing_values[0])
+
         return KeyError(missing_values)
 
     def node_type(self, node):
@@ -518,15 +521,15 @@ class StellarGraph:
         if self._graph is not None:
             return self._graph.node_type(node)
 
-        if not is_real_iterable(node):
-            node = np.array([node])
-
-        node_ilocs = self._nodes.ids.to_iloc(node)
-
+        nodes = [node]
+        node_ilocs = self._nodes.ids.to_iloc(nodes)
         try:
-            return self._nodes.type_of_iloc(node_ilocs)
+            type_sequence = self._nodes.type_of_iloc(node_ilocs)
         except IndexError:
-            raise self._key_error_for_missing(node, node_ilocs)
+            raise self._key_error_for_missing(nodes, node_ilocs)
+
+        assert len(type_sequence) == 1
+        return type_sequence[0]
 
     @property
     def node_types(self):

--- a/tests/core/test_stellargraph.py
+++ b/tests/core/test_stellargraph.py
@@ -868,3 +868,12 @@ def test_edge_weights_directed():
     assert g._edge_weights(5, 4) == []
     assert g._edge_weights(0, 4) == []
     assert g._edge_weights(4, 0) == [1]
+
+
+def test_node_type():
+    g = example_hin_1()
+    assert g.node_type(0) == "A"
+    assert g.node_type(4) == "B"
+
+    with pytest.raises(KeyError, match="1234"):
+        g.node_type(1234)


### PR DESCRIPTION
Previously this was trying to allow batch queries, but this differed to the old implementation. The new implementation would always return a sequence (pandas.Index) of node types, even if only a single node was queried. This PR switches the new StellarGraph `node_type` method to behave like the old one: accept a single node ID and return a single node type. We can move to batched queries in future (this relates to #718).

See: #775