### PR TITLE
fix missing dataset integration into demo notebooks

### DIFF
--- a/.buildkite/steps/test-demo-notebooks.sh
+++ b/.buildkite/steps/test-demo-notebooks.sh
@@ -27,13 +27,11 @@ f=${NOTEBOOKS[$INDEX]}
 case $(basename "$f") in
   'attacks_clustering_analysis.ipynb' | 'hateful-twitters-interpretability.ipynb' | 'hateful-twitters.ipynb' | 'stellargraph-attri2vec-DBLP.ipynb' | \
     'node-link-importance-demo-gat.ipynb' | 'node-link-importance-demo-gcn.ipynb' | 'node-link-importance-demo-gcn-sparse.ipynb' | 'rgcn-aifb-node-classification-example.ipynb' | \
-    'calibration-pubmed-link-prediction.ipynb' | 'ensemble-link-prediction-example.ipynb' | 'movielens-recommender.ipynb' | 'stellargraph-metapath2vec.ipynb' | 'stellargraph-node2vec-weighted-random-walks.ipynb' | 'calibration-pubmed-node-classification.ipynb' | \
-    'ensemble-node-classification-example.ipynb' | 'cora-gcn-links-example.ipynb')
+    'calibration-pubmed-link-prediction.ipynb' | 'ensemble-link-prediction-example.ipynb' | 'movielens-recommender.ipynb' | 'stellargraph-metapath2vec.ipynb' | 'stellargraph-node2vec-weighted-random-walks.ipynb' | 'calibration-pubmed-node-classification.ipynb' )
     # These notebooks do not yet work on CI:
     # FIXME #818: datasets can't be downloaded
     # FIXME #819: out-of-memory
     # FIXME #820: too slow
-    # FIXME #816: missing dataset download
     echo "+++ :python: :skull_and_crossbones: skipping $f"
     exit 2 # this will be a soft-fail for buildkite
     ;;

--- a/.buildkite/steps/test-demo-notebooks.sh
+++ b/.buildkite/steps/test-demo-notebooks.sh
@@ -27,7 +27,7 @@ f=${NOTEBOOKS[$INDEX]}
 case $(basename "$f") in
   'attacks_clustering_analysis.ipynb' | 'hateful-twitters-interpretability.ipynb' | 'hateful-twitters.ipynb' | 'stellargraph-attri2vec-DBLP.ipynb' | \
     'node-link-importance-demo-gat.ipynb' | 'node-link-importance-demo-gcn.ipynb' | 'node-link-importance-demo-gcn-sparse.ipynb' | 'rgcn-aifb-node-classification-example.ipynb' | \
-    'calibration-pubmed-link-prediction.ipynb' | 'ensemble-link-prediction-example.ipynb' | 'movielens-recommender.ipynb' | 'stellargraph-metapath2vec.ipynb' | 'stellargraph-node2vec-weighted-random-walks.ipynb' | 'calibration-pubmed-node-classification.ipynb' )
+    'calibration-pubmed-link-prediction.ipynb' | 'ensemble-link-prediction-example.ipynb' | 'movielens-recommender.ipynb' | 'stellargraph-metapath2vec.ipynb' | 'stellargraph-node2vec-weighted-random-walks.ipynb' | 'calibration-pubmed-node-classification.ipynb' | 'ensembles/ensemble-node-classification-example.ipynb' )
     # These notebooks do not yet work on CI:
     # FIXME #818: datasets can't be downloaded
     # FIXME #819: out-of-memory

--- a/.buildkite/steps/test-demo-notebooks.sh
+++ b/.buildkite/steps/test-demo-notebooks.sh
@@ -27,7 +27,7 @@ f=${NOTEBOOKS[$INDEX]}
 case $(basename "$f") in
   'attacks_clustering_analysis.ipynb' | 'hateful-twitters-interpretability.ipynb' | 'hateful-twitters.ipynb' | 'stellargraph-attri2vec-DBLP.ipynb' | \
     'node-link-importance-demo-gat.ipynb' | 'node-link-importance-demo-gcn.ipynb' | 'node-link-importance-demo-gcn-sparse.ipynb' | 'rgcn-aifb-node-classification-example.ipynb' | \
-    'calibration-pubmed-link-prediction.ipynb' | 'ensemble-link-prediction-example.ipynb' | 'movielens-recommender.ipynb' | 'stellargraph-metapath2vec.ipynb' | 'stellargraph-node2vec-weighted-random-walks.ipynb' | 'calibration-pubmed-node-classification.ipynb' | 'ensembles/ensemble-node-classification-example.ipynb')
+    'calibration-pubmed-link-prediction.ipynb' | 'ensemble-link-prediction-example.ipynb' | 'movielens-recommender.ipynb' | 'stellargraph-metapath2vec.ipynb' | 'stellargraph-node2vec-weighted-random-walks.ipynb' | 'calibration-pubmed-node-classification.ipynb' | 'ensemble-node-classification-example.ipynb')
     # These notebooks do not yet work on CI:
     # FIXME #818: datasets can't be downloaded
     # FIXME #819: out-of-memory

--- a/.buildkite/steps/test-demo-notebooks.sh
+++ b/.buildkite/steps/test-demo-notebooks.sh
@@ -27,7 +27,7 @@ f=${NOTEBOOKS[$INDEX]}
 case $(basename "$f") in
   'attacks_clustering_analysis.ipynb' | 'hateful-twitters-interpretability.ipynb' | 'hateful-twitters.ipynb' | 'stellargraph-attri2vec-DBLP.ipynb' | \
     'node-link-importance-demo-gat.ipynb' | 'node-link-importance-demo-gcn.ipynb' | 'node-link-importance-demo-gcn-sparse.ipynb' | 'rgcn-aifb-node-classification-example.ipynb' | \
-    'calibration-pubmed-link-prediction.ipynb' | 'ensemble-link-prediction-example.ipynb' | 'movielens-recommender.ipynb' | 'stellargraph-metapath2vec.ipynb' | 'stellargraph-node2vec-weighted-random-walks.ipynb' | 'calibration-pubmed-node-classification.ipynb' | 'ensembles/ensemble-node-classification-example.ipynb' )
+    'calibration-pubmed-link-prediction.ipynb' | 'ensemble-link-prediction-example.ipynb' | 'movielens-recommender.ipynb' | 'stellargraph-metapath2vec.ipynb' | 'stellargraph-node2vec-weighted-random-walks.ipynb' | 'calibration-pubmed-node-classification.ipynb' | 'ensembles/ensemble-node-classification-example.ipynb')
     # These notebooks do not yet work on CI:
     # FIXME #818: datasets can't be downloaded
     # FIXME #819: out-of-memory

--- a/demos/ensembles/ensemble-node-classification-example.ipynb
+++ b/demos/ensembles/ensemble-node-classification-example.ipynb
@@ -144,7 +144,9 @@
     "if use_cora:\n",
     "    dataset = datasets.Cora()\n",
     "else:\n",
-    "    dataset = datasets.PubMedDiabetes()"
+    "    dataset = datasets.PubMedDiabetes()\n",
+    "    \n",
+    "dataset.download()"
    ]
   },
   {

--- a/demos/ensembles/ensemble-node-classification-example.ipynb
+++ b/demos/ensembles/ensemble-node-classification-example.ipynb
@@ -145,7 +145,7 @@
     "    dataset = datasets.Cora()\n",
     "else:\n",
     "    dataset = datasets.PubMedDiabetes()\n",
-    "    \n",
+    "\n",
     "dataset.download()"
    ]
   },

--- a/demos/link-prediction/gcn/cora-gcn-links-example.ipynb
+++ b/demos/link-prediction/gcn/cora-gcn-links-example.ipynb
@@ -463,26 +463,9 @@
     {
      "name": "stdout",
      "output_type": "stream",
-     "text": []
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
      "text": [
-      "  ['...']\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  ['...']\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  ['...']\n",
+      "  ['...']\n",
       "\n",
       "Train Set Metrics of the initial (untrained) model:\n",
       "\tloss: 2.4878\n",
@@ -522,690 +505,109 @@
     {
      "name": "stdout",
      "output_type": "stream",
-     "text": []
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
      "text": [
-      "  ['...']\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  ['...']\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  ['...']\n",
+      "  ['...']\n",
       "Train for 1 steps, validate for 1 steps\n",
-      "Epoch 1/50\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1/1 - 0s - loss: 2.4500 - acc: 0.5000 - val_loss: 0.7966 - val_acc: 0.5408\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Epoch 1/50\n",
+      "1/1 - 0s - loss: 2.4500 - acc: 0.5000 - val_loss: 0.7966 - val_acc: 0.5408\n",
       "Epoch 2/50\n",
-      "1/1 - 0s - loss: 0.7856 - acc: 0.5547 - val_loss: 2.9508 - val_acc: 0.5190\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "1/1 - 0s - loss: 0.7856 - acc: 0.5547 - val_loss: 2.9508 - val_acc: 0.5190\n",
       "Epoch 3/50\n",
-      "1/1 - 0s - loss: 3.0601 - acc: 0.5337 - val_loss: 1.3757 - val_acc: 0.5579\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 4/50\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1/1 - 0s - loss: 1.7043 - acc: 0.5653 - val_loss: 0.6728 - val_acc: 0.6252\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 5/50\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1/1 - 0s - loss: 0.6647 - acc: 0.6453 - val_loss: 0.7923 - val_acc: 0.5465\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 6/50\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1/1 - 0s - loss: 0.7591 - acc: 0.5716 - val_loss: 0.9080 - val_acc: 0.5275\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 7/50\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1/1 - 0s - loss: 0.8537 - acc: 0.5389 - val_loss: 0.9219 - val_acc: 0.5313\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 8/50\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1/1 - 0s - loss: 0.8643 - acc: 0.5484 - val_loss: 0.8485 - val_acc: 0.5541\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 9/50\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1/1 - 0s - loss: 0.7806 - acc: 0.5737 - val_loss: 0.7511 - val_acc: 0.5797\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 10/50\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1/1 - 0s - loss: 0.7162 - acc: 0.6095 - val_loss: 0.6848 - val_acc: 0.6148\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 11/50\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1/1 - 0s - loss: 0.7384 - acc: 0.6032 - val_loss: 0.7950 - val_acc: 0.6148\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 12/50\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1/1 - 0s - loss: 0.8312 - acc: 0.6200 - val_loss: 0.8829 - val_acc: 0.6063\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 13/50\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1/1 - 0s - loss: 1.0317 - acc: 0.6453 - val_loss: 0.7606 - val_acc: 0.6290\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 14/50\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1/1 - 0s - loss: 0.7468 - acc: 0.6905 - val_loss: 0.6624 - val_acc: 0.6452\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 15/50\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1/1 - 0s - loss: 0.6501 - acc: 0.6874 - val_loss: 0.6708 - val_acc: 0.6537\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 16/50\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1/1 - 0s - loss: 0.6120 - acc: 0.6884 - val_loss: 0.7092 - val_acc: 0.6271\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 17/50\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1/1 - 0s - loss: 0.6388 - acc: 0.6484 - val_loss: 0.7233 - val_acc: 0.6129\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 18/50\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1/1 - 0s - loss: 0.6867 - acc: 0.6421 - val_loss: 0.7282 - val_acc: 0.5996\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 19/50\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1/1 - 0s - loss: 0.6571 - acc: 0.6695 - val_loss: 0.7257 - val_acc: 0.6091\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 20/50\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1/1 - 0s - loss: 0.7098 - acc: 0.6568 - val_loss: 0.6997 - val_acc: 0.6214\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 21/50\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1/1 - 0s - loss: 0.5992 - acc: 0.6842 - val_loss: 0.6794 - val_acc: 0.6423\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 22/50\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1/1 - 0s - loss: 0.5995 - acc: 0.6884 - val_loss: 0.6709 - val_acc: 0.6537\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 23/50\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1/1 - 0s - loss: 0.5781 - acc: 0.7179 - val_loss: 0.6442 - val_acc: 0.6660\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 24/50\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1/1 - 0s - loss: 0.5729 - acc: 0.7389 - val_loss: 0.6626 - val_acc: 0.6708\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 25/50\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1/1 - 0s - loss: 0.5755 - acc: 0.7453 - val_loss: 0.7080 - val_acc: 0.6736\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 26/50\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1/1 - 0s - loss: 0.6672 - acc: 0.7484 - val_loss: 0.6484 - val_acc: 0.6793\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 27/50\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1/1 - 0s - loss: 0.5816 - acc: 0.7537 - val_loss: 0.6475 - val_acc: 0.6565\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 28/50\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1/1 - 0s - loss: 0.5102 - acc: 0.7347 - val_loss: 0.6499 - val_acc: 0.6461\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 29/50\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1/1 - 0s - loss: 0.5360 - acc: 0.7421 - val_loss: 0.6463 - val_acc: 0.6471\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 30/50\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1/1 - 0s - loss: 0.5270 - acc: 0.7179 - val_loss: 0.6449 - val_acc: 0.6509\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 31/50\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1/1 - 0s - loss: 0.5160 - acc: 0.7263 - val_loss: 0.6381 - val_acc: 0.6575\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "1/1 - 0s - loss: 3.0601 - acc: 0.5337 - val_loss: 1.3757 - val_acc: 0.5579\n",
+      "Epoch 4/50\n",
+      "1/1 - 0s - loss: 1.7043 - acc: 0.5653 - val_loss: 0.6728 - val_acc: 0.6252\n",
+      "Epoch 5/50\n",
+      "1/1 - 0s - loss: 0.6647 - acc: 0.6453 - val_loss: 0.7923 - val_acc: 0.5465\n",
+      "Epoch 6/50\n",
+      "1/1 - 0s - loss: 0.7591 - acc: 0.5716 - val_loss: 0.9080 - val_acc: 0.5275\n",
+      "Epoch 7/50\n",
+      "1/1 - 0s - loss: 0.8537 - acc: 0.5389 - val_loss: 0.9219 - val_acc: 0.5313\n",
+      "Epoch 8/50\n",
+      "1/1 - 0s - loss: 0.8643 - acc: 0.5484 - val_loss: 0.8485 - val_acc: 0.5541\n",
+      "Epoch 9/50\n",
+      "1/1 - 0s - loss: 0.7806 - acc: 0.5737 - val_loss: 0.7511 - val_acc: 0.5797\n",
+      "Epoch 10/50\n",
+      "1/1 - 0s - loss: 0.7162 - acc: 0.6095 - val_loss: 0.6848 - val_acc: 0.6148\n",
+      "Epoch 11/50\n",
+      "1/1 - 0s - loss: 0.7384 - acc: 0.6032 - val_loss: 0.7950 - val_acc: 0.6148\n",
+      "Epoch 12/50\n",
+      "1/1 - 0s - loss: 0.8312 - acc: 0.6200 - val_loss: 0.8829 - val_acc: 0.6063\n",
+      "Epoch 13/50\n",
+      "1/1 - 0s - loss: 1.0317 - acc: 0.6453 - val_loss: 0.7606 - val_acc: 0.6290\n",
+      "Epoch 14/50\n",
+      "1/1 - 0s - loss: 0.7468 - acc: 0.6905 - val_loss: 0.6624 - val_acc: 0.6452\n",
+      "Epoch 15/50\n",
+      "1/1 - 0s - loss: 0.6501 - acc: 0.6874 - val_loss: 0.6708 - val_acc: 0.6537\n",
+      "Epoch 16/50\n",
+      "1/1 - 0s - loss: 0.6120 - acc: 0.6884 - val_loss: 0.7092 - val_acc: 0.6271\n",
+      "Epoch 17/50\n",
+      "1/1 - 0s - loss: 0.6388 - acc: 0.6484 - val_loss: 0.7233 - val_acc: 0.6129\n",
+      "Epoch 18/50\n",
+      "1/1 - 0s - loss: 0.6867 - acc: 0.6421 - val_loss: 0.7282 - val_acc: 0.5996\n",
+      "Epoch 19/50\n",
+      "1/1 - 0s - loss: 0.6571 - acc: 0.6695 - val_loss: 0.7257 - val_acc: 0.6091\n",
+      "Epoch 20/50\n",
+      "1/1 - 0s - loss: 0.7098 - acc: 0.6568 - val_loss: 0.6997 - val_acc: 0.6214\n",
+      "Epoch 21/50\n",
+      "1/1 - 0s - loss: 0.5992 - acc: 0.6842 - val_loss: 0.6794 - val_acc: 0.6423\n",
+      "Epoch 22/50\n",
+      "1/1 - 0s - loss: 0.5995 - acc: 0.6884 - val_loss: 0.6709 - val_acc: 0.6537\n",
+      "Epoch 23/50\n",
+      "1/1 - 0s - loss: 0.5781 - acc: 0.7179 - val_loss: 0.6442 - val_acc: 0.6660\n",
+      "Epoch 24/50\n",
+      "1/1 - 0s - loss: 0.5729 - acc: 0.7389 - val_loss: 0.6626 - val_acc: 0.6708\n",
+      "Epoch 25/50\n",
+      "1/1 - 0s - loss: 0.5755 - acc: 0.7453 - val_loss: 0.7080 - val_acc: 0.6736\n",
+      "Epoch 26/50\n",
+      "1/1 - 0s - loss: 0.6672 - acc: 0.7484 - val_loss: 0.6484 - val_acc: 0.6793\n",
+      "Epoch 27/50\n",
+      "1/1 - 0s - loss: 0.5816 - acc: 0.7537 - val_loss: 0.6475 - val_acc: 0.6565\n",
+      "Epoch 28/50\n",
+      "1/1 - 0s - loss: 0.5102 - acc: 0.7347 - val_loss: 0.6499 - val_acc: 0.6461\n",
+      "Epoch 29/50\n",
+      "1/1 - 0s - loss: 0.5360 - acc: 0.7421 - val_loss: 0.6463 - val_acc: 0.6471\n",
+      "Epoch 30/50\n",
+      "1/1 - 0s - loss: 0.5270 - acc: 0.7179 - val_loss: 0.6449 - val_acc: 0.6509\n",
+      "Epoch 31/50\n",
+      "1/1 - 0s - loss: 0.5160 - acc: 0.7263 - val_loss: 0.6381 - val_acc: 0.6575\n",
       "Epoch 32/50\n",
-      "1/1 - 0s - loss: 0.5078 - acc: 0.7232 - val_loss: 0.6515 - val_acc: 0.6613\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 33/50\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1/1 - 0s - loss: 0.5130 - acc: 0.7274 - val_loss: 0.6620 - val_acc: 0.6670\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 34/50\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1/1 - 0s - loss: 0.5305 - acc: 0.7516 - val_loss: 0.6644 - val_acc: 0.6632\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 35/50\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1/1 - 0s - loss: 0.5314 - acc: 0.7516 - val_loss: 0.6713 - val_acc: 0.6641\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 36/50\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1/1 - 0s - loss: 0.5197 - acc: 0.7579 - val_loss: 0.6660 - val_acc: 0.6755\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 37/50\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1/1 - 0s - loss: 0.4484 - acc: 0.7653 - val_loss: 0.6606 - val_acc: 0.6822\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 38/50\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1/1 - 0s - loss: 0.5195 - acc: 0.7695 - val_loss: 0.6673 - val_acc: 0.6926\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 39/50\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1/1 - 0s - loss: 0.4663 - acc: 0.7905 - val_loss: 0.6948 - val_acc: 0.6973\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "1/1 - 0s - loss: 0.5078 - acc: 0.7232 - val_loss: 0.6515 - val_acc: 0.6613\n",
+      "Epoch 33/50\n",
+      "1/1 - 0s - loss: 0.5130 - acc: 0.7274 - val_loss: 0.6620 - val_acc: 0.6670\n",
+      "Epoch 34/50\n",
+      "1/1 - 0s - loss: 0.5305 - acc: 0.7516 - val_loss: 0.6644 - val_acc: 0.6632\n",
+      "Epoch 35/50\n",
+      "1/1 - 0s - loss: 0.5314 - acc: 0.7516 - val_loss: 0.6713 - val_acc: 0.6641\n",
+      "Epoch 36/50\n",
+      "1/1 - 0s - loss: 0.5197 - acc: 0.7579 - val_loss: 0.6660 - val_acc: 0.6755\n",
+      "Epoch 37/50\n",
+      "1/1 - 0s - loss: 0.4484 - acc: 0.7653 - val_loss: 0.6606 - val_acc: 0.6822\n",
+      "Epoch 38/50\n",
+      "1/1 - 0s - loss: 0.5195 - acc: 0.7695 - val_loss: 0.6673 - val_acc: 0.6926\n",
+      "Epoch 39/50\n",
+      "1/1 - 0s - loss: 0.4663 - acc: 0.7905 - val_loss: 0.6948 - val_acc: 0.6973\n",
       "Epoch 40/50\n",
-      "1/1 - 0s - loss: 0.4735 - acc: 0.7821 - val_loss: 0.7012 - val_acc: 0.6983\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "1/1 - 0s - loss: 0.4735 - acc: 0.7821 - val_loss: 0.7012 - val_acc: 0.6983\n",
       "Epoch 41/50\n",
-      "1/1 - 0s - loss: 0.4508 - acc: 0.8084 - val_loss: 0.7155 - val_acc: 0.7097\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 42/50\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1/1 - 0s - loss: 0.4532 - acc: 0.7958 - val_loss: 0.7255 - val_acc: 0.7097\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 43/50\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1/1 - 0s - loss: 0.4404 - acc: 0.7905 - val_loss: 0.7346 - val_acc: 0.7068\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 44/50\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1/1 - 0s - loss: 0.4297 - acc: 0.8305 - val_loss: 0.7465 - val_acc: 0.7068\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 45/50\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1/1 - 0s - loss: 0.3886 - acc: 0.8242 - val_loss: 0.7382 - val_acc: 0.7125\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 46/50\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1/1 - 0s - loss: 0.4563 - acc: 0.8337 - val_loss: 0.7296 - val_acc: 0.7116\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 47/50\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1/1 - 0s - loss: 0.4494 - acc: 0.8400 - val_loss: 0.7061 - val_acc: 0.7125\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 48/50\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1/1 - 0s - loss: 0.3988 - acc: 0.8253 - val_loss: 0.7037 - val_acc: 0.7097\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 49/50\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1/1 - 0s - loss: 0.4139 - acc: 0.8326 - val_loss: 0.7067 - val_acc: 0.7116\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 50/50\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "1/1 - 0s - loss: 0.4508 - acc: 0.8084 - val_loss: 0.7155 - val_acc: 0.7097\n",
+      "Epoch 42/50\n",
+      "1/1 - 0s - loss: 0.4532 - acc: 0.7958 - val_loss: 0.7255 - val_acc: 0.7097\n",
+      "Epoch 43/50\n",
+      "1/1 - 0s - loss: 0.4404 - acc: 0.7905 - val_loss: 0.7346 - val_acc: 0.7068\n",
+      "Epoch 44/50\n",
+      "1/1 - 0s - loss: 0.4297 - acc: 0.8305 - val_loss: 0.7465 - val_acc: 0.7068\n",
+      "Epoch 45/50\n",
+      "1/1 - 0s - loss: 0.3886 - acc: 0.8242 - val_loss: 0.7382 - val_acc: 0.7125\n",
+      "Epoch 46/50\n",
+      "1/1 - 0s - loss: 0.4563 - acc: 0.8337 - val_loss: 0.7296 - val_acc: 0.7116\n",
+      "Epoch 47/50\n",
+      "1/1 - 0s - loss: 0.4494 - acc: 0.8400 - val_loss: 0.7061 - val_acc: 0.7125\n",
+      "Epoch 48/50\n",
+      "1/1 - 0s - loss: 0.3988 - acc: 0.8253 - val_loss: 0.7037 - val_acc: 0.7097\n",
+      "Epoch 49/50\n",
+      "1/1 - 0s - loss: 0.4139 - acc: 0.8326 - val_loss: 0.7067 - val_acc: 0.7116\n",
+      "Epoch 50/50\n",
       "1/1 - 0s - loss: 0.4342 - acc: 0.8389 - val_loss: 0.6897 - val_acc: 0.7059\n"
      ]
     }
@@ -1286,20 +688,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  ['...']\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  ['...']\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  ['...']\n",
+      "  ['...']\n",
       "\n",
       "Train Set Metrics of the trained model:\n",
       "\tloss: 0.3185\n",

--- a/demos/link-prediction/gcn/cora-gcn-links-example.ipynb
+++ b/demos/link-prediction/gcn/cora-gcn-links-example.ipynb
@@ -35,7 +35,9 @@
     "from tensorflow import keras\n",
     "from sklearn import preprocessing, feature_extraction, model_selection\n",
     "\n",
-    "from stellargraph import globalvar"
+    "from stellargraph import globalvar\n",
+    "from stellargraph import datasets\n",
+    "from IPython.display import display, HTML"
    ]
   },
   {
@@ -46,30 +48,27 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "**Downloading the CORA dataset:**\n",
-    "    \n",
-    "The dataset used in this demo can be downloaded from https://linqs-data.soe.ucsc.edu/public/lbc/cora.tgz\n",
-    "\n",
-    "The following is the description of the dataset:\n",
-    "> The Cora dataset consists of 2708 scientific publications classified into one of seven classes.\n",
-    "> The citation network consists of 5429 links. Each publication in the dataset is described by a\n",
-    "> 0/1-valued word vector indicating the absence/presence of the corresponding word from the dictionary.\n",
-    "> The dictionary consists of 1433 unique words. The README file in the dataset provides more details.\n",
-    "\n",
-    "Download and unzip the cora.tgz file to a location on your computer and set the `data_dir` variable to\n",
-    "point to the location of the dataset (the directory containing \"cora.cites\" and \"cora.content\")."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "The Cora dataset consists of 2708 scientific publications classified into one of seven classes. The citation network consists of 5429 links. Each publication in the dataset is described by a 0/1-valued word vector indicating the absence/presence of the corresponding word from the dictionary. The dictionary consists of 1433 unique words."
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
-    "data_dir = os.path.expanduser(\"~/data/cora\")"
+    "dataset = datasets.Cora()\n",
+    "display(HTML(dataset.description))\n",
+    "dataset.download()"
    ]
   },
   {
@@ -86,7 +85,7 @@
    "outputs": [],
    "source": [
     "edgelist = pd.read_csv(\n",
-    "    os.path.join(data_dir, \"cora.cites\"),\n",
+    "    os.path.join(dataset.data_directory, \"cora.cites\"),\n",
     "    sep=\"\\t\",\n",
     "    header=None,\n",
     "    names=[\"target\", \"source\"],\n",
@@ -119,7 +118,10 @@
     "feature_names = [\"w_{}\".format(ii) for ii in range(1433)]\n",
     "column_names = feature_names + [\"subject\"]\n",
     "node_data = pd.read_csv(\n",
-    "    os.path.join(data_dir, \"cora.content\"), sep=\"\\t\", header=None, names=column_names\n",
+    "    os.path.join(dataset.data_directory, \"cora.content\"),\n",
+    "    sep=\"\\t\",\n",
+    "    header=None,\n",
+    "    names=column_names,\n",
     ")"
    ]
   },
@@ -461,14 +463,33 @@
     {
      "name": "stdout",
      "output_type": "stream",
+     "text": []
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  ['...']\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  ['...']\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
      "text": [
       "\n",
       "Train Set Metrics of the initial (untrained) model:\n",
-      "\tloss: 1.9300\n",
+      "\tloss: 2.4878\n",
       "\tacc: 0.5000\n",
       "\n",
       "Test Set Metrics of the initial (untrained) model:\n",
-      "\tloss: 1.9193\n",
+      "\tloss: 2.5596\n",
       "\tacc: 0.5000\n"
      ]
     }
