### PR TITLE
Add buildkite annotation when notebook parallelism setting is wrong

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -72,7 +72,7 @@ steps:
   - label: ":python::book: test notebooks %n"
     key: "test-notebooks"
     depends_on: "runner-3_6"
-    parallelism: 30
+    parallelism: 35
     command: ".buildkite/steps/test-demo-notebooks.sh"
     plugins:
       <<: *plugins

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -72,7 +72,7 @@ steps:
   - label: ":python::book: test notebooks %n"
     key: "test-notebooks"
     depends_on: "runner-3_6"
-    parallelism: 35
+    parallelism: 30
     command: ".buildkite/steps/test-demo-notebooks.sh"
     plugins:
       <<: *plugins

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -72,7 +72,7 @@ steps:
   - label: ":python::book: test notebooks %n"
     key: "test-notebooks"
     depends_on: "runner-3_6"
-    parallelism: 30
+    parallelism: 36
     command: ".buildkite/steps/test-demo-notebooks.sh"
     plugins:
       <<: *plugins

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -72,7 +72,7 @@ steps:
   - label: ":python::book: test notebooks %n"
     key: "test-notebooks"
     depends_on: "runner-3_6"
-    parallelism: 36
+    parallelism: 30
     command: ".buildkite/steps/test-demo-notebooks.sh"
     plugins:
       <<: *plugins

--- a/.buildkite/steps/test-demo-notebooks.sh
+++ b/.buildkite/steps/test-demo-notebooks.sh
@@ -18,7 +18,9 @@ done < <(find "${stellargraph_dir}/demos" -name "*.ipynb" -print0)
 NUM_NOTEBOOKS_TOTAL=${#NOTEBOOKS[@]}
 
 if [ "$NUM_NOTEBOOKS_TOTAL" -ne "$SPLIT" ]; then
-  msg="Buildkite step parallelism is set to $SPLIT but found $NUM_NOTEBOOKS_TOTAL notebooks. Please update the notebook testing \`parallelism\` setting in \`.buildkite/pipeline.yml\`  to match the number of notebooks!"
+  msg="Buildkite step parallelism is set to $SPLIT but found $NUM_NOTEBOOKS_TOTAL notebooks. Please update the notebook testing \`parallelism\` setting in \`.buildkite/pipeline.yml\`  to match the number of notebooks!
+
+If a pull request adding or removing notebooks was merged recently, this may be fixed by doing a merge with \`develop\`; for example: \`git fetch origin && git merge origin/develop\`."
   echo "$msg"
   # Every step will do this annotation, but they all use the same context and there's no --append
   # flag here, and so they replace each other. Thus, there should only ever be a single instance of

--- a/.buildkite/steps/test-demo-notebooks.sh
+++ b/.buildkite/steps/test-demo-notebooks.sh
@@ -23,7 +23,7 @@ if [ "$NUM_NOTEBOOKS_TOTAL" -ne "$SPLIT" ]; then
   # Every step will do this annotation, but they all use the same context and there's no --append
   # flag here, and so they replace each other. Thus, there should only ever be a single instance of
   # it.
-  buildkite annotate --context "incorrect-notebook-parallelism" --style error "$msg"
+  buildkite-agent annotate --context "incorrect-notebook-parallelism" --style error "$msg"
   exit 1
 fi
 

--- a/.buildkite/steps/test-demo-notebooks.sh
+++ b/.buildkite/steps/test-demo-notebooks.sh
@@ -19,7 +19,7 @@ NUM_NOTEBOOKS_TOTAL=${#NOTEBOOKS[@]}
 
 if [ "$NUM_NOTEBOOKS_TOTAL" -ne "$SPLIT" ]; then
   msg="Buildkite step parallelism is set to $SPLIT but found $NUM_NOTEBOOKS_TOTAL notebooks. Please update the notebook testing \`parallelism\` setting in \`.buildkite/pipeline.yml\`  to match the number of notebooks!"
-  echo $msg
+  echo "$msg"
   # Every step will do this annotation, but they all use the same context and there's no --append
   # flag here, and so they replace each other. Thus, there should only ever be a single instance of
   # it.

--- a/.buildkite/steps/test-demo-notebooks.sh
+++ b/.buildkite/steps/test-demo-notebooks.sh
@@ -18,7 +18,12 @@ done < <(find "${stellargraph_dir}/demos" -name "*.ipynb" -print0)
 NUM_NOTEBOOKS_TOTAL=${#NOTEBOOKS[@]}
 
 if [ "$NUM_NOTEBOOKS_TOTAL" -ne "$SPLIT" ]; then
-  echo "Buildkite step parallelism is set to $SPLIT but found $NUM_NOTEBOOKS_TOTAL notebooks. Please update parallelism to match the number of notebooks!"
+  msg="Buildkite step parallelism is set to $SPLIT but found $NUM_NOTEBOOKS_TOTAL notebooks. Please update the notebook testing \`parallelism\` setting in \`.buildkite/pipeline.yml\`  to match the number of notebooks!"
+  echo $msg
+  # Every step will do this annotation, but they all use the same context and there's no --append
+  # flag here, and so they replace each other. Thus, there should only ever be a single instance of
+  # it.
+  buildkite annotate --context "incorrect-notebook-parallelism" --style error "$msg"
   exit 1
 fi
 


### PR DESCRIPTION
If the number of notebooks doesn't match the `parallelism` setting used for testing notebooks, all of the steps will fail, and one needs to go into them to deduce what the problem was, and then interpret the message. This PR (a) rewrites the message to be a bit clearer, including mentioning the common case of needing to merge with develop, and (b) adds it as [an annotation](https://buildkite.com/docs/agent/v3/cli-annotate) at the top of the build for convenience.

## Example

https://buildkite.com/stellar/stellargraph-public/builds/1628

![image](https://user-images.githubusercontent.com/1203825/75000860-bfaebb00-54b3-11ea-98a7-a4451e31702c.png)