### PR TITLE
Xfail tests relying on BlogCatalog3 download

### DIFF
--- a/.buildkite/steps/test-demo-notebooks.sh
+++ b/.buildkite/steps/test-demo-notebooks.sh
@@ -27,11 +27,13 @@ f=${NOTEBOOKS[$INDEX]}
 case $(basename "$f") in
   'attacks_clustering_analysis.ipynb' | 'hateful-twitters-interpretability.ipynb' | 'hateful-twitters.ipynb' | 'stellargraph-attri2vec-DBLP.ipynb' | \
     'node-link-importance-demo-gat.ipynb' | 'node-link-importance-demo-gcn.ipynb' | 'node-link-importance-demo-gcn-sparse.ipynb' | 'rgcn-aifb-node-classification-example.ipynb' | \
-    'directed-graphsage-on-cora-neo4j-example.ipynb' | 'undirected-graphsage-on-cora-neo4j-example.ipynb' | 'load-cora-into-neo4j.ipynb')
+    'directed-graphsage-on-cora-neo4j-example.ipynb' | 'undirected-graphsage-on-cora-neo4j-example.ipynb' | 'load-cora-into-neo4j.ipynb' | \
+    'stellargraph-metapath2vec.ipynb')
     # These notebooks do not yet work on CI:
     # FIXME #818: datasets can't be downloaded
     # FIXME #819: out-of-memory
     # FIXME #849: CI does not have neo4j
+    $ FIXME #907: socialcomputing.asu.edu is down
     echo "+++ :python: :skull_and_crossbones: skipping $f"
     exit 2 # this will be a soft-fail for buildkite
     ;;

--- a/.buildkite/steps/test-demo-notebooks.sh
+++ b/.buildkite/steps/test-demo-notebooks.sh
@@ -33,7 +33,7 @@ case $(basename "$f") in
     # FIXME #818: datasets can't be downloaded
     # FIXME #819: out-of-memory
     # FIXME #849: CI does not have neo4j
-    $ FIXME #907: socialcomputing.asu.edu is down
+    # FIXME #907: socialcomputing.asu.edu is down
     echo "+++ :python: :skull_and_crossbones: skipping $f"
     exit 2 # this will be a soft-fail for buildkite
     ;;

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -25,7 +25,13 @@ from unittest.mock import patch
 
 
 # use parametrize to automatically test each of the datasets that (directly) derive from DatasetLoader
-@pytest.mark.parametrize("dataset_class", list(DatasetLoader.__subclasses__()))
+def _marks(cls):
+    if cls == BlogCatalog3:
+        return pytest.mark.xfail(reason="https://github.com/stellargraph/stellargraph/issues/907")
+    return []
+
+
+@pytest.mark.parametrize("dataset_class", [pytest.param(cls, marks=_marks(cls)) for cls in DatasetLoader.__subclasses__()])
 def test_dataset_download(dataset_class):
     dataset_class().download(ignore_cache=True)
 
@@ -72,6 +78,7 @@ def test_download_cache(mock_urlretrieve) -> None:
     assert not mock_urlretrieve.called
 
 
+@pytest.mark.xfail(reason="https://github.com/stellargraph/stellargraph/issues/907")
 def test_blogcatalog3_load() -> None:
     g = BlogCatalog3().load()
 
@@ -87,6 +94,7 @@ def test_blogcatalog3_load() -> None:
     assert g.nodes_of_type("group") == [f"g{x}" for x in range(1, n_groups + 1)]
 
 
+@pytest.mark.xfail(reason="https://github.com/stellargraph/stellargraph/issues/907")
 def test_blogcatalog3_deprecated_load() -> None:
     from stellargraph.data import load_dataset_BlogCatalog3
 

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -27,11 +27,16 @@ from unittest.mock import patch
 # use parametrize to automatically test each of the datasets that (directly) derive from DatasetLoader
 def _marks(cls):
     if cls == BlogCatalog3:
-        return pytest.mark.xfail(reason="https://github.com/stellargraph/stellargraph/issues/907")
+        return pytest.mark.xfail(
+            reason="https://github.com/stellargraph/stellargraph/issues/907"
+        )
     return []
 
 
-@pytest.mark.parametrize("dataset_class", [pytest.param(cls, marks=_marks(cls)) for cls in DatasetLoader.__subclasses__()])
+@pytest.mark.parametrize(
+    "dataset_class",
+    [pytest.param(cls, marks=_marks(cls)) for cls in DatasetLoader.__subclasses__()],
+)
 def test_dataset_download(dataset_class):
     dataset_class().download(ignore_cache=True)
 


### PR DESCRIPTION
These tests are failing in a way that is out of our control (the website is down), so we can [xfail (expected-fail)](http://doc.pytest.org/en/latest/skipping.html) them for now, to allow CI to pass and other development to continue.

See: #907