@@ -501,107 +522,691 @@
     {
      "name": "stdout",
      "output_type": "stream",
+     "text": []
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "Epoch 1/50\n",
-      "1/1 - 0s - loss: 1.8187 - acc: 0.5000 - val_loss: 1.8040 - val_acc: 0.5455\n",
+      "  ['...']\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  ['...']\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Train for 1 steps, validate for 1 steps\n",
+      "Epoch 1/50\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 - 0s - loss: 2.4500 - acc: 0.5000 - val_loss: 0.7966 - val_acc: 0.5408\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "Epoch 2/50\n",
-      "1/1 - 0s - loss: 2.2420 - acc: 0.5442 - val_loss: 0.7943 - val_acc: 0.6157\n",
+      "1/1 - 0s - loss: 0.7856 - acc: 0.5547 - val_loss: 2.9508 - val_acc: 0.5190\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "Epoch 3/50\n",
-      "1/1 - 0s - loss: 0.9887 - acc: 0.6074 - val_loss: 0.7350 - val_acc: 0.5588\n",
-      "Epoch 4/50\n",
-      "1/1 - 0s - loss: 0.7206 - acc: 0.5947 - val_loss: 0.7700 - val_acc: 0.5427\n",
-      "Epoch 5/50\n",
-      "1/1 - 0s - loss: 0.7529 - acc: 0.5653 - val_loss: 0.7496 - val_acc: 0.5560\n",
-      "Epoch 6/50\n",
-      "1/1 - 0s - loss: 0.7073 - acc: 0.5895 - val_loss: 0.7048 - val_acc: 0.5797\n",
-      "Epoch 7/50\n",
-      "1/1 - 0s - loss: 0.6452 - acc: 0.6432 - val_loss: 0.6886 - val_acc: 0.6347\n",
-      "Epoch 8/50\n",
-      "1/1 - 0s - loss: 0.6463 - acc: 0.6726 - val_loss: 0.6864 - val_acc: 0.6110\n",
-      "Epoch 9/50\n",
-      "1/1 - 0s - loss: 0.6265 - acc: 0.6789 - val_loss: 0.6917 - val_acc: 0.6091\n",
-      "Epoch 10/50\n",
-      "1/1 - 0s - loss: 0.6234 - acc: 0.6800 - val_loss: 0.6834 - val_acc: 0.6139\n",
-      "Epoch 11/50\n",
-      "1/1 - 0s - loss: 0.6345 - acc: 0.6811 - val_loss: 0.6869 - val_acc: 0.6195\n",
-      "Epoch 12/50\n",
-      "1/1 - 0s - loss: 0.5710 - acc: 0.6947 - val_loss: 0.6801 - val_acc: 0.6252\n",
-      "Epoch 13/50\n",
-      "1/1 - 0s - loss: 0.5798 - acc: 0.7126 - val_loss: 0.6956 - val_acc: 0.6395\n",
-      "Epoch 14/50\n",
-      "1/1 - 0s - loss: 0.5634 - acc: 0.7221 - val_loss: 0.6921 - val_acc: 0.6471\n",
-      "Epoch 15/50\n",
-      "1/1 - 0s - loss: 0.5778 - acc: 0.7358 - val_loss: 0.6810 - val_acc: 0.6584\n",
-      "Epoch 16/50\n",
-      "1/1 - 0s - loss: 0.5236 - acc: 0.7495 - val_loss: 0.6730 - val_acc: 0.6651\n",
-      "Epoch 17/50\n",
-      "1/1 - 0s - loss: 0.5660 - acc: 0.7295 - val_loss: 0.6649 - val_acc: 0.6717\n",
-      "Epoch 18/50\n",
-      "1/1 - 0s - loss: 0.4976 - acc: 0.7432 - val_loss: 0.6579 - val_acc: 0.6850\n",
-      "Epoch 19/50\n",
-      "1/1 - 0s - loss: 0.5007 - acc: 0.7579 - val_loss: 0.6629 - val_acc: 0.6917\n",
-      "Epoch 20/50\n",
-      "1/1 - 0s - loss: 0.5152 - acc: 0.7695 - val_loss: 0.6337 - val_acc: 0.6973\n",
-      "Epoch 21/50\n",
-      "1/1 - 0s - loss: 0.4662 - acc: 0.7768 - val_loss: 0.6275 - val_acc: 0.7040\n",
-      "Epoch 22/50\n",
-      "1/1 - 0s - loss: 0.4722 - acc: 0.7779 - val_loss: 0.6332 - val_acc: 0.7049\n",
-      "Epoch 23/50\n",
-      "1/1 - 0s - loss: 0.4502 - acc: 0.7989 - val_loss: 0.6462 - val_acc: 0.7030\n",
-      "Epoch 24/50\n",
-      "1/1 - 0s - loss: 0.4438 - acc: 0.8095 - val_loss: 0.6420 - val_acc: 0.7068\n",
-      "Epoch 25/50\n",
-      "1/1 - 0s - loss: 0.4315 - acc: 0.8158 - val_loss: 0.6630 - val_acc: 0.7059\n",
-      "Epoch 26/50\n",
-      "1/1 - 0s - loss: 0.4399 - acc: 0.8189 - val_loss: 0.6739 - val_acc: 0.7116\n",
-      "Epoch 27/50\n",
-      "1/1 - 0s - loss: 0.4640 - acc: 0.8284 - val_loss: 0.6698 - val_acc: 0.7173\n",
-      "Epoch 28/50\n",
-      "1/1 - 0s - loss: 0.4515 - acc: 0.8295 - val_loss: 0.6667 - val_acc: 0.7239\n",
-      "Epoch 29/50\n",
-      "1/1 - 0s - loss: 0.3956 - acc: 0.8389 - val_loss: 0.6643 - val_acc: 0.7201\n",
-      "Epoch 30/50\n",
-      "1/1 - 0s - loss: 0.3846 - acc: 0.8337 - val_loss: 0.6616 - val_acc: 0.7182\n",
-      "Epoch 31/50\n",
-      "1/1 - 0s - loss: 0.3953 - acc: 0.8589 - val_loss: 0.6590 - val_acc: 0.7201\n",
+      "1/1 - 0s - loss: 3.0601 - acc: 0.5337 - val_loss: 1.3757 - val_acc: 0.5579\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 4/50\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 - 0s - loss: 1.7043 - acc: 0.5653 - val_loss: 0.6728 - val_acc: 0.6252\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 5/50\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 - 0s - loss: 0.6647 - acc: 0.6453 - val_loss: 0.7923 - val_acc: 0.5465\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 6/50\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 - 0s - loss: 0.7591 - acc: 0.5716 - val_loss: 0.9080 - val_acc: 0.5275\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 7/50\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 - 0s - loss: 0.8537 - acc: 0.5389 - val_loss: 0.9219 - val_acc: 0.5313\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 8/50\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 - 0s - loss: 0.8643 - acc: 0.5484 - val_loss: 0.8485 - val_acc: 0.5541\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 9/50\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 - 0s - loss: 0.7806 - acc: 0.5737 - val_loss: 0.7511 - val_acc: 0.5797\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 10/50\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 - 0s - loss: 0.7162 - acc: 0.6095 - val_loss: 0.6848 - val_acc: 0.6148\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 11/50\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 - 0s - loss: 0.7384 - acc: 0.6032 - val_loss: 0.7950 - val_acc: 0.6148\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 12/50\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 - 0s - loss: 0.8312 - acc: 0.6200 - val_loss: 0.8829 - val_acc: 0.6063\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 13/50\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 - 0s - loss: 1.0317 - acc: 0.6453 - val_loss: 0.7606 - val_acc: 0.6290\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 14/50\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 - 0s - loss: 0.7468 - acc: 0.6905 - val_loss: 0.6624 - val_acc: 0.6452\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 15/50\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 - 0s - loss: 0.6501 - acc: 0.6874 - val_loss: 0.6708 - val_acc: 0.6537\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 16/50\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 - 0s - loss: 0.6120 - acc: 0.6884 - val_loss: 0.7092 - val_acc: 0.6271\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 17/50\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 - 0s - loss: 0.6388 - acc: 0.6484 - val_loss: 0.7233 - val_acc: 0.6129\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 18/50\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 - 0s - loss: 0.6867 - acc: 0.6421 - val_loss: 0.7282 - val_acc: 0.5996\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 19/50\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 - 0s - loss: 0.6571 - acc: 0.6695 - val_loss: 0.7257 - val_acc: 0.6091\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 20/50\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 - 0s - loss: 0.7098 - acc: 0.6568 - val_loss: 0.6997 - val_acc: 0.6214\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 21/50\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 - 0s - loss: 0.5992 - acc: 0.6842 - val_loss: 0.6794 - val_acc: 0.6423\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 22/50\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 - 0s - loss: 0.5995 - acc: 0.6884 - val_loss: 0.6709 - val_acc: 0.6537\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 23/50\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 - 0s - loss: 0.5781 - acc: 0.7179 - val_loss: 0.6442 - val_acc: 0.6660\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 24/50\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 - 0s - loss: 0.5729 - acc: 0.7389 - val_loss: 0.6626 - val_acc: 0.6708\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 25/50\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 - 0s - loss: 0.5755 - acc: 0.7453 - val_loss: 0.7080 - val_acc: 0.6736\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 26/50\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 - 0s - loss: 0.6672 - acc: 0.7484 - val_loss: 0.6484 - val_acc: 0.6793\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 27/50\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 - 0s - loss: 0.5816 - acc: 0.7537 - val_loss: 0.6475 - val_acc: 0.6565\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 28/50\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 - 0s - loss: 0.5102 - acc: 0.7347 - val_loss: 0.6499 - val_acc: 0.6461\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 29/50\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 - 0s - loss: 0.5360 - acc: 0.7421 - val_loss: 0.6463 - val_acc: 0.6471\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 30/50\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 - 0s - loss: 0.5270 - acc: 0.7179 - val_loss: 0.6449 - val_acc: 0.6509\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 31/50\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 - 0s - loss: 0.5160 - acc: 0.7263 - val_loss: 0.6381 - val_acc: 0.6575\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "Epoch 32/50\n",
-      "1/1 - 0s - loss: 0.4024 - acc: 0.8526 - val_loss: 0.6576 - val_acc: 0.7211\n",
-      "Epoch 33/50\n",
-      "1/1 - 0s - loss: 0.3868 - acc: 0.8484 - val_loss: 0.6681 - val_acc: 0.7230\n",
-      "Epoch 34/50\n",
-      "1/1 - 0s - loss: 0.3695 - acc: 0.8558 - val_loss: 0.6724 - val_acc: 0.7249\n",
-      "Epoch 35/50\n",
-      "1/1 - 0s - loss: 0.3695 - acc: 0.8684 - val_loss: 0.7002 - val_acc: 0.7258\n",
-      "Epoch 36/50\n",
-      "1/1 - 0s - loss: 0.3540 - acc: 0.8779 - val_loss: 0.7207 - val_acc: 0.7249\n",
-      "Epoch 37/50\n",
-      "1/1 - 0s - loss: 0.3643 - acc: 0.8705 - val_loss: 0.7329 - val_acc: 0.7268\n",
-      "Epoch 38/50\n",
-      "1/1 - 0s - loss: 0.3733 - acc: 0.8558 - val_loss: 0.7207 - val_acc: 0.7277\n",
-      "Epoch 39/50\n",
-      "1/1 - 0s - loss: 0.3493 - acc: 0.8863 - val_loss: 0.7190 - val_acc: 0.7230\n",
+      "1/1 - 0s - loss: 0.5078 - acc: 0.7232 - val_loss: 0.6515 - val_acc: 0.6613\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 33/50\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 - 0s - loss: 0.5130 - acc: 0.7274 - val_loss: 0.6620 - val_acc: 0.6670\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 34/50\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 - 0s - loss: 0.5305 - acc: 0.7516 - val_loss: 0.6644 - val_acc: 0.6632\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 35/50\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 - 0s - loss: 0.5314 - acc: 0.7516 - val_loss: 0.6713 - val_acc: 0.6641\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 36/50\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 - 0s - loss: 0.5197 - acc: 0.7579 - val_loss: 0.6660 - val_acc: 0.6755\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 37/50\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 - 0s - loss: 0.4484 - acc: 0.7653 - val_loss: 0.6606 - val_acc: 0.6822\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 38/50\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 - 0s - loss: 0.5195 - acc: 0.7695 - val_loss: 0.6673 - val_acc: 0.6926\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 39/50\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 - 0s - loss: 0.4663 - acc: 0.7905 - val_loss: 0.6948 - val_acc: 0.6973\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "Epoch 40/50\n",
-      "1/1 - 0s - loss: 0.3254 - acc: 0.8832 - val_loss: 0.7206 - val_acc: 0.7287\n",
+      "1/1 - 0s - loss: 0.4735 - acc: 0.7821 - val_loss: 0.7012 - val_acc: 0.6983\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "Epoch 41/50\n",
-      "1/1 - 0s - loss: 0.3598 - acc: 0.8779 - val_loss: 0.7535 - val_acc: 0.7334\n",
-      "Epoch 42/50\n",
-      "1/1 - 0s - loss: 0.3260 - acc: 0.8768 - val_loss: 0.7531 - val_acc: 0.7343\n",
-      "Epoch 43/50\n",
-      "1/1 - 0s - loss: 0.3212 - acc: 0.8842 - val_loss: 0.7523 - val_acc: 0.7372\n",
-      "Epoch 44/50\n",
-      "1/1 - 0s - loss: 0.2966 - acc: 0.8863 - val_loss: 0.7540 - val_acc: 0.7372\n",
-      "Epoch 45/50\n",
-      "1/1 - 0s - loss: 0.3057 - acc: 0.8874 - val_loss: 0.7369 - val_acc: 0.7343\n",
-      "Epoch 46/50\n",
-      "1/1 - 0s - loss: 0.3234 - acc: 0.8916 - val_loss: 0.7105 - val_acc: 0.7353\n",
-      "Epoch 47/50\n",
-      "1/1 - 0s - loss: 0.2769 - acc: 0.8916 - val_loss: 0.6903 - val_acc: 0.7353\n",
-      "Epoch 48/50\n",
-      "1/1 - 0s - loss: 0.2989 - acc: 0.8842 - val_loss: 0.6981 - val_acc: 0.7372\n",
-      "Epoch 49/50\n",
-      "1/1 - 0s - loss: 0.2684 - acc: 0.9000 - val_loss: 0.7014 - val_acc: 0.7410\n",
-      "Epoch 50/50\n",
-      "1/1 - 0s - loss: 0.2917 - acc: 0.8895 - val_loss: 0.7457 - val_acc: 0.7429\n"
+      "1/1 - 0s - loss: 0.4508 - acc: 0.8084 - val_loss: 0.7155 - val_acc: 0.7097\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 42/50\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 - 0s - loss: 0.4532 - acc: 0.7958 - val_loss: 0.7255 - val_acc: 0.7097\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 43/50\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 - 0s - loss: 0.4404 - acc: 0.7905 - val_loss: 0.7346 - val_acc: 0.7068\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 44/50\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 - 0s - loss: 0.4297 - acc: 0.8305 - val_loss: 0.7465 - val_acc: 0.7068\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 45/50\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 - 0s - loss: 0.3886 - acc: 0.8242 - val_loss: 0.7382 - val_acc: 0.7125\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 46/50\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 - 0s - loss: 0.4563 - acc: 0.8337 - val_loss: 0.7296 - val_acc: 0.7116\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 47/50\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 - 0s - loss: 0.4494 - acc: 0.8400 - val_loss: 0.7061 - val_acc: 0.7125\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 48/50\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 - 0s - loss: 0.3988 - acc: 0.8253 - val_loss: 0.7037 - val_acc: 0.7097\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 49/50\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 - 0s - loss: 0.4139 - acc: 0.8326 - val_loss: 0.7067 - val_acc: 0.7116\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 50/50\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 - 0s - loss: 0.4342 - acc: 0.8389 - val_loss: 0.6897 - val_acc: 0.7059\n"
      ]
     }
    ],
