### PR TITLE
Return a list from `nodes_of_type` in new StellarGraph

### DIFF
--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -497,7 +497,7 @@ class StellarGraph:
             return self.nodes()
 
         ilocs = self._nodes.type_range(node_type)
-        return self._nodes.ids.from_iloc(ilocs)
+        return list(self._nodes.ids.from_iloc(ilocs))
 
     def _key_error_for_missing(self, query_ids, node_ilocs):
         valid = self._nodes.ids.is_valid(node_ilocs)


### PR DESCRIPTION
This matches the old StellarGraph class more closely and is thus more compatible for the switch.