### PR TITLE
Use float32 for new StellarGraph default edge weights

### DIFF
--- a/stellargraph/core/convert.py
+++ b/stellargraph/core/convert.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
 import pandas as pd
 
 from ..globalvar import SOURCE, TARGET, WEIGHT
@@ -122,7 +123,7 @@ def convert_nodes(data, *, name, default_type, dtype) -> NodeData:
     return NodeData(nodes, node_features)
 
 
-DEFAULT_WEIGHT = 1
+DEFAULT_WEIGHT = np.float32(1)
 
 
 def convert_edges(


### PR DESCRIPTION
This requires less memory than numpy's default `np.int64` for an integer like `1` (or `np.float64` for a float like `1.0`), and is generally a better type to be using with tensorflow.

This is confirmed by the benchmarks, e.g. the `test_allocation_benchmark_creation[None-1000-5000]` benchmark goes from 747k on `develop` to 725k with this PR, a reduction of 22k. This is close to the theoretical reduction of 5000 edges &times; 4 bytes/edge = 20k.

(Reopening of https://github.com/stellargraph/stellargraph/pull/779 due to #786.)