### PR TITLE
Add brute force importance

### DIFF
--- a/stellargraph/utils/saliency_maps/naive.py
+++ b/stellargraph/utils/saliency_maps/naive.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2020 Data61, CSIRO
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+from scipy.sparse import coo_matrix
+from ...core.graph import StellarGraph
+from ...core.element_data import ExternalIdIndex
+
+
+class PerturbedGraph:
+    def __init__(self, graph: StellarGraph, *, node=None, edge=None):
+        self._graph = graph
+        self._node = node
+        self._edge = edge
+
+    def __getattr__(self, item):
+        return getattr(self._graph, item)
+
+    def _index(self, nodes):
+        if nodes is None:
+            return self._graph._nodes._id_index
+        else:
+            return ExternalIdIndex(list(nodes))
+
+    def to_adjacency_matrix(self, nodes=None):
+        adj = self._graph.to_adjacency_matrix(nodes=nodes)
+
+        if self._edge is not None:
+            src_iloc, dst_iloc = self._index(nodes).to_iloc(self._edge)
+            adj[src_iloc, dst_iloc] = 0
+            if not self._graph.is_directed() and src_iloc != dst_iloc:
+                adj[dst_iloc, src_iloc] = 0
+
+        return adj
+
+    def node_features(self, nodes, node_type=None):
+        features = self._graph.node_features(nodes=nodes, node_type=node_type)
+
+        if self._node is not None:
+            node_iloc = self._index(nodes).to_iloc([self._node])
+            features[node_iloc, :] = 0
+
+        return features
+
+
+def node_importance(graph: StellarGraph, predict, nodes=None):
+    pred_baseline = predict(graph)
+
+    if nodes is None:
+        nodes = graph.nodes()
+
+    def importance(node):
+        perturbed = PerturbedGraph(graph, node=node)
+        pred = predict(perturbed)
+        return pred_baseline - pred
+
+    return np.array([importance(node) for node in nodes])
+
+
+def edge_importance(graph: StellarGraph, predict, edges=None):
+    pred_baseline = predict(graph)
+    n = graph.number_of_nodes()
+    if edges is None:
+        edges = graph.edges()
+
+    def importance(e):
+        src, dst = e
+        perturbed = PerturbedGraph(graph, edge=[src, dst])
+        pred = predict(perturbed)
+        return src, dst, pred_baseline - pred
+
+    if not graph.is_directed():
+        edges = set((undirected for e in edges for undirected in [e, e[::-1]]))
+    srcs, dsts, importances = zip(*(importance(e) for e in edges))
+    srcs = graph._nodes._id_index.to_iloc(srcs)
+    dsts = graph._nodes._id_index.to_iloc(dsts)
+
+    return coo_matrix((importances, (srcs, dsts)), shape=(n, n)).todense()

--- a/tests/utils/test_naive.py
+++ b/tests/utils/test_naive.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2020 Data61, CSIRO
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ..test_utils.graphs import example_graph
+from stellargraph.core import StellarGraph
+from stellargraph.utils.saliency_maps.naive import edge_importance, node_importance
+import numpy as np
+import pytest
+
+
+def predict_node_based(graph: StellarGraph):
+    return graph.node_features(graph.nodes()).sum()
+
+
+def predict_edge_based(graph: StellarGraph):
+    return graph.to_adjacency_matrix().sum()
+
+
+def expected_undirected_edge_importance(graph, edges=None):
+    n = graph.number_of_nodes()
+    adj = graph.to_adjacency_matrix().todense()
+    if edges is not None:
+        srcs, dsts = zip(*edges)
+        src_ilocs = graph._nodes._id_index.to_iloc(srcs)
+        dst_ilocs = graph._nodes._id_index.to_iloc(dsts)
+        srcs = np.concatenate([src_ilocs, dst_ilocs], axis=0)
+        dsts = np.concatenate([dst_ilocs, src_ilocs], axis=0)
+        mask = np.ones((n, n), dtype=bool)
+        mask[srcs, dsts] = False
+        adj[mask] = 0
+    return adj.T + adj - np.eye(adj.shape[0]) * np.array(adj.diagonal())
+
+
+def expected_node_importance(graph, nodes=None):
+    expected = graph.node_features(graph.nodes()).sum(axis=-1)
+    if nodes is not None:
+        node_ilocs = graph._nodes._id_index.to_iloc(nodes)
+        return expected[node_ilocs]
+    else:
+        return expected
+
+
+@pytest.mark.parametrize("edges", [None, [(1, 2), (4, 2)]])
+def test_edge_importance(edges):
+    graph = example_graph(feature_size=4)
+    expected = expected_undirected_edge_importance(graph, edges=edges)
+    importances = edge_importance(graph, predict=predict_edge_based, edges=edges)
+    assert np.allclose(importances, expected)
+
+
+def test_edge_importance_zeros():
+    graph = example_graph(feature_size=4)
+    importances = edge_importance(graph, predict=predict_node_based)
+    n = graph.number_of_nodes()
+    assert np.allclose(importances, np.zeros((n, n)))
+
+
+@pytest.mark.parametrize("nodes", [None, [1, 3]])
+def test_node_importance(nodes):
+    graph = example_graph(feature_size=4)
+    expected = expected_node_importance(graph, nodes=nodes)
+    importances = node_importance(graph, predict=predict_node_based, nodes=nodes)
+    assert np.allclose(importances, expected)
+
+
+def test_node_importance_zeros():
+    n_feat = 4
+    graph = example_graph(feature_size=n_feat)
+    importances = node_importance(graph, predict=predict_edge_based)
+    assert np.allclose(importances, np.zeros((graph.number_of_nodes(), n_feat)))


### PR DESCRIPTION
Currently, this only works for algorithms that use the adjacency matrix instead of querying for neighbours using other stellargraph methods. 