@@ -650,7 +1255,7 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAtcAAAEWCAYAAACt0rvRAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAAgAElEQVR4nOzdd3yV9fn/8deVdbIDJAGEEAjIBkEIiOKAqgjWiqNVcLYqqFV/bbVWtFarHfLtUOuuKCoOXDioooAVirggTNkjAgkgZJAQssf1++M+gUMWIeSMJNfz8cgj59zjnCul3nnncz739RFVxRhjjDHGGHPigvxdgDHGGGOMMa2FhWtjjDHGGGOaiYVrY4wxxhhjmomFa2OMMcYYY5qJhWtjjDHGGGOaiYVrY4wxxhhjmomFa2OMMca0CCKyQ0TO83cdxjTEwrUxxhhjjDHNxMK1McYYY4wxzcTCtTGAiEwTke0iUiAiG0TkUo99U0Rko8e+Ye7t3UTkPRHJEpEcEXnKfz+BMca0HSLiEpHHRWSP++txEXG59yWIyEcikiciuSLyhYgEuffdIyK73dfzzSJyrn9/EtMahfi7AGMCxHbgLOAH4GfAayJyMnAm8EfgEiAN6AWUi0gw8BHwOXAtUAmk+r5sY4xpk34PjAKGAgp8CNwP/AG4C8gEEt3HjgJURPoCtwMjVHWPiPQAgn1btmkLbOTaGEBV31HVPapapapvAVuBkcBNwN9Udbk6tqnqTve+LsDdqlqoqiWqutSPP4IxxrQlVwMPq+p+Vc0CHsIZ6AAoB04Cuqtquap+oaqKMwjiAgaISKiq7lDV7X6p3rRqFq6NAUTkOhFZ7f4YMQ8YBCQA3XBGtWvqBuxU1Qpf1mmMMQZwBjd2ejzf6d4G8HdgG7BARNJFZBqAqm4Dfo3zaeR+EXlTRLpgTDOzcG3aPBHpDszA+bgwXlXbAesAATJwpoLUlAEki4hNrTLGGN/bA3T3eJ7s3oaqFqjqXaraE7gYuLN6brWqvqGqZ7rPVeD/fFu2aQssXBsDUTgX2SwAEfkFzsg1wAvAb0VkuDhOdofxZcBeYLqIRIlIuIiM9kfxxhjTBs0G7heRRBFJAB4AXgMQkYvc12oB8nGmg1SJSF8R+ZH7xscSoBio8lP9phWzcG3aPFXdAPwT+BrYBwwGvnTvewf4C/AGUAB8AHRQ1UrgJ8DJwC6cm2eu9HnxxhjTNv0Z5ybztcB3wEr3NoDewGfAIZzr+jOqughnvvV0IBvn5vWOwL2+Ldu0BeLM8TfGGGOMMcacKBu5NsYYY4wxpplYuDbGGGOMMaaZWLg2xhhjjDGmmVi4NsYYY4wxppm0mh69CQkJ2qNHD3+XYYwxTbJixYpsVU089pGth123jTEtVUPX7FYTrnv06EFaWpq/yzDGmCYRkZ3HPqp1seu2MaalauiabdNCjDHGGGOMaSYWro0xxhhjjGkmFq6NMcYYY4xpJq1mznVdysvLyczMpKSkxN+leF14eDhJSUmEhob6uxRjjDHGtHJtJWM1JV+16nCdmZlJTEwMPXr0QET8XY7XqCo5OTlkZmaSkpLi73KMMS2QiHQDZgGdAAWeV9V/1TjmauAeQIAC4FZVXePet8O9rRKoUNVU31VvjPG1tpCxmpqvvDotRETGi8hmEdkmItPq2N9dRP4rImtFZLGIJHnsu15Etrq/rm/K+5eUlBAfH99q/9GriQjx8fGt/q9HY4xXVQB3qeoAYBRwm4gMqHHM98A5qjoY+BPwfI39Y1V1qAVrY1q/tpCxmpqvvBauRSQYeBqYAAwAJtdxof4HMEtVTwEeBh5xn9sBeBA4DRgJPCgi7ZtYR9N+gBamrfycxhjvUNW9qrrS/bgA2Ah0rXHMV6p6wP30GyAJY0yb1RayR1N+Rm+OXI8EtqlquqqWAW8CE2scMwD43P14kcf+C4CFqprrvpAvBMZ7sVZjjGm0/QUlvLV8FxWVVf4uxStEpAdwKvBtA4fdCHzi8VyBBSKyQkSmNvDaU0UkTUTSsrKymqNcduYU8r8tzfNaxhhzorwZrrsCGR7PM6kxCgKsAS5zP74UiBGR+Eae65WLdHPLy8vjmWeeOe7zLrzwQvLy8rxQkTHmRFRUVnHLqyu4Z8533Pr6SkrKK/1dUrMSkWhgDvBrVT1YzzFjccL1PR6bz1TVYTifVt4mImfXda6qPq+qqaqampjYPAtSPvX5Nn795qpmeS1jTMsQyPnK3634fgucIyKrgHOA3Tg3wzSKNy7Sza2+f/yKiooGz5s3bx7t2rXzVlnGmCZ64r9bWbkrj4uHdGHhhn1cP3MZB0vK/V1WsxCRUJxg/bqqvlfPMacALwATVTWneruq7nZ/3w+8j/PppU/szCniUGnD11RjTOsSyPnKm+F6N9DN43mSe9thqrpHVS9T1VOB37u35TXm3JZi2rRpbN++naFDhzJixAjOOussLr74YgYMcKafX3LJJQwfPpyBAwfy/PNH7g3q0aMH2dnZ7Nixg/79+zNlyhQGDhzIuHHjKC4u9tePY0yb9m16Dk8t2sblw5J4YvKp/GvSUFbsPMDk578h+1Cpv8s7IeJMLHwR2Kiqj9ZzTDLwHnCtqm7x2B4lIjHVj4FxwDrvV+3YlVtEeaVSVtE6p+kYY2oL5HzlzVZ8y4HeIpKCE4wnAVd5HiAiCUCuqlYB9wIz3bvmA3/1uIlxnHt/kz30n/Vs2FPnJ5xNNqBLLA/+ZGCDx0yfPp1169axevVqFi9ezI9//GPWrVt3uKXLzJkz6dChA8XFxYwYMYLLL7+c+Pj4o15j69atzJ49mxkzZnDFFVcwZ84crrnmmmb9WYxpK7IPlfJtei6VqrX29e0UQ9/OMXWel1dUxq/fWk1yh0gemuj8dz9xaFdiI0K59bUV/Oy5r5l1w0i6dYj0av1eNBq4FvhORFa7t90HJAOo6nPAA0A88Iz7Jp/qlnudgPfd20KAN1T1U18UXVJeyQ8HnTv5i8sqCQvx9weyxrQ9/shYgZyvvBauVbVCRG7HCcrBwExVXS8iDwNpqjoXGAM8IiIKLAFuc5+bKyJ/wgnoAA+raq63avWlkSNHHtUr8YknnuD9998HICMjg61bt9b6x09JSWHo0KEADB8+nB07dvisXmNag5LySj7ftJ85KzJZvCWLyqrawRogSODGM1O48/y+RIQFH96uqkyb8x3Zh0p579bRRLuOXDrH9u3I6zedxi9eWs5Pn/uKV288jT6d6g7ogUxVl+L0r27omJuAm+rYng4M8VJpDco8cGSkqai8gjhsIS1j2qJAyldeXURGVecB82pse8Dj8bvAu/WcO5MjI9kn7FgjzL4SFRV1+PHixYv57LPP+Prrr4mMjGTMmDF19lJ0uVyHHwcHB9u0EGMaoKocLKkgq6CUvfnFfLLuBz5as4eDJRV0inUx5ayeTBjUmSjX0Ze/KlVe+nIHM774nvnr9/HIZYMZfXICALOXZfDp+h+478J+DE6Kq/Wew7t34O1bTue6F5dx97tr+eCXZ7SJFlWBICO36PDjwtLWdXOpMS1FIGSsQMpXrXqFxkAQExNDQUFBnfvy8/Np3749kZGRbNq0iW+++cbH1RnjHY8u2EzWoTLO6ZPA6b0SiIto3tFEVSWroJQNew+ycW8BG/ceZGdOIdmHysg6VHrU3NuI0GDGD+rMZcO6ckavBIKD6g+9j1w2mIlDuzBtzlqufuFbrkhN4orUbjz80XrO6p3ATWf2rPfcfp1jmXPrGUDb6P0aKHZ5hOviMgvXxrQVgZyvLFx7WXx8PKNHj2bQoEFERETQqVOnw/vGjx/Pc889R//+/enbty+jRo3yY6XGNI9dOUU88fk2goOE2ct2ERwkDO3WjrN7J3JO30SGJMU1OXx+m57D04u3s353PjmFZYe3d20XQc/EKHp1jCYx2kVijIsE9/ch3dodNY3jWEb1jOfTX5/N459tZcYX6bydlkl8VBj/vGIIQQ0Ec6Alz7dusTzDdWGZdQwxpq0I5HwlWsdNPS1RamqqpqWlHbVt48aN9O/f308V+V5b+3lNYHps4Rae+HwrS+4eyw8HS1iyJYslW7JYuzsfVRjUNZapZ/fiwkGdCQlu3M1nBSXlTP9kE69/u4uT4sI58+QEBnSJpf9JsfTvHEtcpHfm2a7bnc/jn23lhjN7cEavBK+8RzURWdHWlg2v67p9vKbMSuOzjftQhZd+PoKx/To2U3XGmIa0pcxR18/a0DXbRq6NMc2mqkqZszKTM09OoFuHSLp1iGREjw7cNa4vuYVlzF//AzO+SOf/zV7F39pHMOWsnvwsNYnIsPovRZ9t2Mf9H6xjf0EJN52Zwp3j+jR4fHMa1DWOF65vU3m3xdmVU0Ryh0h25hTZyLUxJiBYuDbGHKaqvJ2WQbQrlAsHdz7u6Rvffp9L5oFi7r6gb619HaLCmDwymStTu/HZxn38e0k6D85dz+OfbeEnQ7pwUlyEezpHGIkxLiJCg3l04RY+WruXfp1jeO7a4QztZgsrmSNUlV25RZzdJ4GdOUUU2ZxrY0wAsHBtjAGcdnX3vf8d76101msa2zeRP186mK7tIhr9GnNWZhLtCmHcgM71HhMUJIwb2JlxAzuTtiOXfy9J590VmXUGo7DgIO46vw83n9PL+hebWrIPlVFcXknfzrHMX7+PIlul0RgTACxcG2PYX1DCLa+uYOWuPH59Xm9iw0P5+/zNjHv0f9wzoR/XnNb9mDfzFZZWMO+7vVw8pMtRPaIbktqjA6k9Ohw+P/tQKdmHSskqKCWnsIxRPePplRh9wj+faZ2qb2bs7174p6jcRq6NMf5n4dqYNm79nnymvJJGblEZz1w9jAsHnwTA+QM6cd/73/HAh+uZu3oP0y8/hZM71h90P1n3A0Vllfx0eFKT6ohyhRDlCqF7fNSxDzaGIz2ue3eKJkigyPpcG2MCgH3Oakwb9um6vfz02a9R4N1bzjgcrMFpKzfrhpH842dD2Lr/EBf+6wsWbd5f72u9uyKDHvGRDO/e3geVG3Nk5DqpfSSRYSE259oYExAsXHtZXl4ezzzzTJPOffzxxykqKjr2gcY0watf7+CW11bS76QYPrx9NIO61l55UET46fAkPrvzHHp1jObXb64+akW8ahm5RXyTnstPhyfZAirGZ3blFtE5Npzw0GAiw4Ipsm4hxrQZgZyvLFx7WSD/45u266O1e3hg7nrO69+J2VNG0TEmvMHjE2NcPHfNMKpUufX1FZTUmNs6Z2UmInDpsKZNCTGmKXblOm34AHe4tpFrY9qKQM5XNufay6ZNm8b27dsZOnQo559/Ph07duTtt9+mtLSUSy+9lIceeojCwkKuuOIKMjMzqays5A9/+AP79u1jz549jB07loSEBBYtWuTvH8W0El9uy+Y3b61mRPcOPHXVqYSHNu7mw+7xUTx2xVBumpXGH+euZ/rlpwBHeluf0Sv+uDqLGHOiMnKLDi/u40wLsZFrY9qKQM5XbSdcfzINfviueV+z82CYML3BQ6ZPn866detYvXo1CxYs4N1332XZsmWoKhdffDFLliwhKyuLLl268PHHHwOQn59PXFwcjz76KIsWLSIhwbsrw5m2Y93ufG5+dQU9E6KZcV1qo4N1tfMGdOK2sb14etF2hiW354oR3Vi+I5eM3GLuPL+Pl6o2praS8kp+OFhiI9fGBAI/ZKxAzlc2LcSHFixYwIIFCzj11FMZNmwYmzZtYuvWrQwePJiFCxdyzz338MUXXxAXV3vuq2m7fsgvoayi6oRfZ2dOIT9/aTlxEaG8csPIJi8Zfuf5fRl9cjx/+HAd63bn8+4Kp7f1BQPr721tTHPbnVeMKnSPd4drVwiFFq6NaZMCLV+1nZHrY4ww+4Kqcu+993LzzTfX2rdy5UrmzZvH/fffz7nnnssDDzzghwpNoNmVU8R5j/6PLu3C+d34fkwYdPyrJgJkFZRy3cxlVFRV8eYNo+gc1/Ac64YEBwlPTDqVi55cyq2vryD3UBkXndLFZ0uSGwPOfxvgdLUBiAwN5of8Yn+WZEzb5eeMFWj5ykauvSwmJoaCggIALrjgAmbOnMmhQ4cA2L17N/v372fPnj1ERkZyzTXXcPfdd7Ny5cpa55q26cWl6ShKWEgQv3x9JZc/+xUrdh44rtfIPFDEz19axr6DJcz8+YgGe1U3Vny0i6evHsYP+SUUllVyeRN7W5vAISLdRGSRiGwQkfUi8qs6jhEReUJEtonIWhEZ5rHvehHZ6v663tv1VrfhOzwtxBVMofW5NqbNCOR85dWhJhEZD/wLCAZeUNXpNfYnA68A7dzHTFPVeSLSA9gIbHYf+o2q3uLNWr0lPj6e0aNHM2jQICZMmMBVV13F6aefDkB0dDSvvfYa27Zt4+677yYoKIjQ0FCeffZZAKZOncr48ePp0qWL3dDYBuUVlfF2WiYTh3Zl+mWDeXdFJv9cuIXLn/2KCwd35ncX9KNHQv0LrlRWKa98tYN/LNiMAM9eM5xhyc3Xg3pYcnv+/tMhfLE1mxE9rLd1K1AB3KWqK0UkBlghIgtVdYPHMROA3u6v04BngdNEpAPwIJAKqPvcuap6fH8JHodduUVEhAaTEB0GOHOui22FRmPajEDOV6Kqzf6iACISDGwBzgcygeXAZM8LtYg8D6xS1WdFZAAwT1V7uMP1R6o6qLHvl5qaqmlpaUdt27hxI/379z/hn6WlaGs/b2v39KJt/H3+Zub/+mz6upd3LiytYMYX6Ty/JJ2S8krO7J3I5cO6Mm5A56OWHN+yr4B75qxl1a48xvRN5C+XDrZOHgFORFaoaqq/66gmIh8CT6nqQo9t/wYWq+ps9/PNwJjqL1W9ua7j6lPXdbuxpsxKY1dOEfN/czYAj8zbyMtf7WDznyc06fWMMcenLWWOun7Whq7Z3hy5HglsU9V0dxFvAhMBz1EQBWLdj+OAPV6sx5gWo7Sikpe+3MHZfRIPB2twlgj/9Xl9uGpkMq9+s5P3Vu7mV2+uJtoVwoRBnbl0WFe+Tc/lmcXbiHaF8NiVQ7hkaFdb2MUcF/cAx6nAtzV2dQUyPJ5nurfVt72u154KTAVITk5uco0ZuUWH51sDRIQFU1pRRWWVEhxk/383xviPN8N1XRfb02oc80dggYjcAUQB53nsSxGRVcBB4H5V/aLmGzTXRdqYQPPhqj1kHypl6lk969zfMTacu8b15Tfn9eHb73N5b2Um877byzsrMgG4eEgXHvzJAOKjXb4s27QCIhINzAF+raoHm/v1VfV54HlwRq6b+Brs8uhxDRDlvqG2qKyCmPCmdcIxxpjm4O/b+ycDL6vqP0XkdOBVERkE7AWSVTVHRIYDH4jIwJoX+sZcpFW1TYzaeWt6j/E9VWXGF+n0PymW0SfHN3hsUJBweq94Tu8Vz8MTB/HfTfvoEBV2VOgwprFEJBQnWL+uqu/VcchuoJvH8yT3tt04U0M8ty/2TpWQU1hGUVklyR2OTHWqnhZVVFZp4doYH2kLGasp+cqb3ULquwh7uhF4G0BVvwbCgQRVLVXVHPf2FcB24LhXqAgPDycnJ6fVB09VJScnh/DwprdXM4Fj8ZYstu4/xNSzU47rohURFsxFp3SxYG2aRJz/s70IbFTVR+s5bC5wnbtryCggX1X3AvOBcSLSXkTaA+Pc27zicKeQ+CPTQqJcR8K1Mcb72kLGamq+8ubI9XKgt4ik4ITqScBVNY7ZBZwLvCwi/XHCdZaIJAK5qlopIj1x7kxPP94CkpKSyMzMJCsr60R+jhYhPDycpCRrh9YazFiSTufYcC46pYu/SzFty2jgWuA7EVnt3nYfkAygqs8B84ALgW1AEfAL975cEfkTznUf4GFVzfVWoRk12vABRIQ6v84KS20JdGN8oa1krKbkK6+Fa1WtEJHbcUYvgoGZqrpeRB4G0lR1LnAXMENEfoNzc+PPVVVF5GzgYREpB6qAW5pyoQ4NDSUlJaXZfiZjmkNJeSUrdh5gZEoHQoOP/vBo3e58vtqew70T+tXaZ4w3qepSoMGPStQZorqtnn0zgZleKK2W6gVkktrXHrm2dnzG+IZlrPp5dc61qs7DGenw3PaAx+MNOKMlNc+bgzPvz5hWZd/BEqbOSmNNZj5d4sK54cwUJo1MJtrl/Kc444t0ol0hTD7NbtA1pj47c4voHBtOeOiR9pOR7jnXNnJtjPE3GxozxkfWZuZx8VNL2br/EPdO6EdyfCR//ngjZzzyX/726SbWZOTx0dq9TBrRjVi7IcuYeu3KLTpqSghApLtbSLHNuTbG+Jm/u4UY0yb8Z80efvvOGhKiXcy59Qz6nxTLzef0YnVGHs8v2c6z/9vOM4u3Exwk/OJM+5jNmIZk1GjDBx4j1xaujTF+ZuHaGC+qqlIe/+9WnvjvVkb0aM+z1wwnwaP39NBu7Xjm6uHsyC7kpS+/56R2EbaSojENKCmv5IeDJQ2MXNu0EGOMf1m4NqYZlFdWsT3rENkFZWQdKiGroJTsQ2V8l5nP1+k5/Gx4En++dBCukOA6z++REMVDEwf5uGpjWp7decWoQnL80X+E2si1MSZQWLg25gRlHijiplfS2PRDwVHbXSFBdIx18cBFA/jF6B6tvtG+Mb6wq442fAARodbn2hgTGCxcG3MC0nbkcvOrKyirrOKRywbTMyGKxBgXiTEuol0hFqiNaWbVPa671QjXQUFCRGgwRdYtxBjjZxaujWmid9IyuO/97+jaLoIXrh/ByR2j/V2SMa3erpwiwkODSPS4d6FalCuYIutzbYzxMwvXxhynyipl+icbmfHF94w+OZ6nrxpGu8gwf5dlTJtQ3Yavrk+FIsNCbOTaGON3Fq6NaaTKKmVNZh5P/ncrizZncf3p3bn/ogG2kqIxPlRXj+tqkWHBNufaGON3Fq6NacCevGKWbMliydYslm7N5mBJBaHBwp8vGcQ1o7r7uzxj2hRVrbPHdTUL18aYQGDh2pg6/G9LFv+Yv5nvducD0Dk2nPGDOnNW70TOPDmB9lE2DcQYX8spLKOwrJLkDnX3go8MC6HI+lwbY/zMwrUxHjbsOcgjn2zki63ZJHeI5PcX9uecvon07hhtnT+M8bPDbfji658Wkn2o1JclGWNMLRaujQH25hfzzwVbmLMyk9jwUP5w0QCuGZVc76Ivxhjf616VyaKerxPr6gp0qrXfpoUYYwKBhWvT5s36egd/nbeRqiqYclZPbhtzMnGRof4uyxhTQ3xIGfF7Poby6+vcH+myaSHGGP+zcG3aLFXl0YVbePLzbYztm8jDEwfVWpjCGBNAXDHO99KCOndHhtrItTHG/yxcmzapskr5w4freOPbXUwa0Y2/XDqY4CCbU23aLhGZCVwE7FfVQXXsvxu42v00BOgPJKpqrojsAAqASqBCVVO9UmR4rPO99GCdu52R60qqqpQg++/ZGOMnXm3QKyLjRWSziGwTkWl17E8WkUUiskpE1orIhR777nWft1lELvBmnaZtKa2o5P/NXsUb3+7i1jG9eOQyC9bGAC8D4+vbqap/V9WhqjoUuBf4n6rmehwy1r3fO8Eajj1yHebcI1FSYaPXxhj/8drItYgEA08D5wOZwHIRmauqGzwOux94W1WfFZEBwDygh/vxJGAg0AX4TET6qKpdMc0JKSyt4JbXVvDF1mx+f2F/ppzd098lGRMQVHWJiPRo5OGTgdneq6YeoZEgQVBS98h1lDtcF5ZWEhlmH8waY/zDmyPXI4FtqpquqmXAm8DEGsco4P6cjzhgj/vxROBNVS1V1e+Bbe7XM6bJDpVWcNUL3/LV9hz+/tNTLFgb0wQiEokzwj3HY7MCC0RkhYhM9eKbO6PX9YxcR7gDdbHNuzbG+JE3/7TvCmR4PM8ETqtxzB9xLsh3AFHAeR7nflPj3K4138B9EZ8KkJyc3CxFm9brucXbWZORx3PXDGf8oM7+LseYluonwJc1poScqaq7RaQjsFBENqnqkrpOPuHrtiuu3nB9eOTaOoYYY/zIq3OuG2Ey8LKqJgEXAq+KSKNrUtXnVTVVVVMTExO9VqRp+fYdLOGFpen8ZEgXC9bGnJhJ1JgSoqq73d/3A+/TwCeNJ3zddsXUe0NjhDtcW8cQY4w/eTNc7wa6eTxPcm/zdCPwNoCqfg2EAwmNPNeYRnv8sy1UVil3j+vr71KMabFEJA44B/jQY1uUiMRUPwbGAeu8VkQD4TrK5XwYa72ujTH+5M1wvRzoLSIpIhKGM9oxt8Yxu4BzAUSkP064znIfN0lEXCKSAvQGlnmxVtOKbdtfwFvLM7j6tO71LptsTFsnIrOBr4G+IpIpIjeKyC0icovHYZcCC1S10GNbJ2CpiKzBuU5/rKqfeq3Q8Nj651yH2si1Mcb/vDbnWlUrROR2YD4QDMxU1fUi8jCQpqpzgbuAGSLyG5wbYn6uqgqsF5G3gQ1ABXCbdQoxTfV/n24mMiyEO350sr9LMSZgqerkRhzzMk7LPs9t6cAQ71RVB1cM5Gyvc5eNXBtjAoFXexWp6jyc9nqe2x7weLwBGF3PuX8B/uLN+kzrl7Yjl4Ub9vHbcX2Ij3b5uxxjzIlqoFtIpEcrPmOM8Rd/39BojNeoKn+dt5GOMS5uODPF3+UYY5qDq/5pIdXh2lrxGWP8ycK1abXmr9/Hyl15/Ob8PraghDGthSsWKoqhsrzWrur/zq0VnzHGnyxcm1aporKKv83fRK/EKH42PMnf5RhjmksDS6AHBwmukCAbuTbG+JWFa9PqFJZW8PJXO0jPKuR34/sREmz/Nzem1TgcrutuxxcZFmwj18YYv7LPyk2L9um6H/hw9W72F5SSfaiUrILSw224Uru3Z9yATn6u0BjTrMJjne/1zrsOsVZ8xhi/snBtWqR9B0t44MN1zF+/jy5x4fRIiGJIUjsSY1wkRLtIjHFxfv9OiIi/SzXGNKfqkeuS+keui6xbiDHGjyxcmxZFVXlreQZ/mbeRsooqpk3ox01nptjUD2PaigbmXANEukIoKrdwbYzxHwvXpsXYkV3Ive99x9fpOYzq2YFHLjuFlIQof5dljPElV5zzvZ5wHRUWTFGpzbk2xviPhWvTIizZkt80PTUAACAASURBVMXUV9MIDQrikcsGc2VqN4KCbMqHMW3O4ZHr/Dp3R4YFk1dUu02fMcb4ioVrE/CWbs1myqw0eiZG89LPR9A5LtzfJRlj/OVY00LCQmz5c2OMX1m4NgHtq23Z3DRrOSkJUbx+02l0iArzd0nGGH8KjQAJbnCVRusWYozxJ7sLzASsb9JzuPGVNJI7RFqwNsY4RJx2fNaKzxgToCxcm4C07Ptcbnh5OV3bR/D6TaOIj3b5uyRjTKBwxTTciq+sAlX1cVHGGOOwcG0CzoqdufzipWV0jgvnjSmnkRhjwdoY48HVwMi1K5gqhdKKKh8XZYwxDgvXJqBk5BZx4ytpdIwNZ/aUUXSMsZsXjTE1uGLrX/48NBjApoYYY/zGq+FaRMaLyGYR2SYi0+rY/5iIrHZ/bRGRPI99lR775nqzThMYSsor+eXrK6msUl76+Qg6xVqwNsaXRGSmiOwXkXX17B8jIvke1+YHPPY1eL1vVq6Y+sO1y7lPv9B6XRtj/MRr3UJEJBh4GjgfyASWi8hcVd1QfYyq/sbj+DuAUz1eolhVh3qrPhN4HvrPBr7bnc+M61LpYYvDGOMPLwNPAbMaOOYLVb3Ic0NjrvfNyhUDOVvr3BUZ5oxcF9sqjcYYP/HmyPVIYJuqpqtqGfAmMLGB4ycDs71Yj/GByiqlvPL45zq+k5bB7GW7+OWYXpw/oJMXKjPGHIuqLgFym3Dq8V7vT4wrpoEVGm3k2hjjX94M112BDI/nme5ttYhIdyAF+Nxjc7iIpInINyJyST3nTXUfk5aVldVcdZsmKigp56Inl3Ldi8uO60799Xvyuf+DdZzRK547z+/jxQqNMc3gdBFZIyKfiMhA97ZGX++bRXhsvd1CIqpHrm3OtTHGTwLlhsZJwLuq6nk17K6qqcBVwOMi0qvmSar6vKqmqmpqYmKir2o1daisUu6YvYqNew/ydXoO/1m7t1Hn5ReVc+trK2kfGcYTk08lJDhQ/i9pjKnDSpxr8xDgSeCD432BZhkUccVAZSlUlNbadXjk2sK1McZPvJlkdgPdPJ4nubfVZRI1poSo6m7393RgMUfPxzYB5q/zNrJ4cxZ/mjiQgV1imT5v4zFHjqqqlDvfXs3e/GKevnoYCdbL2piApqoHVfWQ+/E8IFREEjiO632zDIq4Yp3vpYdq7aoeubYl0I0x/uLNcL0c6C0iKSIShhOga3X9EJF+QHvga49t7UXE5X6cAIwGvHNjjDlhby7bxYtLv+fnZ/Tg2tN78MBFA9iTX8KML9IbPO/Jz7fx3037uf/HAxjevb2PqjWmmVRVQe73sPlTWPoYvH8L/PsceO9mf1fmNSLSWUTE/Xgkzu+QHBp5vW82h8N17akhUS5rxWeM8S+vdQtR1QoRuR2YDwQDM1V1vYg8DKSpavWFdxLwph49Sbc/8G8RqcK5eE/32l3n5oR8vT2H+z9Yx9l9Ern/x/0BOK1nPBcO7syzi7dzRWo3OsfVbqn38dq9PPbZFi4b1pXrTu/u67KNaZqSfCdMb/gA0hdDedGRfTFdILEvdOzvt/JOlIjMBsYACSKSCTwIhAKo6nPAT4FbRaQCKAYmua/ddV7vvVaoK8b5Xke4jgx1fq1ZuDbG+IvXwjUc/thwXo1tD9R4/sc6zvsKGOzN2syJ25lTyK2vr6B7fCRPXXX0fOl7J/Tnsw37+dv8TTx6xdEdFb/LzOeud1YzvHt7HrlsMO6BMGMap6wItI7gFBIBwV64pBXnweZPnEC9/XOoLIPYrjD0aug82AnTCX0gol3zv7ePqerkY+x/CqdVX137al3vveZwuK7dMeTwtBDrFmKM8ROvhmvTeh0sKefGV9IAePH6EcSGhx61v1uHSG48K4VnF2/nutN7MLSbEzz2HSzhplnLiY9y8e9rh+MKCfZ57aaFKdgHO5fCDvdX9pa6jwuNhG6nQY8zocdZ0OVUCAk7+hhVKCt0RqDR2vsKsyBrk/O13/09b5dzbGwSjJgCAy+BrqkQZDff+k149bSQ2uE6LCSI0GChyPpcG2P8xMK1OW4VlVXc/sYqdmQX8uqNp9W74MttY0/mnbRMHv7PeubcegYl5VVMmZVGQUkFc249w25gNI7yYti/AQqzna+ibCfkHsqC3SuOLBYSFgPdT4fBP4PQiNqvk7cLdnwJn//JeR4SAd1GQHCY+3VznO8VxceuKSgUEnpD1+HOCHWvsRaoA0n1nOt62vFFhoXYyLUxxm8sXJvj9pd5G1myJYvplw3m9F7x9R4X7Qrhdxf05Xdz1jJ3zR4WbNjHd7vzef7aVPqfFOvDik1AytkOaTNh1WtQknf0vmAXRCVAp4Ew7FpnNLrzkMZN+yjMgZ1fOqPcGd8A4rxWx/4QGe88jmgPUkdQDo+DxP7Qoad3ppiY5tHAnGtwVmm0OdfGGH+x3x7muLz+7U5e+nIHN56ZwqSRycc8/vLhSbzy9Q7ufmctZZVV3Duhn63A2JZVVcKW+bD8Bdj+XwgKgf4Xw6DLIOakI+E3LBqaOhc/Kh4GXOx8mdapgTnXYOHaGONfFq5No321LZsHP1zPmL6J3Hdh4zoiBAcJD1w0gEkzvuHyYUlMPbunl6s0XqXqjBZ6TuEICYeUcxoe6S0vgVWvwpdPQP4up7PG2N/DsOshxv7YMscpJNyZulPvyHUIhdbn2hjjJxauTaN8n13Ira+vJCUhiicmn0pwUONHFU/rGc+Su8fSpV2EdQbxp/JijznNOc685opiiOjgjBZHJkBUojNlojQfsjYffWNf9lYo3O90y6gprhsM/zkMuw6iO3q8ZwmsnOX0gS7YA91Gwfi/Qp8JNu3CNJ2IM3ptI9fGmABkv93MMeUXlXPjy8sJkro7gzRGtw6RXqgswFWUwvr3neCacg4EH///bsdNFfIz3cF445FwnL3VCcyNIUGgVUeeh0Y6/Zt7nAkxnT2CeIIzjSM/05nm8fmfYPF0GDARUm+Afeth6aNQsBeSz4BLn4OUs5s+3cMYT8cI11mHai+NbowxvmDh2jSouKyS295YScaBIl678TSS49tgSD5eqrDlU5h/H+S6V6mMaA/9fgwDLoWezRC0K8ud0Jq1GfZv9AjTm6HMY0noqI5OMD7lZxDbxSMUu7+HRkBRrns022OqR1i0cwNgYj9nVLqhLhldhznzm7O2ODcorn4D1r3r7Es+Ay573mmNZ6HaNKfw2PrDtSuEotyiOvcZY4y3Wbg29fohv4Qps9JYtyefv11+Cqf1rL8ziHHL2gKfTnNu1kvoC1e9A1UVzgIkG+Y6nTHC20Gf8XDSKU54TeznBN/q8KkKh/YfCctZm+HQPnf4zXLCb0mNUeiojtCxHwy9ynm96mAc2eHYNcd2aZ6fPbEPTJgO5/4BNn3svG730RaqjXe4YuttxRcVFkxRqU0LMcb4h4VrU6fVGXlMnZVGYWkFM65N5Tzr8NGw4jz4399g2b8hNAoueARGTjkyQt3vQmeayPbPYf0HsO0zWPvmkfNdsc4Ic1CIMxLt2ZrOFecE1agEJ5BXjzpHd3LOaWyI9pWwKDjlCn9XYVo7Vwwc3FPnrsiwEIrshkZjjJ9YuDa1fLh6N3e/u5aOMS5evXE0fTvH+LukwFWcB98+B18/43QuGHYdnPuAE35rCnFB3wnOFzgj0VmbPKZ1bHJa1Q281D367B7Vju5ko7/G1GQ3NBpjApSFa3NYVZXy6MItPLVoGyNTOvDs1cOIt1UU61acB98863yV5kO/i2DMNOg8uPGvEZUAUWc6NwoaY46PK7bBRWQqqpSyiirCQmxVTWOMb1m4Nof9/oN1zF62i0kjuvHwxEH2S6kuxQc8QvVBJ1Sfc48zXcMY4zsNjlw7v9qKyioICwnzZVXGGEOj0pOIXCoicR7P24nIJd4ry/jaki1ZzF62iylnpfDIZYMtWNdUfAA+/ws8fgr87/+cjh+3LIVJr1uwNgFHRH4lIrHieFFEVorIOH/X1axcMU7P9YraLfciw4IBbGqIMcYvGpugHlTVw+0JVDUPeNA7JRlfKyqr4L73v6NnQhR3jevb9hZ6UXVa29WlKBc+/7MTqpf8DXqOcUL1la8d3xQQY3zrBlU9CIwD2gPXAtP9W1IzC3eP99TRMSTSdWTk2hhjfK2x00LqCuE2paSVeGzhFjIPFPPW1FGEhwb7u5wTV1XpzIkOi4LQ8LqPUYU9K53OHRs+hLydzhxOzx7QYdGw+RMoK3AWRjn7d9B5kG9/FmOapvov5AuBV1V1vbS2v5pd7hutSw9CdOJRuyJDbeTaGOM/jQ3IaSLyKPC0+/ltwIpjnSQi44F/AcHAC6o6vcb+x4Cx7qeRQEdVbefedz1wv3vfn1X1lUbWao7Dd5n5vLj0eyaPTG55faxVYf17Tv9ozx7QRbmAOisNtk9x93zuC4n9nV/C2z5zB+pdTuu7nmNgyGSn/V1hlvNaebugKAdOPhfO+R10GujnH9aY47JCRBYAKcC9IhIDVDV0gojMBC4C9qtqrb8iReRq4B6c4F4A3Kqqa9z7dri3VQIVqprajD9L3Q6H69rzriNdTrgutF7Xxhg/aGy4vgP4A/AWoMBCnIBdLxEJxgnj5wOZwHIRmauqG6qPUdXfeBx/B3Cq+3EHnGknqe73W+E+90Aj6zWNUF5ZxT1z1pIQ7WLahH7+Luf47F0Dn0yDXV9BbBK0S3YWMYka7Yw8R8Y74bh6IZbNn4C6f9EGhUDPsc6NiH0vDKwe0cY0jxuBoUC6qha5r6m/OMY5LwNPAbPq2f89cI6qHhCRCcDzwGke+8eqavaJlX0cGgrX7hsai8ttWogxxvcaFa5VtRCYdpyvPRLYpqrpACLyJjAR2FDP8ZM5Mo/7AmChqua6z10IjAdmH2cNpgEvLv2eDXsP8tw1w4iLOMHluH2lMBs+/xOseMUJxT/5F5x6LQQdYzpLRSnkbIeDuyEp1VmO3JjW63RgtaoWisg1wDCcTxHrpapLRKRHA/u/8nj6DZDUDHU2nSvW+V5HO76oMBu5Nsb4T2O7hSwUkXYez9uLyPxjnNYVyPB4nuneVtfrd8f5+PLz4zlXRKaKSJqIpGVlZR37BzGH7cgu5LGFWxg3oBPjB53k73KOraLUWajliWHOEuKjboU7VsLwnx87WIOzgEunAdD7fAvWpi14FigSkSHAXcB26h+RboobgU88niuwQERWiMjUZnyf+jUwch3hDtfFNufaGOMHjZ0WkuDuEAKA+2PBjs1YxyTgXVU9riuhqj6P89Ekqamp2oz1tGqqyn3vf0dYcBAPTwzwG/QqSmHlLFj6mDPq3OtHMH66M4faGFOfClVVEZkIPKWqL4rIjc3xwiIyFidce65+dKaq7nb/XlgoIptUdUk9508FpgIkJyc3vZDDI9e1w3WUe1pIoXULMcb4QWNb8VWJyOGroPujw2OF2d1AN4/nSe5tdZnE0VM+judcc5xe+nIHX23P4Z4J/egcV083DX8rL4FlM+BfQ2HebyGuG1z7PlzzngVrY46tQETuxWnB97GIBAEnPPdLRE4BXgAmqmpO9XZV3e3+vh94H2daYJ1U9XlVTVXV1MTExPoOO7Zwd7guya+1K8L6XBtj/KixI9e/B5aKyP9w7hQ/C/fIQwOWA71FJAUnGE8Crqp5kIj0w+nD+rXH5vnAX0Wk+vP7ccC9jazVNGDx5v38+eMNnD+gE1eNPIFRI2+prICVr8CSf0DBHkg+HS59FlLOgVbWScwYL7oS53p7g6r+4B4c+fuJvKD7Nd4DrlXVLR7bo4AgVS1wPx4HPHwi79UoIS4IDqtz5NoVEkRwkFifa2OMXzT2hsZPRSQVJ1CvAj4Aio9xToWI3I4TlIOBme5eqw8Daao6133oJOBNVVWPc3NF5E84AR3g4eqbG03TbdtfwB1vrKJv51gev3IoQUEBFla/X+J0ANm/3h2qn4OUsy1UG3Oc3IH6dWCEiFwELFPVBudci8hsYAyQICKZODeYh7pf7zngASAeeMbdMru65V4n4H33thDgDVX91Cs/WE31LIEuIkSGBtvItTHGLxoVrkXkJuBXONMzVgOjcEaaf9TQeao6D5hXY9sDNZ7/sZ5zZwIzG1OfObYDhWXc8HIartBgXrg+lShXAK0BdGAnLPg9bPyP01Lvileh/08sVBvTRCJyBc5I9WKcTxufFJG7VfXd+s5R1ckNvaaq3gTcVMf2dGDICRXcVK6YOruFgNPrusi6hRhj/KCxCetXwAjgG1Ud657K8VfvlWWaU1lFFbe8toIfDpYwe8oouraL8HdJjvJi+OKf8OUTTsePsffDGbdDaIDUZ0zL9XtghHsONCKSCHwG1BuuWyRXbJ0j1+D0ui4qt3BtjPG9xobrElUtERFExKWqm0TE7iprAVSVB+eu49vvc3n8yqEM7x4gbegqK+Cta2HbQhj8MzjvIYirs1OjMeb4BVUHa7ccGn8De8vRYLgOpqjU5lwbY3yvseE6093n+gOcNksHgJ3eK8uciPLKKnIOlZF9qJQFG/Yxe1kGt489mUtODZDwqgqf/M4J1hc9Bqk3+LsiY1qbT91rEVR3YbqSGlP0WgVXDBzMrHNXZJjNuTbG+Edjb2i81P3wjyKyCIgDfHPDijlKRWUVy77PZW9+CVmHSskuKCXrUClZBc5X9qFSDhSVH3XO+IGdufP8Pn6quA7fPANpL8IZ/8+CtTFeoKp3i8jlwGj3pudV9X1/1uQV4bGwv54512Eh5BWV+bggY4xp/Mj1Yar6P28UYhqmqizavJ9H5m1i6/5Dh7dHhAaTGOMiITqMlIQoRqZ0IDHG5d7momOMi1OS2gVOZ5CNH8H830P/i52pIMYYr1DVOcAcf9fhVfV0CwFn5HpPno1cG2N8L4BaRpj6rNudz18+3sjX6TmkJETx5ORTGdw1jsQYV2B1/TiW3Sthzk3QdThc9jwEtb4poMb4k4gUUPcCXwKoqsb6uCTvqg7XqrW6C0WGhdi0EGOMX7SgZNb27M4r5h/zN/P+qt10iArjoYsHctVpyYQGt8BQmrcLZk+C6ESYPNs6ghjjBaoa4+8afMoVC1XlUFFS65rizLm2GxqNMb5n4TpAlZRXcunTX5JfXM6tY3px65hexIaf8OrF/rFvPbx7g7Ok+XVzIbqjvysyxrQGLvffEqUFtcO1K5hCG7k2xviBhesAtWDDPvYXlPLyL0Ywpm8LDaNFubDor87Ni+FxMOk16NjP31UZY1oLl3uWS2lBrT/ao8JCKKuooqKyipCW+GmfMabFsnAdoN5enkHXdhGc3TvR36Ucv8oKWPESLPoLlORD6o0w9j6I7ODvyowxrUn1yHVJfq1dkWHBABSVVxJr4doY40MWrgNQRm4RS7dl8+vzegdOl4/G+n4JfDIN9q+HHmfBhP+DTgP9XZUxpjUK9xi5riEyzPn1VlRa2XKn1BljWiQL1wHonbQMROBnqd38XUrjHdgJC+6HjXMhLhmumOW025MW9seBMabl8JxzXcPhkWu7qdEY42MWrgNMZZXyzopMzuqdSNd2LaCjRlkhLH0cvnoCJAjG3g9n3G7dQIwx3teocG03NRpjfMvCdYD5YmsWe/NLuP/HA/xdSsNUYd0cWPgAHNwNg3/mLAoTFyBLrBtjWj9XnPO9tPYqjYenhVi4Nsb4mIXrAPN2WgbtI0M5b0AAdwipqoKPfwMrXoaThsBPZ0LyKH9XZYxpa1zRzve6wrXLGbkutGkhxhgfs3AdQHIOlbJwwz6uO70HrpBgf5dTt6oq+OhXsHIWnHkn/Oh+CArQWo0xrVuIC4JdDU4LKbaRa2OMj3m1P5GIjBeRzSKyTUSm1XPMFSKyQUTWi8gbHtsrRWS1+2uuN+sMFO+v2k15pXLliAC9kbGqCv7z/5xgffbv4NwHLFgb04qIyEwR2S8i6+rZLyLyhPuavlZEhnnsu15Etrq/rvdZ0a4YKKk9ch3lnhZSWGoj18YY3/LayLWIBANPA+cDmcByEZmrqhs8jukN3AuMVtUDIuI5F6JYVYd6q75Ao6q8tTyDod3a0adTAK5gXFUF/7kDVr0G59wDY+61TiDGtD4vA08Bs+rZPwHo7f46DXgWOE1EOgAPAqmAAivc1/sDXq84PLbOkeuI6pHrchu5Nsb4ljdHrkcC21Q1XVXLgDeBiTWOmQI8XX0BVtX9XqwnoK3clcfW/YcCc9S6qgrmVgfrac6CMBasjWl1VHUJkNvAIROBWer4BmgnIicBFwALVTXXfT1fCIz3fsU4I9d1hOsjI9cWro0xvuXNcN0VyPB4nune5qkP0EdEvhSRb0TE82IcLiJp7u2X1PUGIjLVfUxaVlZW81bvY28vzyAyLJifDOni71KOVl4CH/4SVlcH63v9XZExxn/qu6435nrvHa7YOm9oDA8NQgSK7YZGY4yP+fuGxhCcjxfHAEnAEhEZrKp5QHdV3S0iPYHPReQ7Vd3uebKqPg88D5Camqq+Lb35FJZW8NHaPfx48ElEu/z9T+IhY7kTrLO3wJj7YMw9/q7IGNPCichUYCpAcnLyib+gKxbydtb1PkSGBnOwxMK1Mca3vDlyvRvwnOOQ5N7mKROYq6rlqvo9sAUnbKOqu93f04HFwKlerNWvPl67l8KyysCZElJeDAv+ADPHQVkRXPOeBWtjDNR/XW/M9R5wBkVUNVVVUxMTE0+8IldMnSPXACmJUWzdX3vKiDHGeJM3w/VyoLeIpIhIGDAJqNn14wOcUWtEJAFnmki6iLQXEZfH9tHABlqpRZv307VdBMO7t/d3KZCxDJ47y1lxcdh18Muv4eRz/V2VMSYwzAWuc3cNGQXkq+peYD4wzn3tbg+Mc2/zvnrmXAMMSWrH2ox8qqpa7AebxpgWyGtzEFS1QkRux7nABgMzVXW9iDwMpKnqXI5ckDcAlcDdqpojImcA/xaRKpw/AKZ7dhlpbVZn5DGiRwfE3zcJLn0MPnsI4pLg2veh14/8W48xxqdEZDbOgEeCiGTidAAJBVDV54B5wIXANqAI+IV7X66I/AlnUAXgYVVt6MbI5lPdik+11o3WQ7q14/Vvd5GeXcjJHaN9Uo4xxnh1gq+qzsO5GHtue8DjsQJ3ur88j/kKGOzN2gLFvoMl7M0vYUi3dv4tZP378NkfYeClcPGTzi8sY0yboqqTj7Ffgdvq2TcTmOmNuhoUHgta6UxnC4s8atdQ93V1bWaehWtjjM94dREZc2yrM/LoRC6jXduPfbC37FsPH/wSkkbCpf+2YG2MaTmqr1d1TA3plRhNVFgwazLyfFyUMaYts3DtZ2sy8rgn9C36fjoZDu7xfQFFufDmVc4d91e+6iwnbIwxLYUr1vlex02NwUHCoK5xrM7M93FRxpi2zMK1n63OyGNkaDpSWQZfPeXbN6+qhDk3OqH+ytcgprNv398YY05UA+EanKkhG/ccpLTCFpMxxviGhWs/qqpSvs/cQ1LVbgiJgLSZUJjtuwL++xBs/xwu/Ad0G+G79zXGmObSwLQQcG5qLKusYtNea8lnjPENC9d+tD3rECnlW50n5/0RKkrgm2d88+bfvQtf/gtSb4Th1/vmPY0xprlVh+uSukeuq28WX5Np866NMb5h4dqPVmfkMUTSnSenXAEDJsKyGVDsxV8ClRWwejZ8eDsknw7jp3vvvYwxxtvCq6eF1D0y3SUunIRoF2sybN61McY3LFz70eqMPIaFpKPtUyCyA5x1lzNvcNmM5n+zygpY/QY8PQI+uAUS+8AVsyAkrPnfyxhjfMXVcLgWEYZ2i7ORa2OMz1i49qM1mU64lq7DnA0nnQK9L3CmhpQeap43qayAVa/DU6nwwa0QFgVXvg5TFkN0x+Z5D2OM8Zcwd//qesI1wClJ7diedYiDJeU+KsoY05ZZuPaTkvJKsvdmEF+ZDV2GHdlx9m+hOBdWvHRib1BZDqtec0L1h7905iVOegNu/gL6XwRB9k9vjGkFQsIgJBxK65/2MaRbO1RhnbXkM8b4gCUsP1m/J5+BbHOedB1+ZEe3kZByNnz1JJSXHP8LV5bDylfdofo2Zz7ipNlw8xLo9+NaywMbY0yL54ptcOR6SFIcAKttaogxxgcsXNflzavh0/u8+harduVxSlA6KkHOdBBPZ/0WDu2DVa82/gUry2HlLHhyOMy9HcLbweQ3Yer/oN+FFqqNMa2XK6bBcN0uMowe8ZG2UqMxxicsXNdUVQXbF8GWT7z6Nmsy8xkZugNJ7O/Mg/aUcjYkjYAvn3BCc0MO7oXF0+HxwTD3DufGyMlvwdTF0HeChWpjTOvniqm3FV+1Id3aWccQY4xPhPi7gIBzMBPKCyE33WmJF9HOK2+zelcuj8h26Hpx7Z0icPbd8MYVzgqK3UdDYj/o2B+iEp1jdiyF5TNg40eglXDyefCTJ6D3+RaojTFtS3jD00LAuanxw9V72HewhE6x4T4qzBjTFlm4rilr85HHe9dAz3Oa/S1yDpWiebuIdh08+mZGT73HwdCrnfC84cMj2yPaO6M0ebucqR+jboXUGyC+V7PXaYwxLYIrFgq/b/CQod2ceddrMvIYN7CzL6oyxrRRFq5rOipcrz4crg8UlnH9S8u48/w+jOl7Yi3s1mR6LB7TtZ5wLQKXPAMTn4aCHyBr05Gvgn1wzjQYdBmERpxQLcYY0+K5YqCk4SkfA7vEERwkrMm0cG2M8S6vzrkWkfEisllEtonItHqOuUJENojIehF5w2P79SKy1f3lu/W5szY5Uy/ikmHP6sOb03YeYG1mPre+tpJVuw6c0FuszshnaNB2NDgMOg5s+GARiD0Jeo11Rql/8i+46k049WoL1saY/9/efYfHVVyNH/8ercqqd6vLvffegFCNCWAIvYWO00hCSeMXAoF0eBOSvC9J6C1gWiiGEMChgws2tmzjbslFkiWrWVYvq53fH7OS15JsC2tXZXU+avoMfwAAIABJREFUz3Ofu3v33tWMvbo6O3NmRoFNm6sqsLMsHYEzxMGY1GjNu1ZK+Z3fgmsRcQAPAmcB44DLRWRcu3NGAncA840x44FbPMcTgLuB2cAs4G4RifdXWQ9Tus3eqNMnw751bYe3FtnBMknRoVz/5GpyS49/kZec/Epmh+1GUifpColKKdVd874P486Hd++ENY8f8bTJWXGsL6jE3dLSg4VTSg00/my5ngXsNMbkGWOagOeB89qdcxPwoDHmAIAxpsRz/ExgmTGmwvPaMmChH8tqGQNl2yBpFKRNgQO77KBGYGtxNdkJEfzzhtk4goSrH/uc4oNffR5qYwwb95Yz2uQdOSVEKaV6wbF6G0XkARHJ8WzbRaTS67UWr9eW9mjBgxxwwSN2hds3b4P1L3R62qxBhl+4HkR+nQxPnA1fPNV2j1dKKV/xZ851BpDv9bwA2xLtbRSAiHwGOIBfGmPePsK1Ge1/gIgsBhYDZGdnd7/ENftt3l7ymEMDBD2DGrcUVTEmNZrBiZE8ed0sLn1oBdc8/jkvfnsuseEhXf4Ru8vrSGrcS1hY/ZEHMyqlVA/z6m08A3vPXS0iS40xm1vPMcbc6nX+94GpXm9Rb4yZ0lPl7SA4FC55Cp69GF77DoRGwNhz7WvGQM5znPPJzzGOKvIzzia7ZjO88QN468cw+iz2Dz2PspQTGZ+d3GtVUKpfqCmFrW+Au8UzO5mABNnH4oCgYM/mOLRvaQZXI7Q02r2rERyhNuU1aWRv18jnentAYzAwEjgZyAQ+FpGJXb3YGPMw8DDAjBkzTLdLU7rV7pNHQapnYZd966jPPIFd5bWcOzkdgAkZsTz0zRlc9+Tn3PTUGp6+YRbOEEeXfsT6/EomB+XaJ9pyrZTqO9p6GwFEpLW3cfMRzr8cm77Xd4SE28WznvkGvHSdHZ8Smw1v3gp7PsWROZvz9l7EtEHz+eW542DfWhq/WIJrw8ukbH6NepPCv2b/lQvOOhPRKU2VOlxLM3z+iF1bo9GHYxcSR9h1OUadBVmzwdGDoen2d2DTa3byiCDfJXP4swaFQJbX80zPMW8FwCpjTDOwS0S2Y4PtQmzA7X3th34raavS7XafPMYuxhKXDUU5bN9fjTEwNi267dQTRibxp0um8IPn13Hbizn87crpR3jTw+XkVzLNsQsTGo0kBt63NaVUv9WV3kYARGQwMBR43+uwU0TWAC7g98aY145wrW97HNsLi4IrX4KnzrGr7bpb7EJd5/4FmXo1zkdWkZNficttWLI3kT/lLKCm/kR+MaqARQV/5KxVV/NMwU+55LpbutxoolSfU11sx42Fx0Pa5O5PgJD7PvznZzZ1dvhpcMY9EJ0Gxm17hozbs7XY3zl3C7hdhzZHCAQ7ITgMHGF2X38AdrwL296Clf+wA5LD42H8N2Duzf6dYtjtho/+AB/9HlInQkOljft8xJ/B9WpgpIgMxQbLlwFXtDvnNWzrxxMikoRNE8kDcoHfeg1iXIAd+OhfpVvBGQtRKfZ52hTYl8PWYjuYcUxqzGGnnzs5nbzSWh7473Y27TvI+PTYY/6InPxKrgrbjaRP8em3JKWU6kGXAS8bY7xHBg42xhSKyDDgfRHZaIzJbX+hz3scOxMeB998zQbXCUPhjF9BlE33mJIVx5Of7ebrf/2E7ftrmDMsgV+cM5vx6bGY6gspeuRSrt53L6/8cSOzF/8vGQnRx/hhSvUyVxPsWwsFq6Fgjd2qCg69HhQMKRPsys+ZM2xs44w5FOQGh9lzRGxQ3Ja+0QS1pfDh72DrmxA/1PYMjVrom8XqnDEw6ya7NVTZAH7rv2HdP+GLJ2HceTD/Fkj3cbZZXQW8shh2LoPJV8A5f/L57Gt+C66NMS4RuRl4B5tP/bgxZpOI3AusMcYs9by2QEQ2Ay3Aj40x5QAi8itsgA5wrzGmwl9lbVO6DZJGH/rQpE+BLUvZlV9IRKiD7ISIDpdcPXcwD36wkxdX53PPeUcPrhtdLezYV86Q0F2Q7v/xmUop9RV0pbex1WXA97wPGGMKPfs8EfkQm4/dIbjuMZFJcMM7HQ5Py47j4Y/dNDS7+cdV0zlzfEpbCohEp5L+g2XkP38rF+z8J5//dQf7L32SaWO1l1H1McZA/uew4Xn48hXb8gq2xz17NmR8z6ae1lV4gu7VsH6JXdm5MxIEiG15bi8kEk67G+Z+zwbi/uCMgfHn223Br2Dl3+3MP5tehWGnwAm3wtCTuh/UF22AF66Cqn1w9h9hxg1+WdXar4ktxpi3gLfaHbvL67EBbvNs7a99HDjynEr+ULbNfiNrlW7H6jQXrGN06mSCgjr+B8RHhnLmhFRey9nHHV8fe9RuxHV7Kxnu3k2waYaMrqWRKKVUD+lKbyMiMgaIB1Z4HYsH6owxjZ5eyPnAfT1S6q9owbhUnrlhFrOGJhAW3Mn9OjiUrKseZP/H05ny/k8ofX4ha6ffxrRTL2lr/Vaq11Tk2dlwNrxgZzQLDocxZ9tUiqxZENXJIndjvm737hbbQ79/EzTX2ZZpV8Ohlmrj9rRmhx7aB4fD8FPtehs9JTrVpp2ceJsNsFf8DZ5eBAnDYdKlMOliSBh27PcxxtavoQoaq2DPZ/Cfn0J4Alz3H8ia6bcq9PaAxr6jttx2fySPOXQszXZFRFd8yZhJJx7x0ktnZPHG+n28s6mY86Z0mNSkzaOf7GKOcw8YdDCjUqpP6WJvI9ig+3lP40irscBDIuLGTvH6e+9ZRvqSoCDhxJHHDpJTTrqemuyJBD/zTaat/X+YtT9H0qfCyDNg5ALb+BJ0jJzs5nqoKYG6Mrs4WUymb9IBjbFB0s737D4sxqY0hsfZvTPWtmAmje7ZwWHKf4o2wMf3wZY3AIGhJ8JJP7Yz4jhjjnk5YD+vKePt1h84Y22L9ezvwJcv2y8UH/4OPvwtZM6CSZfY1uyqQqjYZb94tO5rS2xQ7W4+/D0HnwAXP9H5lxAf0t+6VmWeZc+TRx86FpGAKyabEQd2kph25Ly7ecMTyYwP54XV+UcMrrcVV/PfLfv5d3Yx1CRBbFan5ymlVG85Vm+j5/kvO7luOdDlmZ76i6ghMzE/Ws8P//4cwyuXc71rJ1Ef3WcHQoVGgTPO5mqGhENIhN23NNtpXWtKOs6o4AizLW6Jw+0WnQ5NNXYKWO/NEQpxWfbvRFyWnfEkMgkKv4DcD2xuavU++56RyTaIb+pkYbNgpw2k0qbYQW1pkyBxpB30qfqHfevgo/vsoL+wWBtQT78WYjN7u2Q9J8QJU6+y28EC2OgJtN/60eHnBTttXnjCUBg81/OlM+bQl8+IRBj6tR75wqnBdavSToJroCJ2HBMr11KSduRvhkFBwsXTs3jgv9vZW15HdmLH3OyHPsolItTBGPdO22qt0zwppVSfFx0exp03XcFF/xjCE2XN/Ou6MQw7uAoKPoemWtu93lxv9001nsFj421XetQgO0A+ItG2pJXn2q1sh50loaXJ/pDg8EMtzs4Y25Wdv9IG2u05Y2HYyXbGhuGn2uAboMVlu74bKu3COOW5UJRj12rY+BKseezQe0SleoL8YXafMNyzHxZYgXdjNRRvtGkQQcF2NojwBM8+3m7Bzr7x99gY+/mpK7d50tXFdlDfjnfsl7hTfg6zFtveiYEsNhNOuMVuxV9C8QbbS5MwzH6u+8hEERpctyrdZpP2Yw7/NpgbPIK5QW8TH+s66uUXz8jkz+9t56Uv8rl9weEBen5FHa+v38dNswfhyNluE/aVUkr1C8nRYTx9/Swu/PsKrnpuB//67jmkTbq4e2/qbrFTkYVG2Za5zjRUwcF8qMyHmmIYNN42znSWjuLwBI+t04llTLO5qWCnHTuwywaa5Ts9Xee5sGOZbWX35h14xw+BuME2eInLPjx4aW6wXxhqS+2iIuFxdo7i3gpUjbEzZuz6xH6hKFpv0wM4xoQ0QSH2C0VYtG3hDI2yUze2biERdkGiw4538jjE65zgsCP/OzQ32FSe4o2w/0vP/0muDarbpzCEJ8Bpd8HMm7qe+jGQpE6wWx+kwXWrsm12laB233rWNA1hLhBTsQnij5yjkx4Xzkkjk3lpTQG3nD4Kh9fgx0c+ySNIYHHmXljntlPhKKWU6jfs6rwzuezhlVzz+Oe89K15xEZ0fXXeDoIcNtXjaJwx4PRBjmxQ0KFUlPYaazy5qp5W9dbAe/u7Nng+7H1CbEt8o2eAWHuD58Opv7Bd8j2lap9NEch5Dso8a1XEZduF4CZfbtNhWgOwugqorzi0rz9g699Y7bVV2eNVhdBUB821du+q73qZxGFThBwhNsXHEWYfAxzYfWhGjpBI+3878nSISLI9HBEJdh+eYMsdGumzfyrVczS4blW6DYZ0HLT4flUa3wfbvTb8lKO+xaUzs/jus2v5eHspp4yxgXhpdSMvrM7ngikZJKy9zbYCDDvZ58VXSinlXxMyYnn46ulc+/hqLn9kJZOzYmluMbha3LjcBleLIS3OybmT05maFdc/VnkMi7K52GmTOr7WVGdzXCv3QuUe24peXWxTUyKT7RY1CCIH2XzwT/4HnlhoU1ZOvfP4B+67W6Bki02NKfjCHmtN5WhN7Wiut+kueR/YWS6y5sC5f4Ex50JkYufvG5N+fOUB2/rfXGtTgZpqbQpHY40nNcj7uOc1V6NN+3E12jz8lkZbr/Hn20VLUifZ/OA+ksagfEuDa7Bdb1WFdtlz78PNLawvEypjMojbt+6Yb3P62BQSIkN5YXV+W3D95PJdNLW4uWV4ISxdA+c8cOgbrFJKqX5l3vAk/nr5VO59YxP/3VJCSJAQ7AgiOEhwBAnvbyvhic92k5UQzqLJ6Zw3JYNRKcdeiKauycXmfVVs2lfFhIxYpg+OP+Y1fhcaYf8utvvb2KnM6XbA2epH4NMH4JFTYMw5MO58G9S2bt7zJLcO/qwuhuoiG1DvXWnnZG5tGY9Mti2/9RU2r91bbBaceLttofbnan5gg+CwaLspdQwaXIMdXAKHT8MH7Nhfg9tAfdJE4vblHPNtQoODuGBqBk8u301ZTSNhwUE8vWIPX5+QRtqGu+xSoVOu9EcNlFJK9ZCFE1JZOCG109eqG5p5Z9N+Xs8p5O8f5vLgB7mMSY1m+KAoosOCiQoLJspp98bA5qIqNhYeJLe0htbJDUMdQTx1/SzmDj9CC2xfFRoB838I06+zi4Cs+D+7sp+3iCSbDlPnmf72MAKDxsKECyF7js3hjh9yKH+5ueFQWofbZVt/teVX9UEaXIMdXAAdgustnmXPQ7OnwYq37S/0Mdaev3RmFo9+uotX1xbichuqG1zcPqYC3vgEzvyd/1Y3Ukop1euinSFcND2Ti6ZnUlrdyFsbi3j7y2K2FFVR0+CiptFFXdOhVfBSYsKYmBHL2RPTmJgRy5CkCL79z7UsfmYNL397HqNT+2FLqTMGTv4pzP+BHYxZVejZ9tl9XTlEzLUNTtGph/Zx2UefDSPECSHp3UvvUKoHaHANNrh2hNp8aC9bi6pxhgQRN3y2XYusKMdOfXQUI1OimZodx5LP91LV4OLEkUkM23K/HaAw/Ro/VkIppVRfkhwdxjXzhnDNvCGHHXe1uKltasHtNsRHhna47qnrZ/GNBz/j2ic+55XvziMtNryHSuxjIeFdTytRKoBofwrYEcaJIztMLL61uIrRqTE4MibbA11IDQG7YmNeWS1lNY38eGID7FwGc76ro36VUkoR7AgiNjyk08AaICMunCevm0V1g4trH1/NwfrmTs9TSvVNGlyDbblut3iMMYYtRVWMTY22I5Tjh9qVkrrgnMnpRIQ6mJodx8Rdj9pVlWbd5I+SK6WUCkDj0mP4x1XTyS2t4VvPrKHR1dLpeW73MeZxVkr1OE0Laa6HA3vsaGMvJdWNHKhrZkxrvlv6FDvVUBdEhQXz7I2zSW3cjTy71C5X6oz1dcmVUkoFsBNGJnH/xZO49YX13P7iei6clkluaQ25pTXsLKkht7SW2kYXc4cncuqYQZwyehBZCYevEHygtolVu8pZkVtObmkt3z15OPNGHGN+baVUt2hwXbYDMB1arrcU2cGMY1uXPU+bApte7dKgRoCp2fHwyk/tqk2zv+PrUiullBoAvjE1k+KDjfzh7a28uaEIgMTIUIYnR3Hm+BRCHEF8tL2Uu17fBGxi5KAoThkziBa3YXluOVuLqzAGwkMcRDmDufbJ1Tx01fS26WI70+Ry88gneYxPj+Hk0Uc+TynVOQ2uS7fZffuZQoqqARiT6gmu06fa/a6Pu7Z8eUWeneB+znePPKG9UkopdQzf/towpmXH4QgShidHdZqrnVdawwfbSvlgawlPfLYLEWHG4HhuO30Uc4cnMikzjtpGF1c//jmLn1nDXy+bylkT0zq8T35FHTc/t5b1BQcJCw7ixW/NZXLWUWbwUEp1oMF16Va7VGnC4RPQby2uIj3WeWh526zZdtDj23fA0JOO3Xr96QN2qdh53/dTwZVSSg0EIsLsYUdvpBmWHMWw5ChuOGEo9U0tiIAzxHHYOaHBoTx702yue2I1Ny9Zxx9dbs6fmtH2+rubivnRS+sxwH0XTuIv7+1g8TNrWHrzCaTEOP1RNaUCkl8HNIrIQhHZJiI7ReRnnbx+rYiUikiOZ7vR67UWr+NL/VbIsm2QMAyCD28J2FpUfSglBOz8mhc+ArUl8OYttM3235kv/wVrn4YZ19u5O5VSSqkeEh7q6BBYt4pxhvD09bOYNSSBW1/M4fnP99LkcvOrNzez+JkvGJwYyb+/fyKXzMzi0WtmUN3gYvEzX9DQ3PmASqVUR34LrkXEATwInAWMAy4XkXGdnPqCMWaKZ3vU63i91/FF/ionpds65Fs3ulrILa1hTFq7yfvTp8Kpd8Lm1yHnuc7fb+8qePU7kD0XzrjHT4VWSimljk9kWDBPXDeTk0Ym87NXNrLwzx/z2Ke7uGbuYF7+zlyyE+2gyLFpMfzpkimsz6/kZ//agDlao5JSqo0/W65nATuNMXnGmCbgeeA8P/68r87VBOW5HYLrnSU1uNzmUL61t3k/gMEnwH9+YvOqvVXkwfOXQ2wmXPacrsaolOpXutnbeI2I7PBsumJWH+cMcfDw1dM5a0IqpdWNPHjFNO45bwJhwYe3eC+ckMrtZ4zitZx9/OOjvCO82+EaXS2szCvnbx/uZENBpT+Kr1Sf5s+c6wwg3+t5ATC7k/MuFJGTgO3ArcaY1mucIrIGcAG/N8a81v5CEVkMLAbIzs7+6iWsyAPT0mEw41bPYMbD0kJaBTnggofg7/PglcVw3dt28Zm6Cnj2YjBuuPKlLs0oopRSfYVXb+MZ2Pv1ahFZaozZ3O7UF4wxN7e7NgG4G5gBGOALz7UHeqDo6jiFBTv425XTaGpxdwiqvd186gi27a/mvne2MnJQFKePS2l7rbnFTU2Di7yyWlbmlbM8t4w1uw/Q6HID8OfgHfzx4smcO1mXLFcDR28PaHwDWGKMaRSRbwFPAa3riw82xhSKyDDgfRHZaIzJ9b7YGPMw8DDAjBkzvnp/VelWu086fGnWLUVVhAUHMSQxopOLsC3T5zwAL18PH98PJ94GL1wFlXvh6qWQOLzz65RSqu9q620EEJHW3sb2wXVnzgSWGWMqPNcuAxYCS/xUVuUjInLUwLr1nPsvmsye8jpuXrKWtNhwqhtc1DQ209DsPuzcManRXDE7m3nDkxidEs3tL+Xw/SXrKDhQz7e/NgwR8Wd1lOoT/BlcFwJZXs8zPcfaGGPKvZ4+Ctzn9VqhZ58nIh8CU4HDgutuK90GSIfgemtxNaNSogl2HCVrZsKFsGMZfHwf7F0Bez6DCx+DwXN9WkSllOoh3elt7OzajE6u7X6Po+oV4aE2jeT+t7fR7DZEhQUT4wwmKiyYKGcwqTFOZg1NIDHq8HTIZ26YzY9f3sAf3t5KwYE67lk0/uh/W5UKAP4MrlcDI0VkKDaovgy4wvsEEUkzxhR5ni4CtniOxwN1nhbtJGA+XoG3z8z9How+C0IPtVC7Wtzk5FeyaEoXurDOug/2LIddH8Epd8LEi3xeRKWU6kOO1tvYJd3ucVS9Ji02nD9dOuUrXeMMcfCXS6eQGR/O3z/MpbCynv+7YhpRYTb8cLsNFXVNFB9sIMYZ0jaYUqn+zG/BtTHGJSI3A+8ADuBxY8wmEbkXWGOMWQr8QEQWYfOqK4BrPZePBR4SETd20OXvO8n7676wKEibdNihjYUHqWl0MW94FxZ+ccbY/Oo9y2H6tT4vnlJK9aDu9DYWAie3u/ZDn5dQ9UtBQcJPF44hKz6CX7z+Jef+76ckRIZSfLCBkuoGmlsOfceaOSSeS2dm8/WJqUSE+q/9L6+0hi/2HGBsWgxjUo/RU63UV+TXnGtjzFvAW+2O3eX1+A7gjk6uWw5M9GfZjmR5rv3bMfcYE/a3SR7dYbYRpZTqh467txHbiPJbT68jwAI6uberge2K2dmkxzn507LthDiEmUPiSYl1khpjt93ldby4Jp8fvbSeXy7dxKIp6Vw6I4tJmbE+ydV2uw0f7Sjlyc9289H20rbj4SEOJmXGMm1wPNOy45k7PLGtZV2p46GfnnZW5JYzJjW6Q96YUkoFsu70NhpjKkTkV9gAHeDe1sGNSnk7efQgTh496Iivf/trw1i9+wDPr97LK2sLeG7VXkKDg0iLdZIW6yQ9Npy0OCdZ8RFMzIxl9LHGRwHVDc28/EUBT6/Yw66yWgZFh3HbGaNYMD6F7ftrWLvnAGv3HuCRj/NwuQ3ZCREsWTyHjLhwX1dfDRASKJPCz5gxw6xZs6Zb79HQ3MLke97lytmDuevczta7UUop/xCRL4wxM3q7HD3JF/dtFbiqGpp5e2MxuaU17DvYQFFlPUUHGyiuaqDFbWOX1lbnqdnxTM2OI9oZzK6yWnaV1tp9WS17K+pwuQ1Ts+O4dt4QzpqQRmhwx4C8vqmF5bll3PJ8DnGRISy5aQ6Z8ZoDrjp3tHu2tlx7Wbe3kkaXu2v51koppZTymxhnCJfMzOpwvMVtKDhQR05+Jev2VrIuv5LHPs07LHc7LDiIoUmRjE6NZuGEVM4cn8rkrLij/rzwUAenjU3hmRtn883HVnHZwytZctMcshI0wFZfjQbXXlbklhEkMGuYLgCjlFJK9UWOIGFwYiSDEyM5b4qd8bGhuYVN+6poaG5haFIkqTFOgoKOL097SlYcz944m6setQH284s1wFZfjQ6P9bI8t5yJmXHEOEN6uyhKKaWU6iJniIPpg+OZPyKJ9Ljw4w6sW03KjOO5m+ZQ0+jisodXkl9Rd9zv1dziJr+iji/2HKCm0dWtcqn+QVuuPWobXeTkV3LTScN6uyhKKaWU6mUTMmJtC/Zjq7j0oRV862vDmZARw9i0mA7TBBpjKKluZNO+g2zeV0VeWS0FB+opPFBP0cF6PCniBAcJ0wbH87VRyZw4MokJ6bHd/iKg+h4Nrj1W767A5TbMH57U20VRSimlVB8wISOW526cw+Jn1nD30k0ABAkMS45iQnoMydFhbC2uZktRFWU1TW3XpcY4yUoIZ9bQBLLiw8mMjyAuIoR1+ZV8vL2U+9/Zxv3vbCM+IoQTRyZz+rgUTh6drD3nAUKDa4/lueWEOoKYPjj+2CcrpZRSakAYlx7DJz85hf1VjXxZeJCNhQfZtO8gK/MqKK9tZOSgaE4ZPYhx6TGMT49lbFo00UcIkheMT+WnC8dQWt3IZzvL+Hh7KR9uL2Xp+n2EOIQ5wxI5Y1wKp49NId3HUwHWNrrILa2hvKaJOcMSCQ91+PT91SEaXHsszy1janacftiUUkopdRgRITXWSWqsk9PHpbQdd7vNcaV1JEeHcf7UDM6fmkGL27B27wH+u3k/yzbv567XN3HX65sI80wX6D1hcognreTEkUmcNCqZ0SnRHRbYqW10sbW4ii1F1ewsqSG3tIadJTUUHWxoOycuIoRLZ2Rx1ZzBOljTDzS4Birrmti0r4pbThvV20VRSimlVD/hi3xpR5Awc0gCM4ckcMfXx7KzpIb3t+6nvPZQmolgf05to4uVeeX89q2t/PatrQyKDuPEkclkJYSzzZOesrv80ODLyFAHwwdFMWdYIiMGRTE8ORJniIMX1+Tz6Ke7ePiTPE4bk8K184Ywf0TiMVfCPFjfzB/f3ca/NxSx+KRhXDd/aKdzhg90GlwDK/MqMAbmjdD5rZVSSinVe0YMimLEoKijnlN0sJ5Ptpfx0Y5S3tu6n8q6ZoYkRjA2LYYLpmUyNi2GsWnRZMSFdxownzx6EPsq63l21R6WfJ7Pf7fsZ8SgKK6eO5gLpmV2WP7dGMPrOfv49b+3UFHbyISMWH73n628uCafe8+bwPwROl7Nm67QCNz9+pe8uKaA9Xcv0G9gSqleoSs0KqWOR4vb0ORyH3daa0NzC29uKOLpFbvZUHCQ6LBgLpyeyTXzhjA0KZKdJdXc+dqXrMyrYHJWHL85fwITMmJ5b8t+7nljM3sr6jhnUhp3nj2O1FinbyvXh+kKjcewPLecmUMTNLBWSimlVL/iCJJujRdzhji4aHomF07LYF1+JU8t382zq/bw5PLdzBgcz/qCSsJDHPzmGxO4bGY2Dk8qzGljU5g/IomHPsrjbx/u5P2tJZw/NYPUGCcJkaEkRYWSEBlGUlQoQxIjjzuFpqqhmS8LDzI1K77fjIsb8MF1SVUDO0pquGh6Zm8XRSmllFKqV4gI07LjmZYdz8/PHsuSVfm8vr6Q86Zk8LOzxpAUFdbhGmeIgx+ePpJvTM3gN29t5s31+6hq6LhQzvDkSK6bP5QLpmV0mCO8MyVVDSzbsp93Nu1nRW4ZzS2GcWkxPHLNDDJ8PIuKPwz4tJDXcwr54fM5vHHzCUzMjPVDyZRS6tg0LUQpFQiaXG4O1DVRVtNIRW0T+RX1PL96LxvmApx1AAALsElEQVQKDhLjDOby2dlcPXdIW5Dc0NzSNqPJzpIaPt1Zxrq9lQAMSYzgzPGpDE2K5Df/3kJYSBD/uGo6M4Yk9GYVAU0LOarlO8uJcQYzLj2mt4uilFJKKdWvhQYHkRLjJCXmUP715bOyWLv3AI9/uptHP9nFo5/sYlp2HMVVDRQcqKe1nTdI7Lzit58xigXjUxmVEtU2IHPGkARufGo1lz+ykt98YyKXzMg67OfWNLp4Y/0+Xl1bSHJ0GLeeMeqYA0MbmlvYWlzNlKw4n/4b+DW4FpGFwF8AB/CoMeb37V6/FrgfKPQc+j9jzKOe164B7vQc/7Ux5il/lHF5XhlzhiW25RAppZRSSinfERGmD05g+uAECivreXrFblbmljM5M44Lp2W2zZAyJNFOFdiZEYOieO1787n5uXX85OUNbC+u5mdnjWF9wUFeWL2XNzcUUdfUwohBUWwuquLtTcVcMiOLW04feVigD5BfUcezq/by4pp8GptbWPXz0zvMkNIdfguuRcQBPAicARQAq0VkqTFmc7tTXzDG3Nzu2gTgbmAGdv70LzzXHvBlGfMr6sivqOeG+UN9+bZKKaWUUqoTGXHh3HHW2OO6Ni4ilCevm8mv/72FRz/dxb/WFnCgrpmIUAeLJqdz6cwspmTFUVHbxP++v5NnV+3h1XUF3HjCMG46aRhr9x7gnyv28P62EgQ4Y1wK35wzhIgjBPTHy58t17OAncaYPAAReR44D2gfXHfmTGCZMabCc+0yYCGwxJcFXJ5bBsA8nZ9RKaW60tt4G3Aj4AJKgeuNMXs8r7UAGz2n7jXGLOqxgiulBoxgRxC/XDSecWkxvLOpmAXjUzh7UvphLc+JUWH8ctF4rp8/lP95dxv/98FO/v5RLi1uQ1JUGDefMoLLZ2X7fIn5tjL65V2tDCDf63kBMLuT8y4UkZOA7cCtxpj8I1yb0f5CEVkMLAbIzs7+ygWMiwhlwbgURh4jJ0cppQJdF3sb1wEzjDF1IvId4D7gUs9r9caYKT1aaKXUgHXJzCwumZl11HOyEyP46+VTWXzSMF5ak8+MIQmcOT7V71Mv9/aAxjeAJcaYRhH5FvAUcGpXLzbGPAw8DHbU+Vf94WeOT+XM8alf9TKllApEx+xtNMZ84HX+SuCqHi2hUkodhwkZsUzI6LkZ4fwZuhcC3l8pMjk0cBEAY0y5MabR8/RRYHpXr1VKKeVTXeox9HID8B+v504RWSMiK0Xk/CNdJCKLPeetKS0t7V6JlVKqD/JncL0aGCkiQ0UkFLgMWOp9goikeT1dBGzxPH4HWCAi8SISDyzwHFNKKdXLROQq7IDz+70OD/bM+XoF8GcRGd7ZtcaYh40xM4wxM5KTk3ugtEop1bP8lhZijHGJyM3YoNgBPG6M2SQi9wJrjDFLgR+IyCLs4JgK4FrPtRUi8itsgA5wb+vgRqWUUn7RpR5DETkd+DnwNa+eR4wxhZ59noh8CEwFcv1ZYKWU6ov8mnNtjHkLeKvdsbu8Ht8B3HGEax8HHvdn+ZRSSrVp623EBtWXYVuh24jIVOAhYKExpsTreDxQ5xk/kwTMxw52VEqpAae3BzQqpZTqA7rY23g/EAW85Fk1rXXKvbHAQyLixqYb/r6TNQ2UUmpA0OBaKaUU0KXextOPcN1yYKJ/S6eUUv2Dfyf6U0oppZRSagDR4FoppZRSSikfEWO+8torfZKIlAJ7juPSJKDMx8XpawK9joFePwj8OgZ6/eDYdRxsjBlQc9PpffuItH79X6DXMdDrB924ZwdMcH28RGSNZ27WgBXodQz0+kHg1zHQ6wcDo449JdD/LbV+/V+g1zHQ6wfdq6OmhSillFJKKeUjGlwrpZRSSinlIxpcw8O9XYAeEOh1DPT6QeDXMdDrBwOjjj0l0P8ttX79X6DXMdDrB92o44DPuVZKKaWUUspXtOVaKaWUUkopH9HgWimllFJKKR8Z0MG1iCwUkW0islNEftbb5fEFEXlcREpE5EuvYwkiskxEdnj28b1Zxu4QkSwR+UBENovIJhH5oed4QNRRRJwi8rmIrPfU7x7P8aEissrzWX1BREJ7u6zdISIOEVknIm96ngda/XaLyEYRyRGRNZ5jAfEZ7U16z+5/9J4dGPc0COz7tq/v2QM2uBYRB/AgcBYwDrhcRMb1bql84klgYbtjPwPeM8aMBN7zPO+vXMDtxphxwBzge57/t0CpYyNwqjFmMjAFWCgic4A/AA8YY0YAB4AberGMvvBDYIvX80CrH8ApxpgpXvOkBspntFfoPbvf0nt24NzTAv2+7bN79oANroFZwE5jTJ4xpgl4Hjivl8vUbcaYj4GKdofPA57yPH4KOL9HC+VDxpgiY8xaz+Nq7C96BgFSR2PVeJ6GeDYDnAq87Dneb+sHICKZwNnAo57nQgDV7ygC4jPai/Se3Q/pPRvox/VrNUDv28f9GR3IwXUGkO/1vMBzLBClGGOKPI+LgZTeLIyviMgQYCqwigCqo6frLQcoAZYBuUClMcblOaW/f1b/DPwEcHueJxJY9QP7x/VdEflCRBZ7jgXMZ7SX6D27n9N7dr8W6Pdtn96zg31dOtW3GWOMiPT7+RdFJAr4F3CLMabKfom2+nsdjTEtwBQRiQNeBcb0cpF8RkTOAUqMMV+IyMm9XR4/OsEYUygig4BlIrLV+8X+/hlVPSdQPit6z+6/Bsh926f37IHccl0IZHk9z/QcC0T7RSQNwLMv6eXydIuIhGBv0s8aY17xHA6oOgIYYyqBD4C5QJyItH4Z7s+f1fnAIhHZje3WPxX4C4FTPwCMMYWefQn2j+0sAvAz2sP0nt1P6T27339WA/6+7et79kAOrlcDIz2jXUOBy4ClvVwmf1kKXON5fA3wei+WpVs8eV6PAVuMMX/yeikg6igiyZ7WD0QkHDgDm6P4AXCR57R+Wz9jzB3GmExjzBDs79z7xpgrCZD6AYhIpIhEtz4GFgBfEiCf0V6k9+x+SO/ZQD+uHwT+fdsf9+wBvUKjiHwdm0fkAB43xvyml4vUbSKyBDgZSAL2A3cDrwEvAtnAHuASY0z7ATT9goicAHwCbORQ7tf/w+bw9fs6isgk7MAJB/bL74vGmHtFZBi2xSABWAdcZYxp7L2Sdp+ne/FHxphzAql+nrq86nkaDDxnjPmNiCQSAJ/R3qT37P5H79n9/57mLRDv2/64Zw/o4FoppZRSSilfGshpIUoppZRSSvmUBtdKKaWUUkr5iAbXSimllFJK+YgG10oppZRSSvmIBtdKKaWUUkr5iAbXSvmIiJwsIm/2djmUUkodm96zlb9ocK2UUkoppZSPaHCtBhwRuUpEPheRHBF5SEQcIlIjIg+IyCYReU9Ekj3nThGRlSKyQUReFZF4z/ERIvJfEVkvImtFZLjn7aNE5GUR2Soiz3pWJ1NKKXWc9J6t+hsNrtWAIiJjgUuB+caYKUALcCUQCawxxowHPsKukgbwNPBTY8wk7ApjrcefBR40xkwG5gFFnuNTgVuAccAwYL7fK6WUUgFK79mqPwru7QIo1cNOA6YDqz0NFOFACXZZ3hc85/wTeEVEYoE4Y8xHnuNPAS+JSDSQYYx5FcAY0wDgeb/PjTEFnuc5wBDgU/9XSymlApLes1W/o8G1GmgEeMoYc8dhB0V+0e48c5zv3+j1uAX9HVNKqe7Qe7bqdzQtRA007wEXicggABFJEJHB2N+FizznXAF8aow5CBwQkRM9x78JfGSMqQYKROR8z3uEiUhEj9ZCKaUGBr1nq35Hv6GpAcUYs1lE7gTeFZEgoBn4HlALzPK8VoLN8QO4BviH50acB1znOf5N4CERudfzHhf3YDWUUmpA0Hu26o/EmOPtSVEqcIhIjTEmqrfLoZRS6tj0nq36Mk0LUUoppZRSyke05VoppZRSSikf0ZZrpZRSSimlfESDa6WUUkoppXxEg2ullFJKKaV8RINrpZRSSimlfESDa6WUUkoppXzk/wOU7dsksYr6tAAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAtcAAAEWCAYAAACt0rvRAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8li6FKAAAgAElEQVR4nOzdd3zV5fXA8c+5OwsCJGwCQfZQloCCe4G17oGjraPFtmrt0KqtVWtrS5frp7ZStVqtOFCRKs46QJFtlCkbkrBHIPPmjuf3x/cm3CQ3IQn3e29Izvv1yiu533Fzbqm5JyfnOY8YY1BKKaWUUkodOUeyA1BKKaWUUqq10ORaKaWUUkqpONHkWimllFJKqTjR5FoppZRSSqk40eRaKaWUUkqpONHkWimllFJKqTjR5FoppZRSRwUR2SwiZyY7DqUaosm1UkoppZRScaLJtVJKKaWUUnGiybVSgIjcKSIbRKRYRFaJyEVR534gIqujzo2KHO8lIq+LyG4R2SsijyXvFSilVNshIl4ReVhEtkU+HhYRb+Rcloi8JSJFIrJPROaJiCNy7g4RKYz8PP9GRM5I7itRrZEr2QEo1UJsAE4CdgCXAS+ISD9gInAfcCGwBDgGCIiIE3gL+Aj4DhACxiQ+bKWUapN+DYwHRgAGeBO4G/gN8AugAMiOXDseMCIyELgZON4Ys01E+gDOxIat2gKtXCsFGGNeNcZsM8aEjTEvA+uAscD3gT8bYxYby3pjzJbIue7A7caYUmNMhTHmsyS+BKWUakuuBu43xuwyxuwGfotV6AAIAN2A3saYgDFmnjHGYBVBvMAQEXEbYzYbYzYkJXrVqmlyrRQgIt8VkbzInxGLgGFAFtALq6pdWy9gizEmmMg4lVJKAVZxY0vU4y2RYwB/AdYD74vIRhG5E8AYsx74KdZfI3eJyEsi0h2l4kyTa9XmiUhv4J9Yfy7sZIzJBFYAAuRjtYLUlg/kiIi2VimlVOJtA3pHPc6JHMMYU2yM+YUxpi9wPvDzqt5qY8yLxpiJkXsN8KfEhq3aAk2ulYI0rB+yuwFE5DqsyjXAU8BtIjJaLP0iyfgiYDswTUTSRMQnIhOSEbxSSrVBM4C7RSRbRLKAe4AXAETkvMjPagEOYLWDhEVkoIicHln4WAGUA+Ekxa9aMU2uVZtnjFkF/A34AtgJDAc+j5x7FXgAeBEoBmYBHY0xIeDbQD9gK9bimSsSHrxSSrVNv8daZP41sBxYFjkG0B/4ECjB+rn+hDHmY6x+62nAHqzF652BuxIbtmoLxOrxV0oppZRSSh0prVwrpZRSSikVJ5pcK6WUUkopFSeaXCullFJKKRUnmlwrpZRSSikVJ61mRm9WVpbp06dPssNQSqlmWbp06R5jTPbhr2w99Oe2Uupo1dDPbFuTaxGZBDwCOIGnjDHTap3PAZ4DMiPX3GmMmSMifYDVwDeRSxcYY37Y0Pfq06cPS5Ysie8LUEqpBBGRLYe/qnXRn9tKqaNVQz+zbUuuRcQJPA6chTUDeLGIzI7MFK5yN/CKMebvIjIEmAP0iZzbYIwZYVd8SimllFJKxZudPddjgfXGmI3GmErgJeCCWtcYoF3k6/ZEti5VSimllFLqaGRnct0DyI96XBA5Fu0+4BoRKcCqWt8SdS5XRL4UkU9F5KRY30BEporIEhFZsnv37jiGrpRSSimlVNMle0HjlcCzxpi/icgJwPMiMgzYDuQYY/aKyGhglogMNcYcjL7ZGDMdmA4wZsyYOltNBgIBCgoKqKiosP+VJJnP56Nnz5643e5kh6KUUkqpVq6t5FjNya/sTK4LgV5Rj3tGjkW7AZgEYIz5QkR8QJYxZhfgjxxfKiIbgAFAk1a+FBQUkJGRQZ8+fRCRZr6Mls8Yw969eykoKCA3NzfZ4SillFKqlWsLOVZz8ys720IWA/1FJFdEPMAUYHata7YCZwCIyGDAB+wWkezIgkhEpC/QH9jY1AAqKiro1KlTq/1HryIidOrUqdX/9qiUUkqplqEt5FjNza9sq1wbY4IicjPwHtaYvWeMMStF5H5giTFmNvAL4J8i8jOsxY3XGmOMiJwM3C8iASAM/NAYs685cbTmf/RobeV1KqWUUqplaAu5R3Neo60918aYOVgLFaOP3RP19SpgQoz7XgNeszM2pZSKNnftblwO4cR+Wc1+DmMM/mAYn9sZx8hUc33yzS6OyU6nV8fUZIeilGpDdPtzmxUVFfHEE080+b5zzz2XoqIiGyJSSkXbU+Ln5heX8d1nFnHds4vZtKe0Wc+Tv6+M7zy9iDtf+zrOEarm+smML3n6s03JDkMpZYOWnF9pcm2z+v7xg8Fgg/fNmTOHzMxMu8JSqs0zxjDry0LOevBT3l+5kx+fegxel4M7Zn5NOFxn+FC9QmHDvz7fxNkPzSUvv4gxfTpiTOPvV/YpqwxxsDyQ7DCUUjZoyflVskfxtXp33nknGzZsYMSIEbjdbnw+Hx06dGDNmjWsXbuWCy+8kPz8fCoqKrj11luZOnUqcGhb4JKSEiZPnszEiROZP38+PXr04M033yQlJSXJr0ypo9e2onLunrWCj9bsYmROJn++5Fj6d8kgNyuN22d+zfMLtvC9E/sc9nnW7yrmlzO/ZtnWIk4dmM0fLhpO98zW999mZJLTXMCL9b4x0xhzb61rvMC/gdHAXuAKY8zmBIdaLRgKEwwbDlY0/EarlDo6teT8qs0k17/970pWbTt4+AubYEj3dtz77aENXjNt2jRWrFhBXl4en3zyCd/61rdYsWJF9UiXZ555ho4dO1JeXs7xxx/PJZdcQqdOnWo8x7p165gxYwb//Oc/ufzyy3nttde45ppr4vpalGorPl6zi1tmfEkobPjNeUO49sQ+OB3WgpVLR/fk7eXb+dO7azh9UOd6e3UDoTBPfrqBR/+3nlSvk4euOI4LR/RozYt7/MDpxpgSEXEDn4nIO8aYBVHX3ADsN8b0E5EpwJ+AK5IRLIA/GAagxK+Va6XslowcqyXnV9oWkmBjx46tMSvx0Ucf5bjjjmP8+PHk5+ezbt26Ovfk5uYyYsQIAEaPHs3mzZsTFa5Srcp7K3cw9fkl9MlK5b2fnswNE3OrE2uwVoX/4aLhOES447WvY7Z3bD9QzpTpC/jr+2s5a2gXPvz5KVw0smdrTqwxlpLIQ3fko/b/OBcAz0W+ngmcIUn8H6UiEAKgWCvXSrUJLSm/ajOV68NVmBMlLS2t+utPPvmEDz/8kC+++ILU1FROPfXUmLMUvV5v9ddOp5Py8vKExKrU0eKhD9by3sod/Pb8oYzr2ynmNW9/vZ1bX/qSYT3a89z1Y2mfEnu3re6ZKfzq3MH86o3lzFiUz1XjcqrPzV27m5++nIc/EOKRKSO4YEQPW15PSxTZe2Ap0A943BizsNYlPYB8qB7FegDoBOyp9TxTgakAOTk52OVQ5VqTa6Xs1hJyrJaUX2nl2mYZGRkUFxfHPHfgwAE6dOhAamoqa9asYcGCBTGvU0o17M28QtbsKOaK6Qv4zawVFFcE6py/ZcYyRuZk8vwN9SfWVa4c24sJ/TrxhzmrKSwqJxQ2PPj+N3zvX4vonOFl9i0T21RiDWCMCRljRmDttjtWRIY183mmG2PGGGPGZGdnxzfIKFWV6xKtXCvVKrXk/KrNVK6TpVOnTkyYMIFhw4aRkpJCly5dqs9NmjSJf/zjHwwePJiBAwcyfvz4JEaq1NFp58EKNu8t4+dnDaCoLMC/5m/if6t38sDFwzltYGdmLi3g9plfMS63I09/73jSvIf/sSciTLv4WM55eC63v/oVxsAXG/dy+Zie/Pb8YaR42u4ca2NMkYh8DEwCVkSdKgR6AQUi4gLaYy1stF/xDjhYCD1GVx+qqlxrW4hSrVNLzq80uU6AF198MeZxr9fLO++8E/NcVd9PVlYWK1Ycev+67bbb4h6fUkezRZuszVtPHZjNsT0zOe+4btwx82uu+9diJvbL4vMNe5hwTBb//O6YJiXFvTqmcsekQdw7eyU+t4O/XHosl43pZdfLaNFEJBsIRBLrFOAsrAWL0WYD3wO+AC4FPjKJmkn42UOw8g24bW31oarKdWUojD8Ywutqu78QKdVatdT8SpNrpdRRbeGmvaR7XQzp1g6AUTkdeOsnE3n8o/U88ckGThmQzT+uGd2sXRO/M743xhhOOCaLgV0z4h360aQb8Fyk79oBvGKMeUtE7geWGGNmA08Dz4vIemAfMCVh0VUcgLJ9NQ8FwtVfF1cE8aZrcq2USgxNrpVSR7VFm/YxuncHXM5DS0i8Lic/P3sg107IJTPFjcPRvKEVDodw7YTcw1/YyhljvgZGxjh+T9TXFcBliYyrWqAcwgEIVoLLA4A/GKo+XVIRJCvdW9/dSikVV7qgUSl11NpXWsnanSWMze0Y83zHNE+zE2t1FAlGpgBUllQfql25VkqpRNHkWil11Fq82WoFGFdPcq3aiEBkfFZUch1duS7WjWSUUgmkybVS6qi1aNM+vC4Hw3u2T3YoKpmqK9el1Yf8UZVrHcenlEokTa6VUkethZv2MjInUydBtHVVlWt/VFtIdOVak2ulVAJpcm2zoqIinnjiiWbd+/DDD1NWVhbniJRqHQ5WBFi17SDjcmPvyKjakBg91zUq17pLo1KtTkvOrzS5tllL/sdX6mi2dMt+wkb7rRUQqNsWUjXnGqizY6dS6ujXkvMrHcVnszvvvJMNGzYwYsQIzjrrLDp37swrr7yC3+/noosu4re//S2lpaVcfvnlFBQUEAqF+M1vfsPOnTvZtm0bp512GllZWXz88cfJfilK2SIcNlSGwk2eQ71o0z5cDmFkTgebIlNHjWCsBY1hnA7B6RCKtXKtVKvTkvOrtpNcv3Mn7Fge3+fsOhwmT2vwkmnTprFixQry8vJ4//33mTlzJosWLcIYw/nnn8/cuXPZvXs33bt35+233wbgwIEDtG/fngcffJCPP/6YrKys+MatVAvywJzVzP5qG2/eNIHumSmNvm/Rpn0c27N9m96KXEUEYo3iC+F1OUj1OHVBo1J2S0KO1ZLzK20LSaD333+f999/n5EjRzJq1CjWrFnDunXrGD58OB988AF33HEH8+bNo317nXyg2oaKQIhXFuezu9jPzS8uozIYPvxNQHlliK8Lihir/dYKDlWu/TUr1z63k3SvSxc0KtXKtbT8ytbKtYhMAh4BnMBTxphptc7nAM8BmZFr7jTGzImcuwu4AQgBPzHGvHdEwRymwpwIxhjuuusubrzxxjrnli1bxpw5c7j77rs544wzuOeee2I8g1Kty/urdlLsD/Kd8b15fsEW/vjOau799tDD3vfl1v0EQkb7rRWEAhCOJM+1eq59LgfpPpcuaFTKbknOsVpafmVb5VpEnMDjwGRgCHCliAypddndwCvGmJHAFOCJyL1DIo+HApOAJyLPd9TJyMiguLgYgHPOOYdnnnmGkhKrulJYWMiuXbvYtm0bqampXHPNNdx+++0sW7aszr1KtUavLS2gR2YKvz1/KNee2Id/fb6Zt77edtj7Fm7ah0NgdB/tt27zqsbwQc3kOhjG63aS4XXrgkalWqGWnF/ZWbkeC6w3xmwEEJGXgAuAVVHXGKBd5Ov2QNW76gXAS8YYP7BJRNZHnu8LG+O1RadOnZgwYQLDhg1j8uTJXHXVVZxwwgkApKen88ILL7B+/Xpuv/12HA4Hbrebv//97wBMnTqVSZMm0b17d13QqFqdXQcrmLduNz8+tR8Oh/CrcwfzdUERd8z8mkFd29Gvc3q99y7atI8h3dvRzudOYMSqRaoawwdQeejN0h/puU73ucjfp1OXlGptWnJ+ZWdy3QPIj3pcAIyrdc19wPsicguQBpwZde+CWvf2qP0NRGQqMBUgJycnLkHb4cUXX6zx+NZbb63x+JhjjuGcc86pc98tt9zCLbfcYmtsSiXLrLxCwgYuGmX9p+1xOXj86lF869HP+PF/ljLrpgmkeur+iKoMhlm2dT9Xj+ud6JBVS3S4yrVPe66Vaq1aan6V7AWNVwLPGmN6AucCz4tIo2Myxkw3xowxxozJzs62LUilVHwZY3htaSEjemVyTPahCnW39ik8MmUE63aV8Os3VmCMqXPv8sIi/MEwY7XfWkHNynX0gsZIz3WGV3uulVKJZWdyXQj0inrcM3Is2g3AKwDGmC8AH5DVyHuVUkepldsO8s3OYi4Z3bPOuZP6Z/OzMwfwxpeF3P/WKg6U1+yXXbhpH4Am18rSQOXa53ZWL2iM9YuaUkrZwc7kejHQX0RyRcSDtUBxdq1rtgJnAIjIYKzkenfkuiki4hWRXKA/sKg5QbSVH6ht5XWq1uH1ZYV4nA6+fWy3mOdvPq0fV47N4dn5mznlLx/z1LyN1TvuLdy4jwFd0umY5klkyKqlqqpcO9y1tj+3eq4zfG5CYUN51I6NSqn4aAu5R3Neo23JtTEmCNwMvAesxpoKslJE7heR8yOX/QL4gYh8BcwArjWWlVgV7VXAu8BNxpgm/2T0+Xzs3bu31f/jG2PYu3cvPp8v2aEodViBUJg38wo5Y3BnMlNjJ8gOh/DHi4fz1i0TObZnJr9/ezVn/O1TZi4tYOmW/Vq1VodUVa7Tsurs0Fg15xrQjWSUirO2kGM1N7+ydc51ZGb1nFrH7on6ehUwoZ57HwAeOJLv37NnTwoKCti9e/eRPM1Rwefz0bNn3T+xK5UMD3+4ls4ZPq4aV3eh8dy1u9lbWsnFow7//9eh3dvz7+vH8vn6PfzxndXc9upXALp5jDqkqnKdlgWle6oPV1RXrq23uYMVQTq3i/UESqnmaCs5VnPyq1a9/bnb7SY3NzfZYSjVpqwoPMDDH64DYO3OYn5z3hCcDqk+/9qyAjqmeTh1YOMXIU/ol8Xsmyby36+38dGaXU26V7VyVZXr1CzYt7n6cFXluiq51kWNSsWX5lj1a9XJtVIq8Z6cu5EMr4uLRvXg2fmbKdhfzqNXjiDV4+JAWYAPV+3iqnE5uJ1N60pzOIQLRvTgghF1pnKqtqy6cp1ttYUYAyLWDo1uq+catC1EKZU4yR7Fp5RqRfL3lfH219u4anwO918wjN+eP5SP1uxkyvQF7Cqu4K3l26gMhbk0xpQQpZoluucaA4FyjDGRtpBDPde6S6NSKlG0cq2Uipun5m3E6RCun2D9qfB7J/ahR2YKt8z4kosen0+a18mALukM7a7NrypOqirXqZE+/MoSgk4fYQM+t+NQcq1tIUqpBNHKtVIqLvaVVvLyknwuGtmDLu0Oraw+c0gXXrnxBCpDYdbuLOGSUT0RkQaeSakmqK5cR/rwK0uqxzZ6XU7aRdpCdJdGpVSiaOVaKRUXz83fTEUgzNST+9Y5N7xne9748Ym8sGArU8bWnSCiVLMFKwCBlA7WY38Jfk8YsCrXaV4noD3XSqnE0eRaKXXEyiqD/PuLzZw5uAv9OmfEvKZnh1TunDwosYGp1i9QDu4U8KZbjytLa1SuXU4HqR4nJX7tuVZKJYa2hSiljtirSwrYXxbgh6fUrVorZatAObh84In8UldZSkXAqlx73dZbXLrXpW0hSqmE0eRaKXVEgqEw/5y3kdG9OzCmj+6cqBIsWGFVrj1p1uPKYvxBq3Ltc1stIek+ly5oVEoljCbXSqkjMmfFDgr2l3NjjF5rpWxXXbmuSq6jKtcu6y0uw+fWyrVSKmE0uVZKNZsxhic/3UDf7DTOHNwl2eEoG4hILxH5WERWichKEbk1xjWnisgBEcmLfNyTsACrKtfeSFuIv6RO5TrD66JE51wrpRJEFzQqpZrFGMMbXxaycttB/nTJcBwOHa/XSgWBXxhjlolIBrBURD4wxqyqdd08Y8x5CY+uTuW6BH+dyrWLnQcrEh6aUqpt0uRaKdUk5ZUh3viykGfnb2LtzhL6Zqdx4Ujdkry1MsZsB7ZHvi4WkdVAD6B2cp0cVZVrlxcc7hrTQqp7rr0uSrTnWimVIJpcK6UaZVtROc8v2MKMRVspKgswtHs7/nrZcZx3bDe8Lmeyw1MJICJ9gJHAwhinTxCRr4BtwG3GmJX1PMdUYCpATk4cZp4HyiG9s/W1J82qXAer5lxH2kJ8bp1zrZRKGE2ulVINMsbwzOebmfbOakJhw9lDunLdhD6Mze2oOy22ISKSDrwG/NQYc7DW6WVAb2NMiYicC8wC+sd6HmPMdGA6wJgxY8wRBxassNpCADzpteZcR0bx+VyUVAYJh422LymlbKfJtVKqXgfKA/xy5le8t3InZw3pwj3nDaFXx9Rkh6USTETcWIn1f4wxr9c+H51sG2PmiMgTIpJljNkTzzj2lPiZt243E/pl0TkjklBXbSID1kYy/uK6lWuvC2OgtDJIRmQ7dKWUsotOC1FKxbSi8ADf/r/P+N/qXdz9rcFM/85oTazbILH+PPE0sNoY82A913SNXIeIjMV6b9kb71i27C3lZy9/xZrtxYcO1qhcp8WsXGf4rDqSjuNTSiWCVq6VUjUYY/jPwq3c/9YqOqV5ePnG8YzurZvDtGETgO8Ay0UkL3LsV0AOgDHmH8ClwI9EJAiUA1OMMUfe8lFLqsd6yyqrjEqSAxWHKteRtpCqynV0WwigixqVUgmhybVSqtreEj/3zF7J219v5+QB2Tx8xQg6pnmSHZZKImPMZ0CDjcrGmMeAx+yOJdVjtXmU+kOHDgbLa/Zcl+2lIhDC5RBczkObyIBWrpVSiaHJtVIKYwz//Xo7981eSXFFgNvPGciPTjlGF3+pFqW6ch1p+yAcglBlVOXamhZSEQhX91uDNYoPoFg3klFKJYCtybWITAIeAZzAU8aYabXOPwScFnmYCnQ2xmRGzoWA5ZFzW40x59sZq1JHorConEAwTJ+stGSH0mQ7DlRw96wVfLh6J8f1bM+fLh3HoK7tkh2WUnWkea2EuayqvSMY2RimqnLtTa/eodHnPrSkKEPbQpRSCWRbci0iTuBx4CygAFgsIrOjd/Uyxvws6vpbsOanVik3xoywKz6l4mFviZ/HPl7PCwu2kOZ1Me+Xp7XIaQTFFQHKK0N1jn+0ZhcPvL2aQDjMr88dzPUTc3FqtVq1UD6XExEorfr/ciCSXNeoXJdSEQjXmL2uCxqVUolkZ+V6LLDeGLMRQEReAi6g/l29rgTutTEepeKmrDLIM59t4h+fbqSsMsjkYd14e/l2nvlsM7eeGXO8b9Lk7yvjzAc/rV7kVdv4vh2ZdvGxR2XVXbUtDoeQ4nYeqlwHyqzP1T3XGRAspzJQiTeqcl3VFqIbySilEsHO5LoHkB/1uAAYF+tCEekN5AIfRR32icgSIAhMM8bMsitQpRqrauvvhz9cy65iP2cN6cIvzxlI/y4ZBJ9fwlPzNvK9E3uTmdpyFgHOWLSVQCjMfd8egttVc/pmdrqXMwd30d5qddRI9bgO9VwHY1SuASpLa1Su0zwuRLTnWimVGC1lQeMUYKYxJvrv1r2NMYUi0hf4SESWG2M2RN8U9210lYqhxB/kozW7eGf5dj75ZjflgRCje3fg8atHcXyfQyPqfnbWAN5fNY9/ztvI7ecMSmLEhwRCYV5ZUsDpgzpz7YTcZIej1BFL80ZXrsutz9FzrgGpLMXnzqy+x+EQ0j0uirXnWimVAHYm14VAr6jHPSPHYpkC3BR9wBhTGPm8UUQ+werH3lDrmvhuo6tUhDGGd1bs4PVlBcxdt4fKYJjsDC+XjO7BucO7cULfTnW2/h7UtR3fGt6Nf32+mesn5NIp3Zuk6A/5cNVO9pT4uWqc/vKpWodUj+tQz3V15TqyuZE3AwBHoBSfp1ON+9J9Lm0LUUolhJ3J9WKgv4jkYiXVU4Cral8kIoOADsAXUcc6AGXGGL+IZGFtYvBnG2NVqlr+vjJ+9cZy5q3bQ/f2Pq4Z15vJw7syKqfDYRf7/fTMAcxZvp0n527kV+cOTlDE9Xtx0Va6t/dxyoDOyQ5FqbhI9TgPLc6tqly7a1auHYFSvGk1W6AyfC5d0KiUSgjbkmtjTFBEbgbewxrF94wxZqWI3A8sMcbMjlw6BXip1m5eg4EnRSSMtY3utOgpI0rZIRw2PL9gC396dw0C/O6CoVw9rneT+pH7dU7nwhE9eG7+Zr4/MZfO7Xx1rlm/q4T/rd7J9RNzcTsdMZ4lPrbsLWXeuj387MwBOgFEtRqpHuehkXrVo/iidmgEnMEyfFE912AtatRRfEqpRLC159oYMweYU+vYPbUe3xfjvvnAcDtjUyraht0l3DHza5Zs2c8pA7L5w8XD6ZGZ0qznuvXM/rz51Tae+GQD950/tMa5N/MKuev15ZRVhuiemcK3j+sej/BjemlxPg6BK47vdfiLlTpKpHlc7Drotx7UU7l2BUtqTAsBa5fGorLKRIWplGrD7CubKXWUePvr7Ux+ZB7rd5fw4OXH8ex1xzc7sQbo3SmNy0b35MWFW9lWZL35VwRC/PqN5dz6Uh5DurWjR2YKMxZtjddLqKMyGObVJfmcPqgLXdvXrZ4rdbRK9TopraxnE5lI5doVq3Lt0wWNSqnE0ORatWmBUJgH3l7FgC7pfPCzU7h4VM86CxWb4+bT+2EwPPbxerbsLeWSv8/nPwu3cuMpfZkxdTxXjcth/oa9bNpTGodXUdcHq3ayp6SSq3Uho2plYvdcR34Z9lrJtSdcVmOHRoB2uqBRKZUgmlyrNu2/X21j24EKfnHWQLIz4jfdo2eHVKYcn8Mri/M57/8+o2B/OU99dwx3TR6M2+ngsjE9cTnEtur1jEVb6ZGZwskDsm15fqWSJc3jaqBybbWFuEPleN11e651QaNSKhE0uVZtljGGJz/dyMAuGZw6MP5J6M2n98PrctA3K423bpnImUO6VJ/rnOHjrCFdmLm0AH+w7rbkR2LznlI+W7+HKcf30oWMqtVJ9bioCIQJhU3dyrWnqnJdjq/WhknpXjflgRDBUOydSpVSKl40uVZt1idrd/PNzmKmntw3Lq0gtXVp5+OzO07ntR+dSK+OqXXOXzk2h32llby7Ykdcv++MxVtxOoTLdSGjaoVSPVZFuqwyWLdy7XBiXCmkUbdyneGLbIGufddKKZtpcq3arLHrMG8AACAASURBVCc/3UC39j5bJ3Z0SPPgqmfc3sR+WeR0TI1ra0hlMMzMJQWcMagzXWKMAVTqaJfqtZLm8sqQVbl2+SDql2PjSSONCry1K9eR5FpbQ5RSdtPkWrVJeflFLNi4jxsm5uJxJec/A4dDmDK2Fws27mPD7pK4POf7q3awt7RSd2RUrVaax0qSSytDVuXaVfOXSONOI00q6lSu22lyrZRKEE2uVZs0fe4GMnwupoxNbhJ66ejIwsaFsavXxhg+XbubldsOUHOfpZoOlAWYPncD9/93FT0yUzipvy5kVK1TVVtIqT9oVa7dNcdmhtxW5TpWzzVoW4hSyn62biKjVEu0eU8p76zYwY9OOYZ0b3L/E+ic4ePsoV2YuayA284ZiC+q2lYZDPOrN5Yzc2kBADkdU5k8rCuThnVlRK9MRIT1u0p4dv4mXltaSHkgxNjcjtw5eZAuZFStVmqkcl0W3RYSJeRKI5Uy/LWnhVT3XAcSE6hSqs3S5Fq1Of+ctxG3w8G1E/okOxQArhrbmznLd/Deyh1cMKIHAAfKA/zohaXM37CXn5zej+6ZKbyzYgdPf7aJJ+dupHt7H706prJw0z48LgcXHNedayf0YWj39kl+NUrZq6rnunpBY63KddCVSrrso8xVe4dGbQtRSiWGJteqTdld7OfVpQVcMroHnTNaxoK/E4/pRE7HVP6zcCsXjOhBwf4yrvvXYjbvLeXBy4/j4lE9AZgyNocDZQE+XL2Td1bsYOOeEn5+1gCuGpdDVnr8ZnQr1ZKl1a5c10quA84UUqmo8VcggAyvJtdKqcTQ5Fq1Kc/N30wgFOb7J/VNdijVHA7hyrE5/OndNbzxZQEPvL0GfzDEc9eP5cRjsmpc2z7VzSWje3LJ6J5Jilap5KrRcx2sAFft5DqyoLFO5drqudbkWillN13QqNqMUn+Q5xds4ewhXTgmOz3Z4dRw2ZieuJ3Cz17+Cq/Lwes/OrFOYq2Uip5zXVW5rvkXqEpHirWgsVbl2ud24HSI9lwrpWynlWvVZry7YgcHygPcMLHlVK2rZKV7uXpcb77ZUcwjV45oMS0rSrU0ad6otpAYo/j8zlS6xEiuRYQMn4sSrVwrpWymybVqM95ZsZ3u7X0c36dDskOJ6b7zhyY7BKVaPK/LgUMiCxpj9Fz7JQWPhPBK3Qp1utelbSFKKdtpcq3ahOKKAHPX7uGa8b1t2epctUDhMKz/wErAMrpCehfrc1UyZgz4i6FkJxTvsD772kPvCeCpu129ahlEhDSPi1J/7Mp1uVj/vimmos696V4XxTrnWillM02uVZvwv9W7qAyFOXd412SHohKhcCnM+SUULql7ztfe+ijdA4GyuuddPsg9GfqfDQPOgcwcKxE/uA22f3Xow38QTvo59DvT/tejakjxOOutXJeLlWz7wnX/bdv53BRXaM+1UspemlyrNmHO8u10aedlVE7LbAlp01a8DkufBWLsQJk92Epw+0wEVyPGDZbsgv/9Fr58AdI6wwVPQNfhUdXpHVC800qMU7Mgowukdz30+WAhrHsf1r5nfZ5zG3TqD+X7oWyP9T3EAVkDrMTuhUtg4LlwzgPQseX18rdWaV5XvT3XZVjJtjdcXue+dJ+LXcV1K9pKKRVPmlyrVq/EH+STtbu5amwODt25sGXZ8BG89n2rOpxR668K4SAsew4WPQnuNOh7Kgw42/rsqTXtxRhY/ip88kcr6T3xJ3Dy7eBr17R4Og+CfmfApGmwd72VZG+aC+nZ0G0EdDsOugwFTxoE/bDg7zD3L/D4ODjxFpj4c/C2rEk08SAivYB/A12wfguabox5pNY1AjwCnAuUAdcaY5bZEU+qx0mZPxBzE5mySOXaEyO5zvC52Lhb20KUUvbS5Fq1eh+t2UVlMMzkYdoS0qLsWgOvfA+yB8H178ZOhAPlsGkerHsP1r4P37zd8HP2O9NKjLP6H1lsItZzZPWHE2+OfY3LCxN/CsdeAR/eB/P+Bnkz4OzfwbBLrOdoPYLAL4wxy0QkA1gqIh8YY1ZFXTMZ6B/5GAf8PfI57tI8Lir9keS5VuW61FiPHYGSOvfpgkalVCLYmlyLyCSsSoYTeMoYM63W+YeA0yIPU4HOxpjMyLnvAXdHzv3eGPOcnbGq1uud5dvJzvAypk/HZIeiqpTshhcvsxKjq16uv8LsTrGq1QPOhnMN7F4DWxdYVe3aOvWzqtqJTmrbdYOLn4Qx18E7v4SVb8DwSxMbg82MMduB7ZGvi0VkNdADiE6uLwD+bYwxwAIRyRSRbpF74yrF4yRYGkmua1WuS0ykfaiytM596T5d0KiUsp9tybWIOIHHgbOAAmCxiMyOrnQYY34Wdf0twMjI1x2Be4ExWH+CXBq5d79d8arWqawyyMff7OKy0b1waktIyxAoh5eutBLs696GzF6Nu08EOg+2PlqinPHwg4+tCSStmIj0wfpZvbDWqR5AftTjgsixGsm1iEwFpgLk5OQ0K4Y0r5N9+yILFmtVrovDkWTbX7dy3c7npjIYxh8M4XU565xXSql4sHOHxrHAemPMRmNMJfASVmWjPlcCMyJfnwN8YIzZF0moPwAm2RiraqU+XrObikCYc4d3S3YoCqzxeLN+DAWL4eLp0GN0siOKL4cTUjKTHYVtRCQdeA34qTHmYHOewxgz3RgzxhgzJjs7u1lxpHpchCtjV66Lwx7ri8rYbSGAbiSjlLKVncl1fVWMOkSkN5ALfNTUe5VqyJwV2+mU5mFsrraEJF2gAj7+Pax8Hc78LQw5P9kRqSYQETdWYv0fY8zrMS4pBKL/DNEzcizuUj1OTNUYxVrJ9cFwpJIdoy0kw2cl19p3rZSyU0tZ0DgFmGmMCTXlpnj8eVG1XuWVIT5es4sLR/bQlpBEqjgAS5+DnSsObc5SvAMqiqzzo74LE25NboyqSSKTQJ4GVhtjHqznstnAzSLyEtZCxgN29FuDVbk2gXLrHcxVq3IddBFGcDRUuda+a6WUjexMrptSxZgC3FTr3lNr3ftJ7ZuMMdOB6QBjxoyJMSRXtWWfrt1FWWWIb2lLSGKU7YOF/7A+Kg5A+17WeL1O/aw51eldoUMfGHpha5uk0RZMAL4DLBeRvMixXwE5AMaYfwBzsMbwrccaxXedXcGkeZy4wn7rgbtmz7U/ZKgQH6kxK9duQCvXSil72ZlcLwb6i0guVrI8Bbiq9kUiMgjoAHwRdfg94A8iUrXjx9nAXTbGqlqhOct30CHVzThtCbFX6R744jFY9BRUFsOg8+Dk26D7yGRHpuLEGPMZ0OBvRJEpITc1dE28pHpd+Ki0HtSqXFcEQlRIKqkxFpYeagvRXRqVUvaxLbk2xgRF5GasRNkJPGOMWSki9wNLjDGzI5dOAV6K/GCuunefiPwOK0EHuN8Ys8+uWFXrUxEI8b/VO/n2cd1xOe1cWtDGLXveGj8XKLcq0ifdBl2HJTsq1cqlepx4q5LrWpXrimCISkdK7FF82hailEoAW3uujTFzsP5UGH3snlqP76vn3meAZ2wLTjWKMYbpczfSIdXDWUO60CHNk+yQGmXu2t2UVoZ0Soidls+E2bdA7slw7l8ge2CyI1JtRKrHWW/l2h8I43em6oJGpVTStJQFjaqF2rinlD++swYA5xvC+L4dmTysG2cP7ULnDKtiFAiF2VXsZ8eBcnYc8DOkeztys9KSFnM4bHgzbxvtU9yccEynpMXRqq19H964EXqfaG0CU2tig1J2SvO48EmktSNG5TrgTI09is+nlWullP00uVYNyttqTXh4ZMoIvtlRzLsrdnD3rBX85s0V9MtOp6g8wJ4SPyZqOemIXpnMumlCwmMt8QeZuSSf577YwqY9pXzvhN64tSUk/rZ8Aa98FzoPgStnaGKtEi7V23DlOuhLiZlce11OPC6HVq6VUrbS5Fo1KC+/iDSPk/OO7c4FI4TbzxnI2p0lvLNiO8sLDjAq3UvX9r7qjw9W7eTlxfmU+IPV/Y1227q3jGfnb+bVJfkU+4OM6JXJI1NGaEuIHbZ/DS9eAe17wDWvg699siNSbVCqJ2pBY+3KdSBEID0N/Lti3pvhdemCRqWUrTS5Vg3Kyy/i2J6Z1XOiRYSBXTMY2DUj5vUuh/Diwq0s27Kfkwc0b/e1ppi5tIDbZ36FU4RvHduNa0/sw8icDoe/UTXd3g3wwsXgzYDvzIJ0+/99lYolrYGe64pgmJArFcrr9lyD1RqibSFKKTtpcq3qVREIsXr7QX5wct9G3zMqpwNOh7Bo076EJNdPzdvIoK7tePa64+nSznf4G1TzbP8KXroGTBi+Owsyex3+HqVskup14ZNKQg43Tseh1i9jDJXBMCF3OhyInVxn+FzaFqKUspU2pKp6rdx2gGDYMKJXZqPvSfO6GNajPYs22T85cc2Og6zZUcyU43slNrEOtaE35lAQPv0z/PN0CFVarSBZ/ZMdlWrjqirXQYe3xnF/MAxA2B1Z0Gjq7i2W7nVRosm1UspGjUquReQiEWkf9ThTRC60LyzVEnwZWcw4sgnJNcD43I7k5RdREWjSbvZNNuvLbTgdVjtIQhwogJnXwx+6W73Hrd3utfD0WfDxAzDkQvjxF9B9RLKjUkdIRG4VkXZieVpElonI2cmOqylSInOu6yTXASu5xp0GGAiU1bk3w+fmoPZcK6Vs1NjK9b3GmANVD4wxRcC99oSkWoq8/CK6t/fRuYlV4bG5HakMhcnLL7IpMmvc3n+/2sZJ/bPISvce/oYjEaiAuX+Bx46H1W9ZW3cveMLe75lM4TB88QQ8eRLs3wyXPQuXPg2putNlK3G9MeYg1s63HbC2NZ+W3JCaxuN0kCoBAlLzv/2KoPULvfGkWwf8dSeGZHi151opZa/GJtexrtN+7VYuL7+IETlNq1oDjOndERFsbQ1ZsmU/hUXlXDiih23fA2NgzRx4Yhx89HvodwbcvAhGXgMrXoOS3fZ972QJBWDGFHjvLuh7Kvx4AQy9KNlRqfiq2sb8XOB5Y8xKDrO1eUsjIqQ5A1TWTq4jfy2TquQ6xji+DF3QqJSyWWOT6yUi8qCIHBP5eBBYamdgKrn2lPgp2F/epH7rKu1T3Qzq2s7W5HpWXiEpbidnDekS/yffuwEW/AP+dS68dCU4vdZ0jCtegA59YOxUq/942bPx/97JZAy8/XNY9x5M+hNc+RJk2PC/r0q2pSLyPlZy/Z6IZADhJMfUZGkSwC+xe67xVSXXMbZAjyxoNDH6sZVSKh4aW32+BfgN8DJggA+Am+wKSiVf1eYxI3o1b6zduNyOvLw4n0AoHPeNXCqDYeYs387ZQ7uQFo9Z2qEAbJkP696Hte/B3nXW8U79YdI0OP774HQfuj57IPQ9DRY/AxN+WvPc0Wz+o7Ds33DSL2D8D5MdjbLPDcAIYKMxpkxEOgLXJTmmJktxVOLHU+NYVeXa6a2/cp3udRMKGyoCYVI8TtvjVEq1PY3KTIwxpcCdNseiWpC8/CKcDmFYj3bNun9sbkeenb+ZFYUHmjx3evOeUlI9znp7vT9du5uisgAXjOjerNiqBf2Q9x/47CEo2gpOD/SZaCXTA86Gjg2MIBx3o9U+seat1tE2sWo2fHCv9VpOuzvZ0Sh7nQDkGWNKReQaYBTwSJJjarIUCVBh0mscq6pcOxqoXGdEtkAvrghocq2UskVjp4V8ICKZUY87iMh79oWlki0vv4gBXTJI9TSvMnx8H2vx28ImtoaEwoYrpn/BhY9/zr7SypjXzMorpGOah5P6N3OOdqAcFk6HR0fCWz+DtGy47Dn45Sb4zhtW1bahxBqg/9mQ2RsWPtm8GFqSwmXw+lToMRou/Ds4dEJnK/d3oExEjgN+AWwA/p3ckJouhUrKTT2Va1+kKOAvrnNfdXKtfddKKZs09l00KzIhBABjzH6gsz0hqWQLhw1f5Rc1q9+6SnaGl2Oy05rcdz1/wx52HvSz7UAFt770JaFwzb7I4ooAH67aybeGd2t6u0k4ZE3BeOQ4eOd2Kzn+zhvw/f/B0AvBm37456jicMLYH8DWL1rOWL4dy+GFS6xe8S9fiFm1q6Mo36rAp2fDlTPAnXL4e9TRLmishuMLgMeMMY8DsbdcbcG8VFJmarZkVURG8bl9kZfTQOX6YLmO41NK2aOx2UlYRHKqHohIH6zea9UKbdxTSrE/2OT51rWNze3E4s376iTIDZn15TYyvC7u/fYQ5q3bw6P/W1fj/Hsrd+IPhrlwZDNaQv53vzUFI3sgXPs2XP8OHHO6NVqvOUZeA+5UWJTk6nXZPnj7F/DkyVYVumQXvHkT/HUg/PdWKFxaczONcAiKd8K2PHjxCquSf9UrkK6/L7cRxSJyF9YIvrdFxAEcdQsHvFRSFq4Ztj8yis+VWn9y3T7FqnYf0ORaKWWTxv7N/9fAZyLyKdbIppOAqbZFpZKqaj51c8bwRRuX25EZi7ayZsdBhnZvf9jrKwIh3lu5g8nDunLtiX1YXniARz9ax8icTE4daCV+b+YV0qtjCqOa2MfNqjfh84dhzPVw3kPNeTl1pXSAY6+Ar2bAmfdDWqf4PG9jhUOw9F/WmMCKg9YUk1PvBF8m5C+0Fid+9TIsfRayB4HLayXVpbvBRDb4ESdc/Sp0HpzY2FUyXQFchTXvekekcPKXJMfUZB5Tf+XakxJpC6ms2xaSmWrdU1SmybVSyh6NXdD4roiMwUqovwRmAeV2BqaSJy9/P+leF8dkN6FNIoaxuVbf9aJN+xqVXP9v9S5K/EEuHNkDEeGBC4ezattBfvZyHm/95CTcTuHz9Xv48an9kKZUm3d/A7N+DD2Pt6Z/xNPYqVaCu+w5OOnn8X3u+gT91kLKeQ/BzuXQ5ySY/GfoMuTQNTnjrY9Jf7Rmcq+cZSXXXY+FjK6Q3sX63HkIdDomMXGrFiGSUP8HOF5EzgMWGWOOup5rt/FTEq75FlZVufb6fOBwx6xcd0i1Ktf7y2Kv6VBKqSPVqORaRL4P3Ar0BPKA8cAXwOn2haaSJS+/iGN7tsfpOLJ9JbpnptCzQwoLN+7jugm5h71+Vl4hnTO8jO9rVYBTPE6euHoU5z/2OTf9ZxmTh3UlbGhaS0jFQXjpaquX+PJ/WwlmPHUZArknw+Kn4cSfgNPGvZV2rY5Uo1+C8n1Wz/hlz8GQC+pvbfG1t6r1Y663Ly51VBGRy7Eq1Z9g/SXy/0TkdmPMzKQG1hTG4A77KQ7Frlz7XE5rDUWMHRrbp7gRgf1auVZK2aSxmcCtwPHAAmPMaSIyCPiDfWGpZKkIhFizvZipJx9mWkYjjc3tyCff7MYY02C1uaiskk++2cX3TuhTI6nvm53OXy87lh++sIzlhQcY2r0d/To3cu2VMTDrR7BvI3xvNrQ7wtF99Rl7I7x8NXwzB4acH9/nDofh65dhyTNQsMiqxg36Foz6rrWDokNHiakm+zVwvDFmF4CIZAMfAkdPch2qRDCUhd1UBsN4XNbyoerKtdsBnvSYlWunQ2jnc1OklWullE0au6CxwhhTASAiXmPMGmCgfWGpZFlReIBg2BzRpJBo43M7sa+0kg2761aQos1ZvoNAyHBBjO3MJw3rxvcn5hIKm6bNtv7sIat94uzfWfOr7TJwMrTPsb5f0B+/5y3aCv8+H2b9ECoOwNkPwC/WwOXPWVuxa2KtmsdRlVhH7KXx7wUtQ8DqSvTjoazy0Ei9qsq111WVXMf+udMh1a0910op2zS2cl0QmXM9C/hARPYDW+wLSyVLoxczhsNQUQSpHRu8rKrveuGmfQ1WnGflFdI3O63eTWvumDyIETmZjd/ufMNH8NHvYNglMP7HjbunuRxOOPNeeO0GeO37cOm/jqw9xBhrlN67dwEGzv8/GPmd5k81UaqmdyP7FMyIPL4CmJPEeJouWAFABR5KK0NkplqH/YEQXpfD+iuZJ63e5Lp9qkd7rpVStmlUtcIYc5ExpsgYcx/WNuhPAxce7j4RmSQi34jIehGJucOjiFwuIqtEZKWIvBh1PCQieZGP2Y17OepIfZlfRI/MFDpnxN4dEbD+1PrSlfDgYKu62oDenVLpnOFtcN51YVE5izbt48IRPeptHXE7HZx3bHe8rkZUa/dugJnXWxMyzv+/xCSlwy+Fc/4Iq2fDW7fWHH3XFMU7rbnTs2+GbsfBj+ZbLSCaWKs4McbcDkwHjo18TDfG3JHcqJooUrkuNx7KojaD8QfDVtUaIsl17FnvWrlWStmpyeU1Y8ynjblORJzA48BZQAGwWERmG2NWRV3TH7gLmGCM2S8i0YN2y40xI5oanzoyeVsPs3lMyS5rNvL2PDCRfuCTb6/3chFhbG5HFm7cV2/f9ey8bQBHvp05WDOf/3MZiAOmvGi9wSbKCT+G8v0w98/WOLyzf9/4pNhfAstftWZxB8qsRH3cD3W3RGULY8xrwGvJjqPZoirXZZWh6sMVgRA+d+QXcG8GlO6JeXuHVA/rdzXcqqaUUs1l5zv3WGC9MWajMaYSeAlrR7BoPwAej+z4SK0+QJVgu4v9FBaV159c71kPT51pTa244j/Qe6I1ueIwVdpxuR3ZcbCC/H2xpze+mVfIyJxMenc6wkQ46IeXr4EDBTBlBnQ8/ISSuDvtV9Z4vi8eg3l/a/haY6BgCcy+Bf42EN76qRXzjXOtRF0TaxVHIlIsIgdjfBSLyMFkx9ckkcq11RZSs3JdnVw30BaSmermgFaulVI2sXFuGD2A/KjHBcC4WtcMABCRzwEncJ8x5t3IOZ+ILAGCwDRjzKza30BEphLZzCYnJ6f2adVEDfZbb11otSuIA659C3qOgbI9VmJYuAx6jq73eatG6/161nL+dMmxdM88tMX2NzuKWbOjmPu+PaS+2xvHGGs3wi2fwyVPQ07t/6sliAhM+hOUF1k93ymZcPz3rfj8B622j5Id1lblX74Au1ZZuzwOvdhq/+g1VltAlC2MMUfdFuf1ikquy/w1K9eH2kJiTwsBq3Jd7A8SCIVxO/WXWKVUfNmZXDf2+/cHTsWaoT1XRIYbY4qA3saYQhHpC3wkIsuNMRuibzbGTMfqHWTMmDEtajv2bUXlpPtctPMdPbsK5+Xvx+kQhtXe8GXVbHj9B9You2teg46RMX1DLoA5t1s7FDaQXPfvksH9Fwzlj3PWcPZDc7lz8iCuGpuDwyHMyivE6RDOO+4IW0Lm/tWK47RfW/3PyeRwwIVPWMn027fB/MegZKfV7hGt+yg472Fr0aUv9kJOpVQMwUhybWpWrmu0hRymcg3WLo3ZGXGefa+UavPsTK4LgV5Rj3tGjkUrABYaYwLAJhFZi5VsLzbGFAIYYzaKyCfASGADR4mrn1rI+L6d+OPFw5MdSqN9vn4vQ7q1I8UTtWhw+9fw6rXQYxRc+RKkZR0652sPA8+FFTPhnD+Ay1Pvc3/3hD6cNrAzd72+nLtnreC/X23jjxcPZ3beNib2yyIr/Qje4JbPhI9/b21F3kD/d0I53XDZs/DBPVYfePSuiOldIDMnOW0rSjWDiDwDnAfsMsYMi3H+VOBNYFPk0OvGmPttCyhg9Vz78VAe1XNdc0FjutWbHQrWmd6TGdmlsaisUpNrpVTc2ZlcLwb6i0guVlI9Bbiq1jWzgCuBf4lIFlabyEYR6QCUGWP8keMTgD/bGGtcVQbDbN5bSqe0+pPNlmbdzmLy8ov49bmDDx0Mh2HObZDSAa5+1fpc23FXwsrXYf0H1uYmDejVMZXnbxjLq0sK+N3bqzj7obkEw4bbzhnQ/MALllpbm+ecmLjJII3lToFz/5LsKJSKh2eBx4CGtkmfZ4w5LyHRVC9odFNaa0FjqifytuZNtz5XlljtWVE6RCrXukujUsoOtjWbGWOCwM3Ae8Bq4BVjzEoRuV9Eqraxew/YKyKrgI+B240xe4HBwBIR+SpyfFr0lJGWbseBCoyBrfvKDn9xC/Hq0gJcDuGiUVGbuHz1IuQvhLPuj51YAxxzOqRlWy0ZjSAiXH58Lz78+SmcPqgzPTJTOHtI1+YH/v7dkNoJrngh/lubK6UAMMbMBeqfp5logUNtIQ2O4oOYfdcdoirXSikVb7b2XBtj5lBrcwJjzD1RXxvg55GP6GvmA0dPP0UtBUVWUr2r2F+zB7CFCoTCvL6sgDMGdz7UnlG+32pp6DXOqk7Xx+mC4ZfBon9a7Q+H2VSmSpd2PqZ/d8xht0Vv0NaFsHU+TJoGaZ2a9xxKqXg5IVIQ2QbcZoxZGeuiuCxEj1SuQ05fncr1oZ7rqsp13eS6fcqhnmullIo3XSZtg8L9h0bOFexv+dXrj9bsYk9JJZePiWqR/+j3VoJ97l8PPxLuuCkQDsDKN5r8vZudWAN8/rBVUR/13eY/h1IqHpZhLUI/Dvg/rJa/mIwx040xY4wxY7Kzs5v33SKVa4cnhfJa25973VE91wCVxXVu7xBp2dNdGpVSdtDk2gaFRYeS66OhNeTVJfl0zvByyoDIG922L2Hx03D8D6DbsYd/gq7HQvZga+Z1ouxaA9/MsWZKJ3KjGKVUHcaYg8aYksjXcwB3ZL2MPSKVa5cntUbl2moLiZoWAjEr12keJ26naM+1UsoWmlzboGB/Ob5I9WTr3padXO86WMHH3+zmktE9cTkd1iLGt2+z+qhP+1XjnkTEql4XLLK2Hk+E+Y+CKwXG3piY76eUqpeIdJXIn6FEZCzWe8te275hoBwcLjxeD2XRm8gEQtU/e6sXNPrrjuMTETJTPdpzrZSyhSbXNijcX87gbu1IcTvJ3x97V8KW4rVlhYTChstG97QO5L0AhUvg7N/VWWHfoGMvB8TaDt1uBwrg61esdhDttVbKdiIyA/gCGCgiBSJyg4j8UER+GLnkUmBFpOf6UWBKZE2NPYIV4EohzeOk1F9f5br+nmuwJoZoz7VSyg7J3kSmVSosKue4XpmU+oMtui3EGMOrS/IZCIyBlQAAIABJREFU26cjfbPTrQWJH9wLOSdYM6Obol136HuK1Rpy6l32jsT74gkwYTjhJvu+h1KqmjGmgVXNYIx5DGtUX2IEysHtI9Xjqp5zHQobKkPhQ5VrT9QovhgyUzzac62UsoVWruMsHDZsP1BOj8wUcjqmkt+Ck+slW/azcU8pl42JVK0//gNUHLAWMTYnOT7uSijaAlsXxDfQaGX7YOmz1q6GHXrb932UUi1XsALcKaR5ndU7NPqDVpJdY4dGaHCXRq1cK6XsoMl1nO0q9hMIGXp0SKFXx1S27ivDzr+OHolXFueT5nFy7vBuVtL65Qsw4kroWmcDtsYZdB64U+HL5+MbaLTFT0OgFCbcat/3UEq1bIFycKWQ4nFRFqlc+wNhgEbNuQZr1rVWrpVSdtDk+kjtWMH/t3ff8W1V5+PHP0eyZVve2/HKdPaOCYEMIGEEyiy7bCijLaVAB9AB/AKd37ZAgZYV2jAKaZlpoECaQEJCNmRvO05iJ44dr3hbls7vj3O9dyzFsf28Xy+/ZF1dXZ0LyvWjR895Dmv+Vn83x+pxnRwZREqkk4oaN4Xlp94FvKy6lo+2HuGSCYkEB/iZgLi2Ek7/3okfNCDE1EFv+idkrfTeYOu4KmHtCzDsvBP/ACCE6P1qq8A/kGCHvX5CY1XzzLXNbj7sV7dsxQcQEWwy16dq8kMI0XtJcN1d61+BTx6u77uabU1gTLbKQuDUbMf30ZbDVNS4uTo9BTxucx4DZ3Q/aJ3zKEQOgg++1+YftRP2zRtQcQxm3O/d4wohehcrc+10+FFR3UbmGsAZA+XHWj1EpNNBjdtDpcvd6uNCCHGiJLjurkKr9VxJNtDQ4zopMojU6FM3uP7XhmyGxYUwOTUC9nwCxQfh9Lu6f2BHMFzxAhQfgk9/0f3j1XHXwlfPQvJpMHC6944rhOh9rAmNdTXXWuuWmWswE62P57R6iAhrlUbpdS2E8DYJrrurcL+5LT4ImDZ8kU5/nA4/kiODgIZs9qliX14pGw8UcU16slkhce2LEJYMI77lnRdInQZn/hC+XgB7l3jnmMvmmcmSM3/s204kQohTX21dzbUdjzYt+KqszHV9txCwguvDrR4iwmmt0ngKlu0JIXo3Ca67w1VVn7GuD66LK0mygmqnw4+YkIBTbiGZPy/ZQ5C/nSsmJZuVDvcvh9NuB7sXOzOe8wuzauOH95rJkt2x40NY9Qyk3w4jLvTO+IQQvZerrubaXLMqatxUW+Ud9X2uoSG4bqWuOtJpMtfSMUQI4W0SXHdH0X7AumiXHAJM5jopIqh+l9SooFOqLGR1RgEfb83l+2cPJTY0ANa9CPYAmHyrd1/IP9CUh1Qcg//+7MSPk78bPvg+JKXD3N95b3xCiN7LWkTG6TCBdHl1LVW1bWSuayuhsqjFISKDrcy1dAwRQniZLCLTHY2X+i4+iNaanOJKZqbF1m9OjXKyPqvlhd3rDq6Bre+03K5spr1e4iTcHs28xTtIigjizllDoLLYLPoy7mrfrHSYOBFm/Qy++I1p0zfm8q49v+o4vH0D+AfBNa+BX4D3xyiE6H0aLSIDHWSuAUqPgDOqySHqaq6LKyVzLYTwLgmuu6NuMmPCeCg+SFGFi4oad31ZCEBKlJNFmw/jcnvwt/vwi4Ilj0HORggIbbrdVQlfvwZXvcrCkrHsPHKc578z2Uz62fAmuCq8M5GxLTMfhD3/hcUPmJUfQ+M79zytTceRwky4ZRGEJ/lujEKI3qUucx1gZa5r2spcW9eN44chfkyTQ9TVXBdLzbUQwsskuO6OggxwRkPCOMj4nBxr4mLjspCUKCceDYeLKxkYHeybcVSVQPZ6mPEAzPlV08fK8uCf16IX3sABbmfqoKu4aFwCeDyw7mVImQYDJvhmXAB2f7jiRXhxFnxwD9zwLtg68SFj5VOwazFc8BsYNMN34xNC9D513UKszHVljZuq1jLXoQPMbSsdQxx+NoIddukWIoTwOqm57o7CTIgaChGpUHqEw4XFAPVdQoCT0+s6czloNxv8JrVcECEkDm5dzN6wM3lEv8Lz8R+itIZ9S0zNuC+z1nViR8Dc30LGMlj9bMf7ZyyDZU+YJc6nfd/34xNC9B5uF2h3i5rraitzHdA4cx2aAKh2O4YUS821EMLLJHPdHQUZMOQsCE8BNMVHsgCaTWg8CcF1xlIqlZPr/uvmzIz1/OaKsSRHOhseLtFckn8PCwbEMG3z38CdD+X5Jqsz6lLfjauxKbdBxuewdJ5ZrCZ5Suv7HVwDC2+G2JFw6bPSdk8I0ZS1YJepuTbBdeOa6yZ9ru3+EBLfZq/ryGB/mdAohPA6yVyfqJoKKD3ckLkGqo9l4XTYibBaPAHEhwXib1ccKvRRr2ut8exbyir3aMakxLAhq5ALnlrBa6uz8HhMFvvJxTtw+DsYduuLcO7jsO0d034v/Q7zx+dkUAou/YsJ6N+5zZSyNJe1Cl7/tsm23/COWZBGCCEaq60yt/5BBAeY/FB5TaPMtV+zP2thiXD8SKuHighyyIRGIYTXSXB9ogozzW30EIhIAUAXHSA5MsgszGKx2xTJkU4O+SpzXZCBreQQX7jH8eB5w/n0/llMHhjJox9u59qXVvPa6iw+353PfXPSiAkNNHXZV8432eP023wzprYERZrXLsk2Exwbl7BkfgFvXGkmLt72sUxgFEK0ri5z3agspK7mWilwNJ843u5CMv7S51oI4XU+Da6VUnOVUruVUvuUUg+3sc81SqkdSqntSql/Ntp+i1Jqr/Vziy/HeULqOoVEDTUz0pUNR1lOk5KQOilRTt+VhWQsBWC1msjUQVGkRDl57fap/PHqCew5WsajH25ncEwwt5w5qOE5466C2z6C4BjfjKk9qafDOY/AtnfhmzfMtn3/g39eC1GD4daPrDpJIYRoRX3muqEVX3m1m+paDwF+tibJDaDd4DrS6ZCyECGE1/ms5lopZQeeB84DsoH1SqlFWusdjfZJAx4Bpmuti5RScdb2KOAxIB2zSstG67knoWF0J9X1uI4eakorwpIIKTncpA1fndSoILZkF/tmHPuWkmMbQMKgkQRZWRylFFdNSWbW8Bj++nkGl05MxNH8q9KeNONB2L/CLC5TUwZLHjWTHm/60Df9toUQfUejzLXdpgjws1FRU0uVy9203rpOWCJUl0B1GQSENHko0ulPSaULt0djt8n8DiGEd/gy4poK7NNaZ2qta4C3gcua7XMn8Hxd0Ky1zrO2XwAs0VoXWo8tAeb6cKxdV5gBwXH1faXdYcnEefJIinC22DUl0klxhYsSb9f21Vaj96/gfzVjmyxcUycuNJDHLx3D5NRI775ud9nscMVLZnGYTx6GuNFw8yIJrIUQHWuUuQYIDvAzfa5dbgL9WguurRKz0pZ11+FOB1rDcam7FkJ4kS+D6yTgUKP72da2xoYDw5VSq5RSa5RSc7vwXJRSdymlNiilNuTn53tx6J1QkGmy1pbyoESS1LE2Mtcm4PZ63fXBNajaSr70jGfGsB4o8eiOsAFm1cVJN8LNH7ZYPU0IIVrVKHMN4HTYTbeQWk/TNnx16lZpbKVjSKRTVmkUQnhfT9cK+AFpwNnA9cDLSqmIzj5Za/2S1jpda50eG9syc+tThZkQNaThrl88AyggKaxlpU2Kr4LrjGW4sbM7cCKjB4R599gnw6AZcNnzENTp/+VCiP6uUSs+gGCHHxXV7nYy13XBdcu660hrlUapuxZCeJMvg+scIKXR/WRrW2PZwCKttUtrvR/Ygwm2O/PcnlNdBmW5TYLrIyoWu9Kk+rWsrU6NtoLrIu8G1zpjKZsYyaS0FGxSLyiE6A9qm2augxz2+lZ8rWau21mlsa5tqiwkI4TwJl8G1+uBNKXUYKWUA7gOWNRsnw8wWWuUUjGYMpFM4FPgfKVUpFIqEjjf2nZqqG/D11AWst9tyjKiXbktdg8L9Cc8yN+7HUPK8lC5W1nqGsvMtF5WEiKEECfK1bzm2pSFtJm59g+CoKj2M9flUhYihPAenwXXWuta4F5MULwT+JfWertSap5Sqm5ZwE+BAqXUDuBz4Kda6wKtdSHwBCZAXw/Ms7adGhq34bPsqTKTBm3Hs1t9SmqUk4PeXEgmYxkAyz3jW53MKIQQfVJt85prPyu4biNzDWZSYysLyURIzbUQwgd8uvy51vpj4ONm2x5t9LsGHrR+mj/3VeBVX47vhNW14WtUFrK9PBQPClvxwVafkhrlZMeR494bw76lHLeFUxMzhoTwQO8dVwghTmXNMtdmQmMt4EdMa5lrsHpdtywLCQv0x6akLEQI4V09PaGxdyrMhJCEJj1TDxTXUuoXDcWHWn1KclQQOUWVuD261ce7xONBZyxjee1YZgyP6/7xhBCit2glc11e7aba5Sawzcx16wvJ2GyK8CB/mdAohPAqCa5PREFGk3rr6lo3eaXVlAclQvGBVp+SGuWkxu3h6PGq7r/+0a2oimN8XjtO6q2FEP2LqwqUzSzeBQRbmWuzQmM7meuKYw1Z70bMKo1SFiKE8B4Jrk9EYUbTTiHF5oJdG5YM7ZSFAN6Z1LivbsnzCZw+WBZeEUL0I7VVJmttLXPuDPCj0uWmsqPMNbS6kEyE01/KQoQQXiXBdVdVHYfy/CaZ65xi8zWlLXKgqevzuFs8zavBdcYyMu2DSU0dTHCAT8vmhRDi1OKqNB1ALE6HHa2hpNLVfuYa2giuHRT30sx1SYWLlXuP9fQwhBDNSHDdVa10CskpMsG1M24weGpbvYAnRgRhU5Dd3eC6ugx9cA2fVY9h1nDpEiKE8D2l1KtKqTyl1LY2HldKqb8opfYppbYopSb7bDC1VU2C62CHCajdHt1O5tpa4LeVumuTue6dwfUfP9vNjfPXklvihXJDIYTXSHDdVXWdQhplrrOLK7EpCEuwSkVamdTob7cxIDyo+5nrjGUoj4sVvXHJcyFEb/UPYG47j1+IWQAsDbgL+JvPRuKqBL+GDklOR8O3d4H+bWSu21lIxtRc976ykCqXmw83mfNZuU+y10KcSiS47qq6BWQiB9dvyimqJD4sEL+oQWZDO3XX3Q6uN/2TEr9odgeMZ2xSePeOJYQQnaC1XgG0t9bAZcBr2lgDRCilBvhkMLVV9W34wCwiUyfAr40/aYFh4AhtYyEZfypq3FTXtiznO5V9uj2X41W12G2KlXvze3o4QohGJLjuqoIM8xWjw1m/KbuogqSIIAhPNhvaCa4PFXVjIZnSo+i9n7HIM5Npw+Kxy5LnQohTQxLQ+Cu7bGtbC0qpu5RSG5RSG/LzTyAodFXWt+EDCOpM5hra7HUdbq3S2NtKQ97ZmE1SRBAXjk1g5b4CzLIRQohTgQTXXdWsUwiYCY1JkUGmDjA4DkpaD65TooLIL62msuYEMyRbFqK0m39UTpcWfEKIXklr/ZLWOl1rnR4bewLzRppnrh2dyFyDFVy3nA8TWbdKYy8KrnOKK1m57xhXTUlm1vBYjpVVs/toaU8PSwhhkeC6qwozmwTXbo8mt6TKZK4BIlLazFynWB1DDhWdQGmI1rDpTQ6HjiOTJM4eIYvHCCFOGTlASqP7ydY272uWue5UzTVYS6C3VhZiMte9qe763Y3ZaA1XTUmun3sjXUOEOHVIcN0VlcVQUdBkMuPR41XUerTJXANEpLa5SuPQWLOi47ackq6/ds7XkL+LBZUzmJUWK0ueCyFOJYuAm62uIdOAEq11yzSxN7gq26y5brNbCEDYACjLBXdtk80R9Znr3hFcezyadzZmc+bQaFKinCRGBDEkNlgmNQpxCpHguitaa8Nn9bhuyFynQskh8HhaPH30gDBiQwNYtiuv66+96Q3c9kDeLJvCNekpHe8vhBBeopR6C1gNjFBKZSul7lBK3aOUusfa5WMgE9gHvAx832eDqW1ec924LKSDmmvtgbKjTTY3ZK47WRbi8Zi5N4c3mW8UT7K1+ws5WFjB1enJ9dtmDothbWYhNbUt/+4IIU4+WYGkKwqsTiHRLXtcJ9dlrsNTwF0D5XkQmtDk6TabYvaIOD7edgSX24O/vZOfbVyVsPVdNjpn4q/DOXe0lIQIIU4erfX1HTyugR+clMG4mtdcN/wZC2g3c92o13V4w1zLusx1m2Uh+bth/wo4ug1yt0HeDnBZpX0zHoA5j9WvFnky/HvjIUID/Jg7pqEZy/RhMSxYfYCvDxYxbYis2itET5PMdVcUZgCqSRu+bKt+OinC6h4SMdDctlF3PXtUHKVVtWzIKur86+76CKpLeLZoKpdPSmo/OyOEEH1Z3fLnliD/LmSuAUqb1l0H+dtx+NkoaS1znbsN/jYdPv4JbP/ATFqffAtc+py5XfkUfPJwq99U+kJplYuPtx7h4gmJTTL204ZGY7cpVklpiBCnBMlcd0VBhmm31yhrsnZ/IUNighsudBFWyUbxQUiZ2uIQM4bF4LDbWLrzKGcM7WSG4Zs3KA1MZGXxKH5xmpSECCH6sWY11zabwumwU1Hj7qDmuvVVGpVSRDr9W2au3S748PsQFAF3fGaSKo0z1JNuBEcIrHneZLIvfhpsPkp8aA0ZS/kkP4Uql4drGpWEAIQF+jMhOZwv9x7jx+eP8M0YhBCdJpnrrmjWhu94lYs1mQWcNzq+YZ/wRsF1K4ID/Jg2NLrzddfFh9CZX/ChPotxyZGMTAg70dELIUTv5nGDx9Ukcw3gtJIb7WaugyLBHtDOKo3NMternoEjm+FbfzbX/ealH0rBBb+GmT+Br1+DD76Hdvuond/y38MbVxK1/BcMiwthYkpEi11mpMWyJbuYksre01JQiL5KguuuKMhoUm+9fHc+LrduGlwHhEBQVJvBNcCckXFkHisnM7+s49fc/DYKzQvHT+dqmcgohOjPXNYiXP7Ng2vzJWy7mWulrF7XLdvxRTj9m3YLydtpAtrRl8PoS1vs7/FoVmcU8Mbag/y66ko+iLwdtizks3nf4vq/Lae0yosB7qZ/whe/xRWSyJyqJfxoaC6qlRrvmWkxeDSszijw3msLIU6IBNedVVEIVcVNOoUs2XGU6GAHk1Ijm+5b1zGkDbNHmgmJHWavrd7WmSGTybcncOmExBMevhBC9Hq1Vea2RXBtMtbt9rmGNntdRwQ1yly7a+HDH0BAKFz0x1YP88RHO7j+5TX88oNtvLb6AM+7L2dh1D1coNZyy5EnuXvBeqpcXlhOPXM5LPohDD6L50a8ziEdy4VZf4Da6ha7TkyJINhhZ+U+WQpdiJ4mwXVn5W41t7Gmns3l9vD57jxmj4xruQx5RGq7meuUKCcj4kM7Dq4PfAVF+3m57EwuHJtAeJB/d85ACCF6t7rMtV/TPv8NZSEd/ElrI3MdGezfsELjmr9Czka48A8Q0nIFyXc2ZvP3VVncOC2V1Y/MZue8uSx58Cyuve/3cP6TzLWtY9LBv3P/25twe7rRqi9vJyy8CaLTqLlyAW9tKebdhAfwK9pnSlaa8bfbmDYkmlX7JHMtRE+T4LoV72zM5n87mvZC5cAqUDZIOR2AdfsLKa2qbVoSUqduIZl2eqDOHhXHuv2FHG/v68NNb+LyC+b9qilcIxMZhRD9XRuZ6+CAurKQjjLXiVB6pEV3jwing+KKGvSxvfD5r2HkxTD2yhZP33SomJ+/v5UzhkTz2CVjGBAehK1xcuWMe2Hc1fzE/99U7PyUX324DX0ivbBLj8KbV4N/IPo7C/nVJ4fIK61myrnXwJhvw4o/mjLFZqYPi2H/sfL6LlZCiJ7h0+BaKTVXKbVbKbVPKfVwK4/fqpTKV0ptsn6+2+gxd6Pti3w5zuZ+999dPPTulqZf62WthAETINBMKFyy4ygBfjZmpMW0PEBEqlnooLzttkhzRsZR69Gs2NPGV3iVxbD9fb50zCQ2KoJpg6V3qRCin2snc21T4Nf8W8TmwhLNOgQVTbO7kU5/PB437g9+YI79rT+1mMCYV1rFPa9vJDYkgOdvmNz6OgVKwSXPoOJG86Lzb6xYt5Gnluzp2jnWlMM/rzGliN/5F//Y4WHhhkP8cPYwZqbFwtzfgl8ALH6gRQJnpvX3SFryCdGzfBZcK6XswPPAhcBo4Hql1OhWdl2otZ5o/bzSaHtlo+0tZ5T4yLGyao6VVVNQXsM7G7PNRlclZK+HQTMA0FqzZMdRZqbF1E+kaaKDjiEAk1IjiXD6s2xnG6Uhm94EVwV/KprFNVNSmmZHhBCiP6rPXDcNroMdfgT621ud6NdEXa/rZh1DIoIc3Gz/DL/stTD3dy0WAKup9fD9N76muLKGl26eQlSwo+3XcATDta8TaIe3w5/nxWU7WPBVVmfOzgTL798DuVvgqlf5sjyJJxbv4PzR8Txw7nCzT2gCnPsY7F8OW/7V5OnD4kKIDwvgy70SXAvRk3yZuZ4K7NNaZ2qta4C3gct8+HpesTu3FICQAD9e/jLT1MxlrzfZjkEzAdhx5Dg5xZWtl4SAyVwDlLQdXNttinNGxPH57ryWdXkeN6x7iezQCexgEFdOSW79IEII0Z+EDoDZv4ToYU02x4YGEB3STsBbpz64blp3naDz+KnfQo4nnw0TrmvxtMf/s50NB4r4v6smMCYxvOPXiR6K+vbLJFftYX7M2zz+n228ta7tvwf1Nr0JOxfBuY+zP3omP3jza4bHh/LUtRObJlim3A5J6fDpz02G26KUYvqwGL7KKMDTnXpvIUS3+DK4TgIat8zItrY1d6VSaotS6h2lVOPC4kCl1Aal1Bql1OWtvYBS6i5rnw35+d6ZIb3zyHEAHpo7ggMFFXy6PdeUhCgbpE4D4H878lAKZo9sK7juOHMNpmtIUYWLTYearda4dwkUZfFc+RxmpcWSGBHU+gGEEKI/iUiBWT+FyEFNNt87exhv3Tmt4+fXLSTTeJVGrRm/eR4AO6fMa1EO8ubaA/xz7UHuOWsol3SlY9OIuTDrZ8wo+4RHB6znkfe28uuPdrQ9ybHoAPz3YRg4g+OT7+G7C9bjZ7fx8s3p9TXl9Ww2uOQZqCyCJY82eWhmWgyF5TXssP6WCSFOvp6e0PgfYJDWejywBFjQ6LGBWut04DvA00qpoc2frLV+SWudrrVOj41tOav7ROzOLSUmxMF3Th/IoGgnLy7PQGd9adVbm4zFkp25TEqJIDY0oPWDBIabn4J97b7WrOGx+NkU/2tWGlK56q/kEcUSz2n8bK6stiWEEO0JDfQnOdLZ8Y7BsWDza5q53voOETlf8H+115Krms6h2ZBVyOOLtjNreCw/veAErsVnPwxD53BryV95dGwhL3+5n7tf30B5dW3T/TxuUw4CuC/7Kz98azMHCir46w2TSYlq47wSxsKZ98I3r8OOhmlJ04dK3bU4xdWUmwWa9i4xt+XH2m0A0Rv5cvnzHKBxJjrZ2lZPa914VskrwB8aPZZj3WYqpb4AJgEtp0d72e6jpYxICMVuU9w5awjz3v8a7dyAmnY3AIeLK9mWc5yH5o5s/0BD58DWd2HOYxDcyqRHIDzIn9MGRbFsZ1798Q7u2UTqweW8qq7jtTund+4rSCGEEB2z2SEkoSG4Li+ATx7CNWAKr+0/n8GNVmk8UlLJPW98TVJEEM9eN6lly9XOvt6Vr6Dmn8/t+3/M0KnzuG09XPXCaubfkt7wreTq5+DgV2xJ/x3PLs5n+Z58fn3FWKYN6WAi+zm/MN+sfvB9iBsFMWnEhQUyJjGM11Yf4Or0lPbrw4XwlaoSKMk2ndNKDplk47E9cGxv6+uA2B2m7CssyZRvhSdZvyeZ38NTIbj3NHbwZXC9HkhTSg3GBNXXYbLQ9ZRSA7TWR6y7lwI7re2RQIXWulopFQNMp1Hg7Stuj2Z3bik3nD4QgCsnJ7Pi0/eweRrqrf+307Toa7Peus5ZD8H292HV03D+k23uNmdUHE9+tJNDhRVUudx889ZvScCPC25+mGESWAshhHeFJTZMaPzsFyYIuPEZPH85SJG1SmOVy83dr2+ksqaWt+48nXBnN9YYcEbBHZ/B29/hrC0PsWTqT7h802lc9vwqfnPFOEqzvuGSdU/wuec07lqZQmhAAT+ak1b/d6hdfgFw9QJ4cZbpiX3nUnAE85srxnH1C6u5761vWHD71M5/MHC7TACUuw2OboPSXLN4WlWJ6WBVVQzVZWD3M0vQ+wWY7ir+gSYIGnUpjLyo/lte0YfVlJtSpqIsKLZui7IagunqZmVJjhCISYOBZ5rb6DQzObcsz7THPJ5jPvQePww5G8zcA3dN02PEjjLvrxEXQeJkUx51ivJZcK21rlVK3Qt8CtiBV7XW25VS84ANWutFwH1KqUuBWqAQuNV6+ijgRaWUB1O68jut9Q6vD/LAV7D9A7jw96AUBwrKqa71MHJAKGB6pn43JQd3lmKfYwwjMC34BscEMzQ2uP1jx42E8dfAulfgjB9CaOvB+OyRJrh+cUUGK7Zk8l/9BVUjLmfY4MFePlkhhBCEJcLR7ZCxDDa/BTN/gn/iOEIDDlNc4UJrzc/f28qW7BJeumkKafGh3X9NZxTc9AF8+H2Gbv4jK8fcyGX7L+cHr63mQ8evKLUHs2PKPN4aO4L0QZGtt/lrS0QKXDUfXv82LLoPrnyFCSkRPHH5GB56dyt//Gx329+0ag37lsL290yHkvzdDQGNPQDCBkBghAmW40aa24AwE4TXVjX6qTYLre3+2Dwv7TxqRl3O6wWjSE9LZkJKRPf/G3ZG1kpTYjPkrJPzev2B1ibwzd1q/Wwxt0VZTfdzhJi5EJEDTWe18GTz3gxPMb+HxLeYz9Aujwcqjpns9/EcKMw0ZSQrn4Yv/2S+gRoxFwbPMu/Jug96doe51R5wVVg/lebWXWvex3GjzbdKPuTLzDVa64+Bj5tte7TR748Aj7TyvK+Acb4cG2BWwFr3Ioy5HAaeyS6rU8jIhIaL6ST3NnYwmL98LwzQAAAbn0lEQVSvPcbjCfGsySzgtumDO275BCZ7vfUdWPlnE8C3YkhsCINjgnljzUHuC15OMFUw6wdeOT0hhBDNhCXBnk/hP/ebriOzfgpARLA/xRU1zF+5n/e+yeHB84Zz/piEDg7WBf6B8O1XIGIg4Sv/zJLBR8hOTGRwxkG4biH3jzjzxI89dDbM/gUsexJSpsLpd3Ptaalszi7hb19kMD4pnAvHDWjYX2vIWApf/M50wwqKgsSJMOQcSBhv6rmj00yGurO01Vlr23u4tr6LY9dirtcBrP9yPBWzr8A58lyIGd61AKuzig+Zzik7rdrzGQ/AOb/s2vj7M1cV7P3MrExaccyUS1Ucg/J8Uw9dU2btqCB6KCROgkk3QtQQiBhkgmpnlHf/39psEBJnfpImm23Tf2S64+xdArs/MvHVxn90/diOEHPM5Knm30vyaWb8XtS/33kTrodlT8Dq5+uDa5uCtDgruHZV4ndkI2UJV7Jo82FGDgjF5dYdl4TUiR4KE6+HDa/CmfeZuqFWXHdaCu9vPMQPbZ9DyGkNbyQhhBDeFTbALPJVfABu/ai+Z3ak08Ha/YUs2nyYuWMSuPecYR0c6ATYbKZHdeRA/Bc/yGDthsk3mwxcd834MWRvNEHmgImQejqPXTKaHYeP85N/byYtPoRhsSGQ+Tl8/lvIXmeyihc/DRNvAL/2a7M9Hs2/NhzizbUHSR8UybWnpTAyIaxhB6WoTUznxX1R/KVkBmcHZnD/gK0MOrQC59Kfw9Kfm5raIWebzGbUEPMtQmhih6/dJlcVrH4WVvzJ3D/nlybLufIpyPkarnq1zTlP/Z7HAwdXw5aFsOMDU/pj8wNnjJn4GxwNEQPNf7+YNPOhK240BIT07LidUTDhWvNTW23KmGqrm36LUlsFyg7+TrOaa92tUibrfmidef+vfAq0G2z+8Eh2i/753dG/g2uHE9LvMF8xFGSwO/c4g6KDCXJYXxdkbwB3DcNPvxAOwR8+2U1UsIPJqZGdf41ZP4PNC+HLP8LFT7W6y91nDeXuxEx4MxNm/9wLJyaEEKJVdb2uJ99SvzAYmCXQt2SXMCI+lD9dM8G3C3dNudUEttvehQt+451j2mxwxQvw0lnw71vg2jcJqC7hH5OyeOt/a9j58qsMjsnDfuQbCEs2f48m3tipwHZfXik/f28b67IKGRobzBtrDvD3VVlMSIng2vQULpkwgIKyGh781ya+PljMt8Yn8uRl5xMZ7OC5ZXt5e8lKnju9hImuTeZbg81vNX2B4DiTfIobA2OvgMFnt5911tpkWv/7EBTth9GXwfm/bmiDm5wOix+EF2ehr3mNJSXJpA+KOjUnd3o8ppa9eXBYW22ytOV5UJZv3eaZ9ouOEAiKhKAI67aNn4BQU+ZTnm+eW37MHOfYHtj2nqmN9g+GUZeYMtbBZ/WubL9fACR0scghbpQ5VzB144e/gcL9Xg2sob8H1wBT74RVz8DaF9iVexFjEht9Erf6W0ePOotLJ2Tx3jc5zB4Z17VZ45EDYfJN8PXrMP1+c781a180NUmjT/l1doQQovcaOtt8vTzzx002J0UEEh7kz0s3T2nZV9oXhs0xP94UFAHXvA7zz4NXZgMQAXwPyHeHc7AwgYEX/Qnb5JtMYNKBKpebv36Rwd++2IfT4cfvrxzH1VNSKK508f43OSxcf5Cfv7+VJxabKVH+dsUz103k0gmJ9aWT95w1lKW78rh5UxmfPXAPCaEO0zmi5FDDBLbj2VCSAzv/A5veMJnT0ZfDuKvN1/baY+rkD3wFB1aZ24pjpszkpg9g6DlNBz7pRogfC/+6Cc/8C1hRcxN/i72IBXdMIywo0NTbKquu3V3TNKh1VZnHHcHmxz+4+xPntDbnmb8TCjLNB4LC/aaOuCgL3NUdHyMw3HwICYqEigI4sskE2q6Ktp+j7CYz29r2obNNN7ORF5nz7I8cweYDdqMP2d6idB/pLZienq43bNhwYk9+/3voHR8wsexpbp8zmR+dm2a2//1bptbo7uXsOVrKpc+t5JWbT2NGWhe/ZirJgb9MgvFXw2XPt3y8IAOenQxnPQzntChBF0L0A0qpjVZv/36jW9dtLyuvrqWixt32+gW9ydHtcHRHQzuz0ATmrznME4t3MCYxjPvPHc65o+LanDvk9mhW7M3nif/sIPNYOZdPTOSXF48mJqTpfxutNZsOFfOvDYeocnn42dwRDAhvuejZ/mPlXPTMl6QPiuS126e2PWepttrU0279N+z5xAS7YUlQXdrQfSIiFQZONxPZxl7VbuZ9xebdeN69k7Ntmzv3360t/k4TiNkdpnTC5gd2f3PrF2g+DITEmuC37vfKIvP/IM/6qSpperzIwRBl/YQmWuULQU0n5gVFmprj4Ni2Pwy5qkzmu6LQ3FYWNf3xC7LGVje+GJPIc3SiL7xoV3vXbAmuwdTgvDCD37muY9J3/h8XjEkwb9jfpZrM9gW/BqDW7cGvK7O4G/vvQ7DuZbh3vanFBvMVzea3TU128UF4YJtpTSOE6HckuBa+pLXm/W9yeGbpXg4UVDAmMYwfzUnjvNHxKKXQWrMlu4RFmw/zn82HySutJjXKyZOXj2XW8O4v0vb66ix+9eF2nrhsDDedMajjJ1Qdh10fwa7FJiAcOB1Sz2go/ejAnqOlfPuvXzEoKpB3Zx5mz969fLwlhzEDgrloTBw2PCajXBfM1t9anSZqykzZQE15w+9uF3hc4Km1fneDq9wqt7Am/zXOFAeEmTrl+NHmNm60mUQbEuebiZ3ipGrvmi1lIQAJ48iNPp1bjn1GTazV1SN7vfmqxupvDZx4YA0w40HYuAC++K2ZSPn1a+bC4XGZGavnPymBtRBCCJ9QSvHtyclcOiGRDzYd5tlle7nr9Y2MSQxjRloMn27LJaugAofdxtkjYrlsYhJzRsUR6O+dlmU3ThvIkp15/PrjnUwfFsOQ2A4mxgWGmYYAE6/v8msVltdwx4L1BDnsvHzrVALCgxg3Gb6M38e9n+zmriFD+PlFo07wTNrh8UBloalvDgg1LegkiO6XJLi2LI24mhsKfoLnyGcQd019vTWp07zzAqHxMPW78NWz5iuvoCiYepepx47zwT9yIYQQohk/u42rpiRz+cSGIPulFZmcOTSa7589jAvGJhAe1I1Fc9qglOIPV47ngqdX8KO3N3Hl5CTqvjfXGjQQE+Jg+rCYFuUnXVFT6+Ge1zeSd7yahXef0aRM5XtnDSW3pIqXVmQSHxbIHTO8vJ6EzWay7NKhpN+T4NqyuGI0s+wppKx5ztRGZ600rWeCvNj8fuaPTTPzgWfCyIs7NaFECCGE8La6IPuKSUlU1NQSGuj9gLq5hPBAfnPFOO5f+A2P/6ekzf3GJYVz1vBYzhoRy6SUiE5/a6y15pcfbGVdViHPXDeRic0Wr1FK8dglY8g7Xs2TH+0gPiyAi8cnduuchGiNBNeYf5C7jpazfsB1pOT8n1m5K3u9qbf2pqBI+NafvHtMIYQQ4gTZbeqkBNZ1vjV+AGeNiKWm1oPCVE0oFCg4UFDOij35LN+Tz9+WZ/Dc5/sIDfQjNcpJeJA/EU5/woP8CQvyJ8Thh8vtoarWQ5XLTZXLzbGyGpbtyuOHs4dx2cTW15Ww2xRPXzeRm+av5YGFm/Cz2Zg7VkoyhXdJcA3klVZTVOGifMSVUDjfLCHrrvZJexYhhBCiPwsJ8INWvrgdnxzB+OQI7p2dRkmli6/2HePLfcfILamipNLFnqNllFS6KKlwUeP2ABDobyPQ306gn50Afxs3nzGQB84d3u7rB/rbeeXm07jtH+v4/psb+f2V47k6vXMTJYXoDAmuoX7Z82FJcXDad2HFHwBlZiYLIYQQ4qQKD/LnwnEDmi7bbtFaU+vR+NlU2239Ojq+05/X7zidu1/fyE/f2UJpVS23e7sGW/RbElwDu46Y/pkjE0Ih7ruw6mkzydCb9dZCCCGE6DalFP727nfhCA7wY/6t6fzorU3MW7yDkkoX95+b1iRgLyir5r/bclm+Jx+nw05iRBCJEUEkW7dJkUEmE+9FZdW1bD5UTGF5DR6tcXvMhwmPR6MUpEQ6GRIbQnxYwAl/uBC+JcE1sDu3lPiwACKDHUA8XPqszPYVQgiLUmou8AxgB17RWv+u2eO3Av8H5FibntNav3JSBynECQjws/Pcdybx8HtbeWbpXo5Xubhvdhqf7chl8ZYjfJVRgNujSY0yi658vPUILnfT9UFiQgIYFO1kUEwwg2OCGRQdTEpUEAlhgUSHBLS7qrPHo8kpruTrg0VsyCpi44EiduUex9OJJUiCHXaGxIYwNDaY6cNiuGpKcofBdlF5De9/k8OVk5MJd568Wvv+RoJrYGduKSMTGi17PuG6nhuMEEKcQpRSduB54DwgG1ivlFqktd7RbNeFWut7T/oAhegmP7uNP1w5ntBAP/6+Kot/fJWF1jAw2sk9Zw3h4vGJjEwIRSmF26M5VlZNTnElh4srOVRYSdaxcvZbkzHf2Zjd9Ng2RXxYIPFhAcSGBlDp8lh14zXmttJVH0gHO+xMSo3k3tlpTBkYSWJ4IDabwq4Udpv5cXs0BwsryMwvIyO/nIz8MtZkFvLBpsPsyi3lFxeNwtZGMJ9bUsVN89eyN6+Ml1Zk8serJ3R9xWnRKf0+uHa5PWTklTFL3mBCCNGaqcA+rXUmgFLqbeAyoHlwLUSvZbMpHr14NMPjQzlUWMFF4wYwJjGsRSbYXh8sBzI5NbLFccqra8kqKOdwcRW5JZUcKaki93gVuSVVZOaX43TYCXc6SI1yEmF1QIkLC2RSSgQjE0I71XYwJcrJ9GENMYvHo5m3eAfzV+6npNLF7749rsVxso6Vc8MraympdPGbK8Yxf2UmN85fy23TB/HQ3JFeWyxIGP0+uM46Vk6N28PIAaE9PRQhhDgVJQGHGt3PBk5vZb8rlVKzgD3AA1rrQ63sg1LqLuAugNTUVC8PVYgTp5Ti+qnde08GB/gxJjGcMYnhXhpVx2w2xWOXjCYsyJ+/LN1LWVUtz1w/kQA/EzDvPHKcm+avw+3x8Nad0xiXHM4Vk5L4/Se7+PuqLFbuPcZT105kbFLTMbs9mqKKGiKdjnZLW0RL/T643ml1ChkRH9bBnkIIIdrwH+AtrXW1UupuYAEwu7UdtdYvAS8BpKend6KyVAjREaUUD543nPAgf55YvIPvLtjACzdOYVfucW77+3qCA/x4+64zGBZnEolBDjuPXzqG2SPj+Ok7m7nir6s4f3QCpdW15JdWk19aTWF5NR4N0cEOzh4Rx5xRccxMizmpfdF7q34fXO/OPY6fTTE0LrinhyKEEKeiHKBxE+BkGiYuAqC1Lmh09xXgDydhXEKIZu6YMZjQQD8efncLV72wmqxj5SSEB/L6HVNJjnS22H/W8Fg+vX8Wjy/azvqsImJCHCRFBDIxJZzYkADCnQ62ZBfzv51HeffrbPztiqmDozhjSDRKKaprPVTXuql2eaiu9RDssDM8PpS0+BDS4kO90kll79FSfvnBNtweTUxIADGhDnMbEkBaXAinD4nu9mt4W78PrncdKWVIbHD91ydCCCGaWA+kKaUGY4Lq64DvNN5BKTVAa33EunspsPPkDlEIUeea9BTCAv24761NDIsLYcHtU4kNbWXVHkuE08HT101q95i1bg9fHyxm6a6jLNuZxx8/21P/WICfzfz42zle6aK61lP/WFJEEMPjQxgSG8LAaCcDo4MZFO0kKSKoU/XlazMLuPO1DTj8bKTFhZKRX8ba/WbhvzoXjUtg3mVjiQlp+xzbUlLpYl9eKVMGRnX5ue2R4Dq3lMkDW05KEEIIAVrrWqXUvcCnmFZ8r2qttyul5gEbtNaLgPuUUpcCtUAhcGuPDVgIwdyxA/j8pxFEBzu8MlnRz25j6uAopg6O4pELR1FeXYufXeGw25pM+nR7NIcKK9h9tJS9R0vZc7SMPUdLWZ1ZQJWrIej2symGxYXwvbOHcsn4xFY7nHy05QgPLNxESlQQ/7htKilRDZl3l9tDYXkN736dzdNL9rI6YznzLhvLxeMHtNuOsLrWzdcHilm17xgr9x1jS3YxAX52Nj92Pg6/joP9zlJa+67krTu9UZVStwC/tLY/qbVe0N5rpaen6w0bNnRpfMerXIx//DN+esEIfnDOsC49VwghvEkptVFrnd7T4ziZTuS6LYTofbTW5JVWc6CggqyCcg4UlLN0Zx67cksZkxjGwxeOZGZabP3+81fu58mPdjAlNZJXbkknwulo89h7j5byk3e2sPlQMXPHJPDE5WOJDQ1Aa82Rkiq25pSwLaeETYeKWZ9VSJXLg92mmJAczoxhMUwfFkP6oKguT9ps75rts8x1d3qjKqWigMeAdEADG63nFnlzjHusyYwjE6RTiBBCCCGELyjV0MJw6mBTgvHj80bw4eYc/vjpHm6av47pw6L52QUj+c/mw7yycj8XjInnmesmdZh5T4sP5d17zmD+yv38acke1jy1nPHJEWzPKaGgvAYAm4K0uFCuTU9hRlospw+JIsyHEzN9WRbSnd6oFwBLtNaF1nOXAHOBt7w5wF11wfUA6RQihBBCCHGy2GyKKyYlc9G4Abyx5iDPLdvLZc+vAuDWMwfxq4tHdzqb7Ge3cfdZQ5kzKp7HF20n73gVs0fGMS45nLFJ4YxKCCPIcfLm1vkyuO5Ob9TWnpvU/Ind7ZcaExLABWPiSQwP7PJzhRBCCCFE9wT42bljxmCuTk/mH6uyiAp2cMPpqR0u5d6aYXEhvPHd1kLNk6unJzR2ujdqa7rbL3Xu2ATmjk3o6tOEEEIIIYQXhQX6c9+ctJ4ehld4b2pkS53qjaq1rrbuvgJM6exzhRBCCCGEONX4Mriu742qlHJgeqMuaryDUmpAo7uNe6N+CpyvlIpUSkUC51vbhBBCCCGEOGX5rCykO71RtdaFSqknMAE6wLy6yY1CCCGEEEKcqnxac621/hj4uNm2Rxv9/gjwSBvPfRV41ZfjE0IIIYQQwpt8WRYihBBCCCFEvyLBtRBCCCGEEF4iwbUQQgghhBBeIsG1EEIIIYQQXqK07vLaK6ckpVQ+cOAEnhoDHPPycE41ff0c+/r5Qd8/x75+ftDxOQ7UWseerMGcCuS63SY5v96vr59jXz8/6MY1u88E1ydKKbVBa53e0+Pwpb5+jn39/KDvn2NfPz/oH+d4svT1/5Zyfr1fXz/Hvn5+0L1zlLIQIYQQQgghvESCayGEEEIIIbxEgmt4qacHcBL09XPs6+cHff8c+/r5Qf84x5Olr/+3lPPr/fr6Ofb184NunGO/r7kWQgghhBDCWyRzLYQQQgghhJdIcC2EEEIIIYSX9OvgWik1Vym1Wym1Tyn1cE+PxxuUUq8qpfKUUtsabYtSSi1RSu21biN7cozdoZRKUUp9rpTaoZTarpT6kbW9T5yjUipQKbVOKbXZOr//Z20frJRaa71XFyqlHD091u5QStmVUt8opRZb9/va+WUppbYqpTYppTZY2/rEe7QnyTW795Frdt+4pkHfvm57+5rdb4NrpZQdeB64EBgNXK+UGt2zo/KKfwBzm217GFiqtU4Dllr3e6ta4Mda69HANOAH1v+3vnKO1cBsrfUEYCIwVyk1Dfg98JTWehhQBNzRg2P0hh8BOxvd72vnB3CO1npioz6pfeU92iPkmt1ryTW771zT+vp122vX7H4bXANTgX1a60ytdQ3wNnBZD4+p27TWK4DCZpsvAxZYvy8ALj+pg/IirfURrfXX1u+lmH/oSfSRc9RGmXXX3/rRwGzgHWt7rz0/AKVUMvAt4BXrvqIPnV87+sR7tAfJNbsXkms20IvPr04/vW6f8Hu0PwfXScChRvezrW19UbzW+oj1ey4Q35OD8Ral1CBgErCWPnSO1ldvm4A8YAmQARRrrWutXXr7e/Vp4GeAx7ofTd86PzB/XD9TSm1USt1lbesz79EeItfsXk6u2b1aX79ue/Wa7eft0YlTm9ZaK6V6ff9FpVQI8C5wv9b6uPkQbfT2c9Rau4GJSqkI4H1gZA8PyWuUUhcDeVrrjUqps3t6PD40Q2udo5SKA5YopXY1frC3v0fFydNX3ityze69+sl126vX7P6cuc4BUhrdT7a29UVHlVIDAKzbvB4eT7copfwxF+k3tdbvWZv71DkCaK2Lgc+BM4AIpVTdh+He/F6dDlyqlMrCfK0/G3iGvnN+AGitc6zbPMwf26n0wffoSSbX7F5Krtm9/r3a56/b3r5m9+fgej2QZs12dQDXAYt6eEy+sgi4xfr9FuDDHhxLt1h1XvOBnVrrPzd6qE+co1Iq1sp+oJQKAs7D1Ch+Dlxl7dZrz09r/YjWOllrPQjzb26Z1voG+sj5ASilgpVSoXW/A+cD2+gj79EeJNfsXkiu2UAvPj/o+9dtX1yz+/UKjUqpizB1RHbgVa31r3t4SN2mlHoLOBuIAY4CjwEfAP8CUoEDwDVa6+YTaHoFpdQM4EtgKw21Xz/H1PD1+nNUSo3HTJywYz78/ktrPU8pNQSTMYgCvgFu1FpX99xIu8/6evEnWuuL+9L5WefyvnXXD/in1vrXSqlo+sB7tCfJNbv3kWt277+mNdYXr9u+uGb36+BaCCGEEEIIb+rPZSFCCCGEEEJ4lQTXQgghhBBCeIkE10IIIYQQQniJBNdCCCGEEEJ4iQTXQgghhBBCeIkE10J4iVLqbKXU4p4ehxBCiI7JNVv4igTXQgghhBBCeIkE16LfUUrdqJRap5TapJR6USllV0qVKaWeUkptV0otVUrFWvtOVEqtUUptUUq9r5SKtLYPU0r9Tym1WSn1tVJqqHX4EKXUO0qpXUqpN63VyYQQQpwguWaL3kaCa9GvKKVGAdcC07XWEwE3cAMQDGzQWo8BlmNWSQN4DXhIaz0es8JY3fY3gee11hOAM4Ej1vZJwP3AaGAIMN3nJyWEEH2UXLNFb+TX0wMQ4iSbA0wB1lsJiiAgD7Ms70JrnzeA95RS4UCE1nq5tX0B8G+lVCiQpLV+H0BrXQVgHW+d1jrbur8JGASs9P1pCSFEnyTXbNHrSHAt+hsFLNBaP9Jko1K/arafPsHjVzf63Y38GxNCiO6Qa7bodaQsRPQ3S4GrlFJxAEqpKKXUQMy/hausfb4DrNRalwBFSqmZ1vabgOVa61IgWyl1uXWMAKWU86SehRBC9A9yzRa9jnxCE/2K1nqHUuqXwGdKKRvgAn4AlANTrcfyMDV+ALcAL1gX4kzgNmv7TcCLSql51jGuPomnIYQQ/YJcs0VvpLQ+0W9ShOg7lFJlWuuQnh6HEEKIjsk1W5zKpCxECCGEEEIIL5HMtRBCCCGEEF4imWshhBBCCCG8RIJrIYQQQgghvESCayGEEEIIIbxEgmshhBBCCCG8RIJrIYQQQgghvOT/A4HmGDoqo6HuAAAAAElFTkSuQmCC\n",
       "text/plain": [
        "<Figure size 864x288 with 2 Axes>"
       ]
@@ -681,14 +1286,28 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "  ['...']\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  ['...']\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "\n",
       "Train Set Metrics of the trained model:\n",
-      "\tloss: 0.2011\n",
-      "\tacc: 0.9495\n",
+      "\tloss: 0.3185\n",
+      "\tacc: 0.8800\n",
       "\n",
       "Test Set Metrics of the trained model:\n",
-      "\tloss: 0.7457\n",
-      "\tacc: 0.7429\n"
+      "\tloss: 0.6897\n",
+      "\tacc: 0.7059\n"
      ]
     }
    ],
@@ -723,7 +1342,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.6.10"
   },
   "mimetype": "text/x-python",
   "name": "python",


### PR DESCRIPTION
Discovered while implementing #575: 

`demos/ensembles/ensemble-node-classification-example.ipynb` is missing a download() of the dataset, so fails to run.

`demos/link-prediction/gcn/cora-gcn-links-example.ipynb` is missing any use of the new datasets module to use the `cora` dataset.