### PR TITLE
Sort notebooks before deciding which to run in each step on CI

### DIFF
--- a/.buildkite/steps/test-demo-notebooks.sh
+++ b/.buildkite/steps/test-demo-notebooks.sh
@@ -8,12 +8,12 @@ SPLIT="${BUILDKITE_PARALLEL_JOB_COUNT:-1}"
 INDEX="${BUILDKITE_PARALLEL_JOB:-0}"
 
 echo "--- :books: collecting notebooks"
-# Create array with all notebooks in demo directories.
+# Create array with all notebooks in demo directories, with explicit sorting so every parallel step
+# sees the same ordering
 cd "${stellargraph_dir}"
-NOTEBOOKS=()
-while IFS= read -r -d $'\0'; do
-  NOTEBOOKS+=("$REPLY")
-done < <(find "${stellargraph_dir}/demos" -name "*.ipynb" -print0)
+IFS=$'\n' read -rd '' -a NOTEBOOKS < <(
+  find "${stellargraph_dir}/demos" -name "*.ipynb" | sort
+)
 
 NUM_NOTEBOOKS_TOTAL=${#NOTEBOOKS[@]}
 

--- a/.buildkite/steps/test-demo-notebooks.sh
+++ b/.buildkite/steps/test-demo-notebooks.sh
@@ -13,7 +13,7 @@ echo "--- :books: collecting notebooks"
 cd "${stellargraph_dir}"
 IFS=$'\n' read -rd '' -a NOTEBOOKS < <(
   find "${stellargraph_dir}/demos" -name "*.ipynb" | sort
-)
+) || true # (the read always exits with 1, because it hits EOF)
 
 NUM_NOTEBOOKS_TOTAL=${#NOTEBOOKS[@]}
 

--- a/.buildkite/steps/test-demo-notebooks.sh
+++ b/.buildkite/steps/test-demo-notebooks.sh
@@ -8,12 +8,14 @@ SPLIT="${BUILDKITE_PARALLEL_JOB_COUNT:-1}"
 INDEX="${BUILDKITE_PARALLEL_JOB:-0}"
 
 echo "--- :books: collecting notebooks"
-# Create array with all notebooks in demo directories, with explicit sorting so every parallel step
-# sees the same ordering
+# Create array with all notebooks in demo directories.
 cd "${stellargraph_dir}"
-IFS=$'\n' read -rd '' -a NOTEBOOKS < <(
-  find "${stellargraph_dir}/demos" -name "*.ipynb" | sort
-)
+NOTEBOOKS=()
+while IFS= read -r -d $'\0'; do
+  NOTEBOOKS+=("$REPLY")
+done < <(find "${stellargraph_dir}/demos" -name "*.ipynb" -print0)
+
+echo "${NOTEBOOKS[@]}"
 
 NUM_NOTEBOOKS_TOTAL=${#NOTEBOOKS[@]}
 

--- a/.buildkite/steps/test-demo-notebooks.sh
+++ b/.buildkite/steps/test-demo-notebooks.sh
@@ -8,14 +8,12 @@ SPLIT="${BUILDKITE_PARALLEL_JOB_COUNT:-1}"
 INDEX="${BUILDKITE_PARALLEL_JOB:-0}"
 
 echo "--- :books: collecting notebooks"
-# Create array with all notebooks in demo directories.
+# Create array with all notebooks in demo directories, with explicit sorting so every parallel step
+# sees the same ordering
 cd "${stellargraph_dir}"
-NOTEBOOKS=()
-while IFS= read -r -d $'\0'; do
-  NOTEBOOKS+=("$REPLY")
-done < <(find "${stellargraph_dir}/demos" -name "*.ipynb" -print0)
-
-echo "${NOTEBOOKS[@]}"
+IFS=$'\n' read -rd '' -a NOTEBOOKS < <(
+  find "${stellargraph_dir}/demos" -name "*.ipynb" | sort
+)
 
 NUM_NOTEBOOKS_TOTAL=${#NOTEBOOKS[@]}
 


### PR DESCRIPTION
I think #917 is caused by different steps getting different orders of the `$NOTEBOOKS` array, due to differing orders from `find`. This would mean that some steps might be selecting a notebook that was run by a different step and skipping over the notebook they were meant to be running.  For example, consider [build 1643](https://buildkite.com/stellar/stellargraph-public/builds/1643), which is the same code as `develop`, but prints out the array of notebooks in each notebook step to allow for comparisons.

- [in notebook step 0](https://buildkite.com/stellar/stellargraph-public/builds/1643#b3bbd052-b8d9-4574-9f7a-bfc93dcb4304/162-277), the list of notebooks goes:
  - ...
  - `gcn-cora-node-classification-example.ipynb`
  - **`directed-graphsage-on-cora-example.ipynb`**
  -  `graphsage-cora-node-classification-example.ipynb`
  - `graphsage-pubmed-inductive-node-classification-example.ipynb`
  - `stellargraph-node2vec-node-classification.ipynb`
  - ...
- [in notebook step 3](https://buildkite.com/stellar/stellargraph-public/builds/1643#a0a520f4-aa28-47fb-b224-ea8deeb0b2a9/162-277), it goes:
  - ...
  - `gcn-cora-node-classification-example.ipynb`
  -  `graphsage-cora-node-classification-example.ipynb`
  - `graphsage-pubmed-inductive-node-classification-example.ipynb`
  - **`directed-graphsage-on-cora-example.ipynb`**
  - `stellargraph-node2vec-node-classification.ipynb`
  - ...

That is, the position of `directed-graphsage-on-cora-example.ipynb` in the `NOTEBOOKS` array has changed. In that particular build, steps 6, 22 and 25 have the same order as step 3, step 12 has `load-cora-into-neo4j.ipynb` move, step 30 has `node-link-importance-demo-gcn.ipynb` move and step 33 has both `calibration-pubmed-link-prediction.ipynb` and `ensemble-link-prediction-example.ipynb` move. It seems that build got lucky, and those moves didn't affect which notebooks were run (that is, the mini script in #917 didn't find any differences), however they definitely could have done so.

If we sort by the file path, we'll always get a consistent order in the array, so the `f=${NOTEBOOKS[$INDEX]}` selection will always give (a) the same result for same `$INDEX` values, and (b) different notebooks for different `$INDEX` values.

Empirical verification: I did 10 builds with sorting on CI (`1651` `1655` `1656` `1657` `1658` `1659` `1660` `1661` `1662` `1663`), and checked them all with the mini script in #917; all of them built exactly the notebooks they should build. Specifically, the following printed no diff output, and thus all of the inputs are identical.

```bash
for b in 1651 1655 1656 1657 1658 1659 1660 1661 1662 1663; do 
  diff -U100 \
    <(find . -name '*.ipynb' '!' -path '*.ipynb_checkpoints*' | xargs basename | grep -v "$bad_notebooks" | sort) \
    <(curl -H "Authorization: Bearer $t" "https://api.buildkite.com/v2/organizations/stellar/pipelines/stellargraph-public/builds/$b/artifacts" | jq -r '.[].filename' | grep ipynb | sort)
done
```

See: #917