### PR TITLE
Display class name more nicely in `StellarGraph.info`

### DIFF
--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -758,7 +758,7 @@ class StellarGraph:
         """
         directed_str = "Directed" if self.is_directed() else "Undirected"
         lines = [
-            f"{type(self)}: {directed_str} multigraph",
+            f"{type(self).__name__}: {directed_str} multigraph",
             f" Nodes: {self.number_of_nodes()}, Edges: {self.number_of_edges()}",
         ]
 

--- a/tests/core/test_graph.py
+++ b/tests/core/test_graph.py
@@ -736,10 +736,15 @@ def test_stellargraph_experimental():
         StellarGraph(nodes=nodes, edges=edges)
 
 
-def test_info_homogeneous():
-    g = example_graph(node_label="ABC", edge_label="xyz")
+@pytest.mark.parametrize("is_directed", [False, True])
+def test_info_homogeneous(is_directed):
+
+    g = example_graph(node_label="ABC", edge_label="xyz", is_directed=is_directed)
     info = g.info()
-    assert "Undirected multigraph" in info
+    if is_directed:
+        assert "StellarDiGraph: Directed multigraph" in info
+    else:
+        assert "StellarGraph: Undirected multigraph" in info
     assert "Nodes: 4, Edges: 4" in info
 
     assert " ABC: [4]" in info
@@ -751,7 +756,7 @@ def test_info_homogeneous():
 def test_info_heterogeneous():
     g = example_hin_1()
     info = g.info()
-    assert "Undirected multigraph" in info
+    assert "StellarGraph: Undirected multigraph" in info
     assert "Nodes: 7, Edges: 6" in info
 
     assert " A: [4]" in info


### PR DESCRIPTION
By writing just `type(self)`, the output includes `<class 'stellargraph.core.graph.StellarGraph'>`, so we should pick out the `__name__` specifically get just the `StellarGraph` part.

See: #883