### PR TITLE
Coalesce stream output to single chunk in format_notebooks.py

### DIFF
--- a/scripts/format_notebooks.py
+++ b/scripts/format_notebooks.py
@@ -181,6 +181,11 @@ if __name__ == "__main__":
         help="Set kernel spec to default 'Python 3'",
     )
     parser.add_argument(
+        "--coalesce_streams",
+        action="store_true",
+        help="Coalesce streamed output into a single chunk of output",
+    )
+    parser.add_argument(
         "-d",
         "--default",
         action="store_true",
@@ -220,6 +225,7 @@ if __name__ == "__main__":
     on_ci = args.ci
     format_code = args.format_code or args.default
     clear_warnings = args.clear_warnings or args.default
+    coalesce_streams = args.coalesce_streams or args.default
     renumber_code = args.renumber or args.default
     set_kernel = args.set_kernel or args.default
     execute_code = args.execute
@@ -239,9 +245,12 @@ if __name__ == "__main__":
     if execute_code:
         preprocessor_list.append(preprocessors.ExecutePreprocessor)
 
-    # warnings need to be cleared after execution
+    # these clean up the result of execution and so should happen after it
     if clear_warnings:
         preprocessor_list.append(ClearWarningsPreprocessor)
+
+    if coalesce_streams:
+        preprocessor_list.append(preprocessors.coalesce_streams)
 
     # Create the exporters with preprocessing
     c = Config()

--- a/scripts/format_notebooks.py
+++ b/scripts/format_notebooks.py
@@ -181,6 +181,7 @@ if __name__ == "__main__":
         help="Set kernel spec to default 'Python 3'",
     )
     parser.add_argument(
+        "-s",
         "--coalesce_streams",
         action="store_true",
         help="Coalesce streamed output into a single chunk of output",
@@ -189,7 +190,7 @@ if __name__ == "__main__":
         "-d",
         "--default",
         action="store_true",
-        help="Perform default formatting, equivalent to -wcnk",
+        help="Perform default formatting, equivalent to -wcnks",
     )
     group = parser.add_mutually_exclusive_group()
     group.add_argument(


### PR DESCRIPTION
Jupyter notebooks can model incremental/progressive output as a series of separate output chunks. Unfortunately, when using `--execute`,  a progress bar that updates itself ends up having every update saved (see description #842), rather than only the final state.

This patch avoids this, by coalescing all of the incremental progress bar updates into a single chunk, including overwriting earlier updates with later ones (this is driven by the `\r` carriage return used to power progress bars).

Our current set of notebooks seem to satisfy this check already already, but not if they're re-run with `--execute`.

See: #842