### PR TITLE
Handle no nodes and/or no edges in new StellarGraph

### DIFF
--- a/stellargraph/core/element_data.py
+++ b/stellargraph/core/element_data.py
@@ -107,6 +107,8 @@ class ElementData:
         shared (dict of type name to pandas DataFrame): information for the elements of each type
     """
 
+    _SHARED_REQUIRED_COLUMNS = []
+
     def __init__(self, shared):
         if not isinstance(shared, dict):
             raise TypeError(f"shared: expected dict, found {type(shared)}")
@@ -116,6 +118,10 @@ class ElementData:
                 raise TypeError(
                     f"shared[{key!r}]: expected pandas DataFrame', found {type(value)}"
                 )
+
+            require_dataframe_has_columns(
+                f"features[{key!r}]", value, self._SHARED_REQUIRED_COLUMNS
+            )
 
         type_element_ilocs = {}
         rows_so_far = 0
@@ -134,7 +140,11 @@ class ElementData:
             type_sizes.append(size)
             type_dfs.append(type_data)
 
-        all_columns = pd.concat(type_dfs)
+        if type_dfs:
+            all_columns = pd.concat(type_dfs)
+        else:
+            all_columns = pd.DataFrame(columns=self._SHARED_REQUIRED_COLUMNS)
+
         self._id_index = ExternalIdIndex(all_columns.index)
         self._columns = {
             name: data.to_numpy() for name, data in all_columns.iteritems()
@@ -280,13 +290,10 @@ class EdgeData(ElementData):
         node_data (NodeData): the nodes that these edges correspond to
     """
 
+    _SHARED_REQUIRED_COLUMNS = [SOURCE, TARGET, WEIGHT]
+
     def __init__(self, shared, node_data: NodeData):
         super().__init__(shared)
-
-        for key, value in shared.items():
-            require_dataframe_has_columns(
-                f"features[{key!r}]", value, [SOURCE, TARGET, WEIGHT]
-            )
 
         self._nodes = node_data
 

--- a/stellargraph/core/element_data.py
+++ b/stellargraph/core/element_data.py
@@ -107,6 +107,8 @@ class ElementData:
         shared (dict of type name to pandas DataFrame): information for the elements of each type
     """
 
+    # any columns that must be in the `shared` dataframes passed to `__init__` (this should be
+    # overridden by subclasses as appropriate)
     _SHARED_REQUIRED_COLUMNS = []
 
     def __init__(self, shared):

--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -184,7 +184,7 @@ class StellarGraph:
         source_column=globalvar.SOURCE,
         target_column=globalvar.TARGET,
     ):
-        if graph is not None or (nodes is None and edges is None):
+        if graph is not None:
             # While migrating, maintain complete compatibility by deferring to the networkx
             # implementation
 

--- a/tests/core/test_stellargraph.py
+++ b/tests/core/test_stellargraph.py
@@ -100,27 +100,17 @@ def example_benchmark_graph_nx(
 
 
 def test_graph_constructor():
-    sg = StellarGraph()
+    sg = StellarGraph(nodes={}, edges={})
     assert sg.is_directed() == False
-    assert sg._graph._node_type_attr == "label"
-    assert sg._graph._edge_type_attr == "label"
-
-    sg = StellarGraph(node_type_name="type", edge_type_name="type")
-    assert sg.is_directed() == False
-    assert sg._graph._node_type_attr == "type"
-    assert sg._graph._edge_type_attr == "type"
+    assert sg.number_of_nodes() == 0
+    assert sg.number_of_edges() == 0
 
 
 def test_digraph_constructor():
-    sg = StellarDiGraph()
+    sg = StellarDiGraph(nodes={}, edges={})
     assert sg.is_directed() == True
-    assert sg._graph._node_type_attr == "label"
-    assert sg._graph._edge_type_attr == "label"
-
-    sg = StellarDiGraph(node_type_name="type", edge_type_name="type")
-    assert sg.is_directed() == True
-    assert sg._graph._node_type_attr == "type"
-    assert sg._graph._edge_type_attr == "type"
+    assert sg.number_of_nodes() == 0
+    assert sg.number_of_edges() == 0
 
 
 def test_info():

--- a/tests/core/test_stellargraph.py
+++ b/tests/core/test_stellargraph.py
@@ -100,6 +100,11 @@ def example_benchmark_graph_nx(
 
 
 def test_graph_constructor():
+    sg = StellarGraph()
+    assert sg.is_directed() == False
+    assert sg.number_of_nodes() == 0
+    assert sg.number_of_edges() == 0
+
     sg = StellarGraph(nodes={}, edges={})
     assert sg.is_directed() == False
     assert sg.number_of_nodes() == 0
@@ -107,6 +112,11 @@ def test_graph_constructor():
 
 
 def test_digraph_constructor():
+    sg = StellarDiGraph()
+    assert sg.is_directed() == True
+    assert sg.number_of_nodes() == 0
+    assert sg.number_of_edges() == 0
+
     sg = StellarDiGraph(nodes={}, edges={})
     assert sg.is_directed() == True
     assert sg.number_of_nodes() == 0


### PR DESCRIPTION
If there's no node types or no edge types, the code ends up calling `pd.concat([])` which is an error, so this has to be made conditional and appropriately-shaped dataframe created manually.

Now that it works, this also switches the default empty `StellarGraph()` constructor call to use the new `StellarGraph` implementation.

See: #774

(Reopening of #776 due to #786.)