### PR TITLE
Test for warning about from_networkx 0-vector feature default

### DIFF
--- a/tests/core/test_graph.py
+++ b/tests/core/test_graph.py
@@ -924,15 +924,19 @@ def test_from_networkx_smoke():
     g.add_edge(1, 2, edge_label="Y")
     g.add_edge(1, 1)
 
-    from_nx = StellarGraph.from_networkx(
-        g,
-        edge_weight_label="weight_attr",
-        node_type_name="node_label",
-        edge_type_name="edge_label",
-        node_type_default="b",
-        edge_type_default="X",
-        node_features="features",
-    )
+    with pytest.warns(
+        UserWarning,
+        match=r"found the following nodes \(of type 'b'\) without features, using 4-dimensional zero vector: 2",
+    ):
+        from_nx = StellarGraph.from_networkx(
+            g,
+            edge_weight_label="weight_attr",
+            node_type_name="node_label",
+            edge_type_name="edge_label",
+            node_type_default="b",
+            edge_type_default="X",
+            node_features="features",
+        )
 
     raw = StellarGraph(
         nodes={


### PR DESCRIPTION
When reading features from an attribute in a node, the `StellarGraph.from_networkx` functionality will implicitly fill in a 0 vector for nodes that are missing the attribute. It does this with a warning, and so to verify that this is behaving correctly and to avoid the warning appearing in our test logs (for example: https://buildkite.com/stellar/stellargraph-public/builds/1575#64220409-0450-476e-83c3-698926b32c10/254-413), we can and should check for it using [`pytest.warns`](https://docs.pytest.org/en/latest/warnings.html#warns).