### PR TITLE
Move `load_dataset_BlogCatalog3` to a `BlogCatalog3.load` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Breaking changes
 
 - Some layers and models had many parameters move from `**kwargs` to real arguments: `GraphConvolution`, `GCN`. [\#801](https://github.com/stellargraph/stellargraph/issues/801) Invalid (e.g. incorrectly spelled) arguments would have been ignored previously, but now may fail with a `TypeError`; to fix, remove or correct the arguments.
+- The `stellargraph.data.load_dataset_BlogCatalog3` function has been replaced by the `load` method on `stellargraph.datasets.BlogCatalog3` [\#](). Migration: replace `load_dataset_BlogCatalog3(location)` with `BlogCatalog3().load()`; code required to find the location or download the dataset can be removed, as `load` now this automatically.
 
 ### Experimental features
 

--- a/demos/embeddings/stellargraph-metapath2vec.ipynb
+++ b/demos/embeddings/stellargraph-metapath2vec.ipynb
@@ -32,7 +32,6 @@
     "import networkx as nx\n",
     "import numpy as np\n",
     "import pandas as pd\n",
-    "from stellargraph.data.loader import load_dataset_BlogCatalog3\n",
     "from stellargraph import datasets\n",
     "from IPython.display import display, HTML\n",
     "\n",
@@ -74,11 +73,10 @@
    "source": [
     "dataset = datasets.BlogCatalog3()\n",
     "display(HTML(dataset.description))\n",
-    "dataset.download()\n",
-    "g_nx = load_dataset_BlogCatalog3(location=dataset.data_directory)\n",
+    "g = dataset.load()\n",
     "print(\n",
     "    \"Number of nodes {} and number of edges {} in graph.\".format(\n",
-    "        g_nx.number_of_nodes(), g_nx.number_of_edges()\n",
+    "        g.number_of_nodes(), g.number_of_edges()\n",
     "    )\n",
     ")"
    ]
@@ -151,13 +149,12 @@
    ],
    "source": [
     "from stellargraph.data import UniformRandomMetaPathWalk\n",
-    "from stellargraph import StellarGraph\n",
     "\n",
     "# Create the random walker\n",
-    "rw = UniformRandomMetaPathWalk(StellarGraph(g_nx))\n",
+    "rw = UniformRandomMetaPathWalk(g)\n",
     "\n",
     "walks = rw.run(\n",
-    "    nodes=list(g_nx.nodes()),  # root nodes\n",
+    "    nodes=list(g.nodes()),  # root nodes\n",
     "    length=walk_length,  # maximum length of a random walk\n",
     "    n=1,  # number of random walks per root node\n",
     "    metapaths=metapaths,  # the metapaths\n",
@@ -228,7 +225,7 @@
     "node_embeddings = (\n",
     "    model.wv.vectors\n",
     ")  # numpy.ndarray of size number of nodes times embeddings dimensionality\n",
-    "node_targets = [g_nx.nodes[node_id][\"label\"] for node_id in node_ids]"
+    "node_targets = [g.node_type(node_id) for node_id in node_ids]"
    ]
   },
   {

--- a/demos/link-prediction/random-walks/README.md
+++ b/demos/link-prediction/random-walks/README.md
@@ -78,16 +78,15 @@ For the examples we use 2 different datasets. The **Cora** dataset that is a hom
 **BlogCatalog3** can be downloaded from [here.]( http://socialcomputing.asu.edu/datasets/BlogCatalog3)
 
 The **BlogCatalog3** dataset must be loaded into a `networkx` graph object. The `stellargraph` library provides a
-utility method, `stellargraph.data.loader.load_dataset_BlogCatalog3(location)`, that loads the dataset,
-and returns a `networkx` graph object. Assuming that the **BlogCatalog3** dataset has been downloaded and unzipped
-in directory `~/data`, the following 3 lines of code will prepare the dataset for use in the below examples.
+utility method, `stellargraph.datasets.BlogCatalog3.load()`, that loads the dataset,
+and returns a `StellarGraph` graph object. The following 3 lines of code will prepare the dataset for use in the below examples.
 
 ```
 import networkx as nx
 import os
-from stellargraph.data.loader import load_dataset_BlogCatalog3
-g = load_dataset_BlogCatalog3(location='~/data/BlogCatalog-dataset/data/')
-nx.write_gpickle(g, os.path.expanduser('~/data/BlogCatalog3.gpickle'))
+from stellargraph.datasets import BlogCatalog3
+g = BlogCatalog3().load()
+nx.write_gpickle(g.to_networkx(), os.path.expanduser('~/data/BlogCatalog3.gpickle'))
 ```
 
 

--- a/docs/api.txt
+++ b/docs/api.txt
@@ -12,7 +12,7 @@ Data
 ----------------
 
 .. automodule:: stellargraph.data
-  :members: UniformRandomWalk, BiasedRandomWalk, UniformRandomMetaPathWalk, SampledBreadthFirstWalk, SampledHeterogeneousBreadthFirstWalk, TemporalRandomWalk, UnsupervisedSampler, EdgeSplitter, NodeSplitter, from_epgm, load_dataset_BlogCatalog3
+  :members: UniformRandomWalk, BiasedRandomWalk, UniformRandomMetaPathWalk, SampledBreadthFirstWalk, SampledHeterogeneousBreadthFirstWalk, TemporalRandomWalk, UnsupervisedSampler, EdgeSplitter, NodeSplitter, from_epgm
 
 
 Generators

--- a/stellargraph/data/loader.py
+++ b/stellargraph/data/loader.py
@@ -97,4 +97,4 @@ def load_dataset_BlogCatalog3(location):
     from stellargraph.datasets import BlogCatalog3
 
     location = os.path.expanduser(location)
-    return BlogCatalog3._load_from_location(location)
+    return BlogCatalog3._load_from_location(location).to_networkx()

--- a/stellargraph/data/loader.py
+++ b/stellargraph/data/loader.py
@@ -90,43 +90,11 @@ def load_dataset_BlogCatalog3(location):
         A networkx Graph object.
 
     """
+    warnings.warn(
+        "load_dataset_BlogCatalog3 has been replaced by `BlogCatalog3().load()`",
+        DeprecationWarning,
+    )
+    from stellargraph.datasets import BlogCatalog3
+
     location = os.path.expanduser(location)
-    if not os.path.isdir(location):
-        raise NotADirectoryError("The location {} is not a directory.".format(location))
-
-    # load the raw data
-    user_node_ids = pd.read_csv(os.path.join(location, "nodes.csv"), header=None)
-    group_ids = pd.read_csv(os.path.join(location, "groups.csv"), header=None)
-    edges = pd.read_csv(os.path.join(location, "edges.csv"), header=None)
-    group_edges = pd.read_csv(os.path.join(location, "group-edges.csv"), header=None)
-
-    # convert the dataframes to lists because that is what networkx expects as input
-    user_node_ids = user_node_ids[0].tolist()
-    group_ids = group_ids[0].tolist()
-    edges = list(edges.itertuples(index=False, name=None))  # convert to list of tuples
-    group_edges = list(group_edges.itertuples(index=False, name=None))
-
-    # The dataset uses integers for node ids. However, the integers from 1 to 39 are used as IDs for both users and
-    # groups. This would cause a confusion when constructing the networkx graph object. As a result, we convert all
-    # IDs to string and append the character 'p' to the integer ID for user nodes and the character 'g' to the integer
-    # ID for group nodes.
-    user_node_ids = ["u" + str(user_node_id) for user_node_id in user_node_ids]
-    group_ids = ["g" + str(group_id) for group_id in group_ids]
-    edges = [("u" + str(from_node), "u" + str(to_node)) for from_node, to_node in edges]
-    group_edges = [
-        ("u" + str(from_node), "g" + str(to_node)) for from_node, to_node in group_edges
-    ]
-
-    g_nx = nx.Graph()  # create the graph
-
-    # add user and group nodes with labels 'Person' and 'Group' respectively.
-    g_nx.add_nodes_from(user_node_ids, label="user")
-    g_nx.add_nodes_from(group_ids, label="group")
-
-    # add the user-user edges with label 'friend'
-    g_nx.add_edges_from(edges, label="friend")
-
-    # add user-group edges with label 'belongs'
-    g_nx.add_edges_from(group_edges, label="belongs")
-
-    return g_nx
+    return BlogCatalog3._load_from_location(location)

--- a/stellargraph/data/loader.py
+++ b/stellargraph/data/loader.py
@@ -97,4 +97,4 @@ def load_dataset_BlogCatalog3(location):
     from stellargraph.datasets import BlogCatalog3
 
     location = os.path.expanduser(location)
-    return BlogCatalog3._load_from_location(location).to_networkx()
+    return BlogCatalog3._load_from_location(location).to_networkx(feature_name=None)

--- a/stellargraph/datasets/datasets.py
+++ b/stellargraph/datasets/datasets.py
@@ -121,6 +121,9 @@ class BlogCatalog3(
 
     @staticmethod
     def _load_from_location(location):
+        """
+        Support code for the old `load_dataset_BlogCatalog3` function.
+        """
         if not os.path.isdir(location):
             raise NotADirectoryError(
                 "The location {} is not a directory.".format(location)

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -17,7 +17,7 @@
 import pytest
 import tempfile
 import os
-from stellargraph.datasets import Cora, CiteSeer
+from stellargraph.datasets import Cora, CiteSeer, BlogCatalog3
 from urllib.error import URLError
 from stellargraph.datasets.dataset_loader import DatasetLoader
 from urllib.request import urlretrieve
@@ -70,3 +70,18 @@ def test_download_cache(mock_urlretrieve) -> None:
     # if already downloaded and in the cache, then another download should skip urlretrieve
     Cora().download()
     assert not mock_urlretrieve.called
+
+
+def test_blogcatalog3_load() -> None:
+    g = BlogCatalog3().load()
+
+    n_users = 10312
+    n_groups = 39
+    n_friendships = 333983
+    n_belongs_to = 14476
+
+    assert g.number_of_nodes() == n_users + n_groups
+    assert g.number_of_edges() == n_friendships + n_belongs_to
+
+    assert g.nodes_of_type("user") == [f"u{x}" for x in range(1, n_users + 1)]
+    assert g.nodes_of_type("group") == [f"g{x}" for x in range(1, n_groups + 1)]

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -86,6 +86,7 @@ def test_blogcatalog3_load() -> None:
     assert g.nodes_of_type("user") == [f"u{x}" for x in range(1, n_users + 1)]
     assert g.nodes_of_type("group") == [f"g{x}" for x in range(1, n_groups + 1)]
 
+
 def test_blogcatalog3_deprecated_load() -> None:
     from stellargraph.data import load_dataset_BlogCatalog3
 

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -85,3 +85,11 @@ def test_blogcatalog3_load() -> None:
 
     assert g.nodes_of_type("user") == [f"u{x}" for x in range(1, n_users + 1)]
     assert g.nodes_of_type("group") == [f"g{x}" for x in range(1, n_groups + 1)]
+
+def test_blogcatalog3_deprecated_load() -> None:
+    from stellargraph.data import load_dataset_BlogCatalog3
+
+    dataset = BlogCatalog3()
+    dataset.download()
+    with pytest.warns(DeprecationWarning, match=r"BlogCatalog3\(\)\.load\(\)"):
+        load_dataset_BlogCatalog3(dataset.data_directory)


### PR DESCRIPTION
This moves the existing `load_dataset_BlogCatalog3` function to be part of the new `datasets` module, and tweaks it to return a `StellarGraph` object instead of a NetworkX graph. The old function now emits deprecation warning and then calls through to the new code (and does a conversion to a NetworkX graph).

This is a start on #812.