### PR TITLE
Support to_networkx(feature_name=None) to not include node features

### DIFF
--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -871,6 +871,10 @@ class StellarGraph:
         """
         Create a NetworkX MultiGraph or MultiDiGraph instance representing this graph.
 
+        Args:
+            feature_name (str, optional): the name of the attribute to use to store a node's feature
+                vector; if ``None``, feature vectors are not stored within each node.
+
         Returns:
              An instance of `networkx.MultiDiGraph` (if directed) or `networkx.MultiGraph` (if
              undirected) containing all the nodes & edges and their types & features in this graph.
@@ -889,12 +893,15 @@ class StellarGraph:
             node_ids = self.nodes_of_type(ty)
             ty_dict = {node_type_name: ty}
 
-            features = self.node_features(node_ids, node_type=ty)
+            if feature_name is not None:
+                features = self.node_features(node_ids, node_type=ty)
 
-            for node_id, node_features in zip(node_ids, features):
-                graph.add_node(
-                    node_id, **ty_dict, **{feature_name: node_features},
-                )
+                for node_id, node_features in zip(node_ids, features):
+                    graph.add_node(
+                        node_id, **ty_dict, **{feature_name: node_features},
+                    )
+            else:
+                graph.add_nodes_from(node_ids, **ty_dict)
 
         iterator = zip(
             self._edges.sources,

--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -872,6 +872,12 @@ class StellarGraph:
         Create a NetworkX MultiGraph or MultiDiGraph instance representing this graph.
 
         Args:
+            node_type_name (str): the name of the attribute to use to store a node's type (or label).
+
+            edge_type_name (str): the name of the attribute to use to store a edge's type (or label).
+
+            edge_weight_label (str): the name of the attribute to use to store a edge's weight.
+
             feature_name (str, optional): the name of the attribute to use to store a node's feature
                 vector; if ``None``, feature vectors are not stored within each node.
 

--- a/tests/core/test_stellargraph.py
+++ b/tests/core/test_stellargraph.py
@@ -453,7 +453,8 @@ def assert_networkx(g_nx, expected_nodes, expected_edges, *, directed):
 
 
 @pytest.mark.parametrize("has_features", [False, True])
-def test_to_networkx(has_features):
+@pytest.mark.parametrize("include_features", [False, True])
+def test_to_networkx(has_features, include_features):
     if has_features:
         a_size = 4
         b_size = 5
@@ -462,12 +463,24 @@ def test_to_networkx(has_features):
         a_size = b_size = 0
         feature_sizes = None
 
+    if include_features:
+        feature_name = "feature"
+    else:
+        feature_name = None
+
     g = example_hin_1(feature_sizes)
-    g_nx = g.to_networkx()
+    g_nx = g.to_networkx(feature_name=feature_name)
 
     node_def = {"A": (a_size, [0, 1, 2, 3]), "B": (b_size, [4, 5, 6])}
+
+    def node_attrs(label, x, size):
+        d = {"label": label}
+        if feature_name:
+            d[feature_name] = [x] * size
+        return d
+
     expected_nodes = {
-        x: {"label": label, "feature": [x] * size}
+        x: node_attrs(label, x, size)
         for label, (size, ids) in node_def.items()
         for x in ids
     }


### PR DESCRIPTION
Node features can be large, may not be always useful and have complicated types (a ndarray or list). The latter can cause problems with some downstream algorithms that cannot handle completely arbitrary attributes, like [`nx.write_graphml`](https://networkx.github.io/documentation/stable/reference/readwrite/generated/networkx.readwrite.graphml.write_graphml.html#networkx.readwrite.graphml.write_graphml):

```
----> 2 nx.write_graphml(Gnx, os.path.join(dataset.data_directory, pred_fname))
[...]
NetworkXError: GraphML writer does not support <class 'list'> as data values.
```

```
----> 2 nx.write_graphml(Gnx, os.path.join(dataset.data_directory, pred_fname))
[...]
NetworkXError: GraphML writer does not support <class 'numpy.ndarray'> as data values.
```

This helps with some of our notebooks that use `nx.write_graphml` (see: #717).