### PR TITLE
Remove helpful handling of GraphSchema features removed in 0.9

### DIFF
--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -759,12 +759,6 @@ class StellarGraph:
         Returns:
             GraphSchema object.
         """
-        if create_type_maps is not None:
-            warnings.warn(
-                "The 'create_type_maps' parameter is ignored now, and does not need to be specified",
-                DeprecationWarning,
-            )
-
         if self._graph is not None:
             return self._graph.create_graph_schema(nodes)
 

--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -741,7 +741,7 @@ class StellarGraph:
 
         return "\n".join(lines)
 
-    def create_graph_schema(self, create_type_maps=None, nodes=None):
+    def create_graph_schema(self, nodes=None):
         """
         Create graph schema in dict of dict format from current graph.
 

--- a/stellargraph/core/schema.py
+++ b/stellargraph/core/schema.py
@@ -36,21 +36,6 @@ class GraphSchema:
         self.edge_types = edge_types
         self.schema = schema
 
-    def __getattr__(self, item):
-        try:
-            return super().__getattribute__(item)
-        except AttributeError as e:
-            if item in ("node_type_map", "get_node_type"):
-                raise AttributeError(
-                    f"{e.args[0]}. This has been replaced by accessing node types through 'StellarGraph.node_type'."
-                )
-            if item in ("edge_type_map", "get_edge_type"):
-                raise AttributeError(
-                    f"{e.args[0]}. This was removed because it wasn't meaningfully used, please file an issue with a use case if you were using it."
-                )
-            # not something we know about
-            raise
-
     def __repr__(self):
         s = "{}:\n".format(type(self).__name__)
         for nt in self.schema:

--- a/tests/core/test_stellargraph.py
+++ b/tests/core/test_stellargraph.py
@@ -767,7 +767,7 @@ def test_edges_include_weights():
 
 def test_adjacency_types_undirected():
     g = example_hin_1(is_directed=False)
-    adj = g._adjacency_types(g.create_graph_schema(create_type_maps=True))
+    adj = g._adjacency_types(g.create_graph_schema())
 
     assert adj == {
         ("A", "R", "B"): {0: [4], 1: [4, 5], 2: [4], 3: [5]},
@@ -778,7 +778,7 @@ def test_adjacency_types_undirected():
 
 def test_adjacency_types_directed():
     g = example_hin_1(is_directed=True)
-    adj = g._adjacency_types(g.create_graph_schema(create_type_maps=True))
+    adj = g._adjacency_types(g.create_graph_schema())
 
     assert adj == {
         ("A", "R", "B"): {1: [4, 5], 2: [4]},

--- a/tests/core/test_stellargraph.py
+++ b/tests/core/test_stellargraph.py
@@ -189,28 +189,6 @@ def test_digraph_schema():
     assert len(schema.schema["movie"]) == 0
 
 
-def test_schema_removals():
-    sg = create_graph_1()
-    schema = sg.create_graph_schema()
-
-    with pytest.raises(AttributeError, match="'StellarGraph.node_type'"):
-        _ = schema.node_type_map
-
-    with pytest.raises(AttributeError, match="'StellarGraph.node_type'"):
-        _ = schema.get_node_type
-
-    with pytest.raises(AttributeError, match="This was removed"):
-        _ = schema.edge_type_map
-
-    with pytest.raises(AttributeError, match="This was removed"):
-        _ = schema.get_edge_type
-
-    with pytest.warns(
-        DeprecationWarning, match="'create_type_maps' parameter is ignored"
-    ):
-        sg.create_graph_schema(create_type_maps=True)
-
-
 @pytest.mark.benchmark(group="StellarGraph create_graph_schema")
 @pytest.mark.parametrize("num_types", [1, 4])
 def test_benchmark_graph_schema(benchmark, num_types):


### PR DESCRIPTION
Various per-edge and per-node functionality was removed from `GraphSchema` in 0.9. We'd left some deprecations and other helpful hints to ease any migrations. I think it's somewhat unlikely that anyone would be depending on these specifically, and those that do will hopefully upgrade to 0.9 and get the warnings. Thus, I think we can remove them for the next release and not have to maintain this code anymore.