### PR TITLE
Handle no edges in StellarGraph.create_graph_schema's np.unique calls

### DIFF
--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -715,9 +715,20 @@ class StellarGraph:
 
     def _unique_type_triples(self, *, return_counts, selector=slice(None)):
         all_type_ilocs = self._edge_type_iloc_triples(selector, stacked=True)
-        ret = np.unique(
-            all_type_ilocs, axis=0, return_index=True, return_counts=return_counts
-        )
+
+        if len(all_type_ilocs) == 0:
+            # if there's no edges, np.unique is being called on a shape=(0, 3) ndarray, and hits
+            # "ValueError: cannot reshape array of size 0 into shape (0,newaxis)", so we manually
+            # reproduce what would be returned
+            if return_counts:
+                ret = None, [], []
+            else:
+                ret = None, []
+        else:
+            ret = np.unique(
+                all_type_ilocs, axis=0, return_index=True, return_counts=return_counts
+            )
+
         edge_ilocs = ret[1]
         # we've now got the indices for an edge with each triple, along with the counts of them, so
         # we can query to get the actual edge types (this is, at the time of writing, easier than

--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -717,9 +717,9 @@ class StellarGraph:
         all_type_ilocs = self._edge_type_iloc_triples(selector, stacked=True)
 
         if len(all_type_ilocs) == 0:
-            # if there's no edges, np.unique is being called on a shape=(0, 3) ndarray, and hits
-            # "ValueError: cannot reshape array of size 0 into shape (0,newaxis)", so we manually
-            # reproduce what would be returned
+            # FIXME(https://github.com/numpy/numpy/issues/15559): if there's no edges, np.unique is
+            # being called on a shape=(0, 3) ndarray, and hits "ValueError: cannot reshape array of
+            # size 0 into shape (0,newaxis)", so we manually reproduce what would be returned
             if return_counts:
                 ret = None, [], []
             else:

--- a/tests/core/test_graph.py
+++ b/tests/core/test_graph.py
@@ -189,6 +189,14 @@ def test_digraph_schema():
     assert len(schema.schema["movie"]) == 0
 
 
+def test_graph_schema_no_edges():
+    nodes = pd.DataFrame(index=[0])
+    g = StellarGraph(nodes=nodes, edges={})
+    schema = g.create_graph_schema()
+    assert len(schema.node_types) == 1
+    assert len(schema.edge_types) == 0
+
+
 @pytest.mark.benchmark(group="StellarGraph create_graph_schema")
 @pytest.mark.parametrize("num_types", [1, 4])
 def test_benchmark_graph_schema(benchmark, num_types):


### PR DESCRIPTION
`numpy.unique` behaves poorly on a 2D array with a zero dimension when uniquing whole rows (`axis=0`) instead of individual elements:

```python
>>> import numpy as np
>>> arr = np.zeros(shape=(0, 3))

>>> np.unique(arr) # individual elements is fine
array([], dtype=float64)

>>> np.unique(arr, axis=0) # whole rows is not
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<__array_function__ internals>", line 6, in unique
  File "/opt/anaconda3/lib/python3.7/site-packages/numpy/lib/arraysetops.py", line 274, in unique
    ar = ar.reshape(orig_shape[0], -1)
ValueError: cannot reshape array of size 0 into shape (0,newaxis)
```

This patch special-cases having no edges (which results in zero edge triples (rows) being passed to `np.unique`).

See: #869