### PR TITLE
Add a timeout to every CI step to halt hung builds

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,7 +3,7 @@ timeout: &timeout
   # steps can run for half an hour, maximum: if they haven't finished by then, there's probably some
   # deeper problem. A global timeout would be better
   # (https://github.com/buildkite/feedback/issues/170).
-  timeout_in_minutes: 30
+  timeout_in_minutes: 2
 
 compose-config: &compose-config
   config:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,4 +1,10 @@
 ---
+timeout: &timeout
+  # steps can run for half an hour, maximum: if they haven't finished by then, there's probably some
+  # deeper problem. A global timeout would be better
+  # (https://github.com/buildkite/feedback/issues/170).
+  timeout_in_minutes: 30
+
 compose-config: &compose-config
   config:
     - docker-compose.yml
@@ -10,6 +16,7 @@ plugins: &plugins
 
 steps:
   - label: ":docker::python: build 3.6 runner"
+    <<: *timeout
     key: "runner-3_6"
     plugins:
       <<: *plugins
@@ -28,6 +35,7 @@ steps:
       queue: "t2medium"
 
   - label: ":docker::python: build 3.7 runner"
+    <<: *timeout
     key: "runner-3_7"
     plugins:
       <<: *plugins
@@ -46,6 +54,7 @@ steps:
       queue: "t2medium"
 
   - label: ":python: 3.6"
+    <<: *timeout
     key: "python_3_6"
     depends_on: "runner-3_6"
     command: ".buildkite/steps/script.sh"
@@ -58,6 +67,7 @@ steps:
       queue: "t2medium"
 
   - label: ":python: 3.7"
+    <<: *timeout
     key: "python_3_7"
     depends_on: "runner-3_7"
     command: ".buildkite/steps/script.sh"
@@ -70,6 +80,7 @@ steps:
       queue: "t2medium"
 
   - label: ":python::book: test notebooks %n"
+    <<: *timeout
     key: "test-notebooks"
     depends_on: "runner-3_6"
     parallelism: 35
@@ -85,12 +96,14 @@ steps:
       - exit_status: 2
 
   - label: ":python-black: format"
+    <<: *timeout
     plugins:
       <<: *plugins
       docker#v3.4.0:
         image: "stellargraph/black:snapshot"
 
   - label: ":python-black::jupyter: check notebook format"
+    <<: *timeout
     depends_on: "runner-3_6"
     command: "python scripts/format_notebooks.py --default --ci demos/"
     plugins:
@@ -102,6 +115,7 @@ steps:
       queue: "t2medium"
 
   - label: ":shell: format"
+    <<: *timeout
     plugins:
       <<: *plugins
       docker#v3.4.0:
@@ -109,6 +123,7 @@ steps:
         command: ["-d", "-i", "2", "-ci", "-sr", "."]
 
   - label: ":shell: shellcheck"
+    <<: *timeout
     command: 'find ./ -type f -name "*.sh" -print0 | xargs -0 shellcheck --color=always'
     plugins:
       <<: *plugins
@@ -116,18 +131,21 @@ steps:
         image: "koalaman/shellcheck-alpine:stable"
 
   - label: ":docker: :hadolint: lint Dockerfiles"
+    <<: *timeout
     plugins:
       <<: *plugins
       docker#v3.4.0:
         image: "stellargraph/hadolint:snapshot"
 
   - label: ":docker: format Dockerfiles"
+    <<: *timeout
     plugins:
       <<: *plugins
       docker#v3.4.0:
         image: "stellargraph/dockerfile-utils:snapshot"
 
   - label: ":prettier::yaml: format YAML"
+    <<: *timeout
     plugins:
       <<: *plugins
       docker#v3.4.0:
@@ -141,18 +159,22 @@ steps:
           ]
 
   - label: ":yaml::lint-roller: lint YAML"
+    <<: *timeout
     plugins:
       <<: *plugins
       docker#v3.4.0:
         image: "stellargraph/yamllint:snapshot"
 
   - label: ":copyright: check copyright headers"
+    <<: *timeout
     command: ".buildkite/steps/check-copyright-headers.sh"
 
   - label: ":space_invader: check whitespace"
+    <<: *timeout
     command: "scripts/whitespace.sh --ci"
 
   - label: ":docker: build image"
+    <<: *timeout
     plugins:
       <<: *plugins
       docker-compose#v3.1.0:
@@ -173,6 +195,7 @@ steps:
   - wait
 
   - label: ":docker: publish image"
+    <<: *timeout
     plugins:
       <<: *plugins
       docker-compose#v3.1.0:
@@ -184,6 +207,7 @@ steps:
   # explicit dependencies, so can be listed after all of the `wait` steps and publishings, so that
   # it runs in parallel with them.
   - label: ":memo: annotate with junit"
+    <<: *timeout
     plugins:
       junit-annotate#v1.7.0:
         artifacts: junit-*.xml

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,7 +3,7 @@ timeout: &timeout
   # steps can run for half an hour, maximum: if they haven't finished by then, there's probably some
   # deeper problem. A global timeout would be better
   # (https://github.com/buildkite/feedback/issues/170).
-  timeout_in_minutes: 2
+  timeout_in_minutes: 30
 
 compose-config: &compose-config
   config:


### PR DESCRIPTION
If a step in build hangs or takes an unusually long time, previously CI would let it continue, occupying machines forever. In lieu of a global timeout (https://github.com/buildkite/feedback/issues/170, https://forum.buildkite.community/t/pipeline-timeouts/722), we can manually apply a timeout to every step, as a last resort to catch slow/hung builds. This uses the [`timeout_in_minutes`](https://buildkite.com/docs/pipelines/command-step#command-step-attributes) optional attribute:

> The number of minutes a job created from this step is allowed to run. If the job does not finish within this limit, it will be automatically canceled and the build will fail. 

Our steps currently range from 30 seconds to 8 minutes, so 30 minutes should be a safe "something serious is wrong" time-out.

See: #905