### PR TITLE
Normalise node importance score

### DIFF
--- a/stellargraph/utils/saliency_maps/integrated_gradients.py
+++ b/stellargraph/utils/saliency_maps/integrated_gradients.py
@@ -149,7 +149,8 @@ class IntegratedGradients(GradientSaliency):
         steps=20,
     ):
         """
-        The importance of the node is defined as the sum of all the feature importance of the node.
+        The importance of the node is defined as the sum of all the feature importance of the node,
+        normalised by the number of features.
 
         Args:
             Refer to the parameters in get_integrated_node_masks.
@@ -172,4 +173,4 @@ class IntegratedGradients(GradientSaliency):
             A_val=A_val,
         )
 
-        return np.sum(gradients, axis=-1)
+        return np.sum(gradients, axis=-1) / np.sqrt(gradients.shape[-1])

--- a/stellargraph/utils/saliency_maps/saliency.py
+++ b/stellargraph/utils/saliency_maps/saliency.py
@@ -224,7 +224,7 @@ class GradientSaliency:
         """
         For nodes, the saliency mask we get gives us the importance of each features. For visualization purpose, we may
         want to see a summary of the importance for the node. The importance of each node can be defined as the sum of
-        all the partial gradients w.r.t its features.
+        all the partial gradients w.r.t its features, normalised by the number of features.
 
         Args:
             X_val, A_val, node_idx, class_of_interest: The values to feed while computing the gradients.
@@ -234,4 +234,4 @@ class GradientSaliency:
         gradients = self.get_node_masks(
             node_idx, class_of_interest, X_val=None, A_index=None, A_val=None
         )
-        return np.sum(gradients, axis=1)
+        return np.sum(gradients, axis=1) / np.sqrt(gradients.shape[1])


### PR DESCRIPTION
Node importance was defined as the sum of node feature importances,
making it not directly comparable to link importance values. This
normalises the sum by the number of features to resolve this issue.

See comments in #500 

I've verified on one notebook node-link-importancer-demo-gcn.ipynb that this does in fact give you node importance values that looks a bit more comparable to link importance ones:
![image](https://user-images.githubusercontent.com/33508488/73814981-af9ea680-4838-11ea-9d1f-1860fef5c82e.png)
Previously, the node importance was at least an order of magnitude larger than that.

I'll run and commit all the other interpretability notebooks once the approach has been reviewed