### PR TITLE
Check notebook formatting in its own step on CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -54,8 +54,6 @@ steps:
       docker-compose#v3.1.0:
         <<: *compose-config
         run: runner-3_6
-        env:
-          - CHECK_NOTEBOOK_FORMATTING=1
     agents:
       queue: "t2medium"
 
@@ -91,6 +89,17 @@ steps:
       <<: *plugins
       docker#v3.4.0:
         image: "stellargraph/black:snapshot"
+
+  - label: ":python-black::jupyter: check notebook format"
+    depends_on: "runner-3_6"
+    command: "python scripts/format_notebooks.py --default --ci demos/"
+    plugins:
+      <<: *plugins
+      docker-compose#v3.1.0:
+        <<: *compose-config
+        run: runner-3_6
+    agents:
+      queue: "t2medium"
 
   - label: ":shell: format"
     plugins:

--- a/.buildkite/steps/script.sh
+++ b/.buildkite/steps/script.sh
@@ -13,14 +13,6 @@ pip freeze
 
 exitCode=0
 
-if [ "${CHECK_NOTEBOOK_FORMATTING-0}" = 1 ]; then
-  echo "+++ checking notebook formatting"
-  # This script takes only 20 seconds but requires non-trivial dependencies, so piggy back off the
-  # installation that is happening in this CI step, rather than run it in a separate parallel step
-  # where it would have to spend ~2 minutes installing dependencies.
-  python scripts/format_notebooks.py --default --ci demos/ || exitCode=$?
-fi
-
 echo "+++ running tests"
 py.test -ra --cov=stellargraph tests/ --doctest-modules --cov-report=xml -p no:cacheprovider --junitxml="./${junit_file}" || exitCode=$?
 


### PR DESCRIPTION
The initial work that added the check of notebook formatting to CI had this part of a main test step, to avoid having to install dependencies separately, because installing the dependencies would take a long time (https://github.com/stellargraph/stellargraph/pull/698#discussion_r369939200). Now that #788 has landed, this is no longer a concern, because we can (and do, in this PR) run the check in the docker image that contains all of the dependencies pre-installed.

Follow-up work to #788 