### PR TITLE
Cache EdgeData.{source,targets,weights}, to optimise neighbours 10%

### DIFF
--- a/stellargraph/core/element_data.py
+++ b/stellargraph/core/element_data.py
@@ -297,6 +297,11 @@ class EdgeData(ElementData):
     def __init__(self, shared, node_data: NodeData):
         super().__init__(shared)
 
+        # cache these columns to avoid having to do more method and dict look-ups
+        self.sources = self._column(SOURCE)
+        self.targets = self._column(TARGET)
+        self.weights = self._column(WEIGHT)
+
         self._nodes = node_data
 
         # record the edge ilocs of incoming, outgoing and both-direction edges
@@ -347,30 +352,6 @@ class EdgeData(ElementData):
         """
         adj = self._adj_lookup(ins=ins, outs=outs)
         return defaultdict(int, ((key, len(value)) for key, value in adj.items()))
-
-    @property
-    def sources(self) -> np.ndarray:
-        """
-        Returns:
-            An numpy array containing the source node ID for each edge.
-        """
-        return self._column(SOURCE)
-
-    @property
-    def targets(self) -> np.ndarray:
-        """
-        Returns:
-            An numpy array containing the target node ID for each edge.
-        """
-        return self._column(TARGET)
-
-    @property
-    def weights(self) -> np.ndarray:
-        """
-        Returns:
-            An numpy array containing the weight for each edge.
-        """
-        return self._column(WEIGHT)
 
     def edge_ilocs(self, node_id, *, ins, outs) -> np.ndarray:
         """


### PR DESCRIPTION
Using a `@property` that calls down to the `._column` method (which itself does a dictionary look-up) adds a non-trivial amount of overhead for retrieving neighbours, which don't do much other work than ask for these properties. Instead of providing them as computed `@properties`s, we can just cache the look-up as a stored property. This cuts ~10% off the neighbours benchmark, and 4-10% off the random walk benchmarks.

(Median times, in microseconds)

|benchmark|develop|this PR|change|
|---|--:|--:|--:|
|`test_benchmark_get_neighbours`|628|562|-10%|
|`test_benchmark_biasedrandomwalk`|330|297|-10%
|`TestBreadthFirstWalk.test_benchmark_bfs_walk`|445|412|-7%|
|`TestDirectedBreadthFirstNeighbours.test_benchmark_bfs_walk`|800|738|-7%|
|`test_benchmark_biasedweightedrandomwalk`|1590|1662|-4%|
