### PR TITLE
Optimise `setdiag(0)` in StellarGraph.to_adjacency_matrix on undirected graphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Some new algorithms and features are still under active development, and are ava
 
 ### Bug fixes and other changes
 
+- `StellarGraph.to_adjacency_matrix` is at least 15× faster on undirected graphs [\#932](http://github.com/stellargraph/stellargraph/pull/932)
 - DevOps changes:
 
 ## [0.10.0](https://github.com/stellargraph/stellargraph/tree/v0.10.0)

--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -979,7 +979,7 @@ class StellarGraph:
             backward = adj.transpose(copy=True)
             # this is setdiag(0), but faster, since it doesn't change the sparsity structure of the
             # matrix (https://github.com/scipy/scipy/issues/11600)
-            nonzero, = backward.diagonal().nonzero()
+            (nonzero,) = backward.diagonal().nonzero()
             backward[nonzero, nonzero] = 0
 
             adj += backward

--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -976,8 +976,12 @@ class StellarGraph:
         if not self.is_directed():
             # in an undirected graph, the adjacency matrix should be symmetric: which means counting
             # weights from either "incoming" or "outgoing" edges, but not double-counting self loops
-            backward = sps.csr_matrix((weights, (tgt_idx, src_idx)), shape=(n, n))
-            backward.setdiag(0)
+            backward = adj.transpose(copy=True)
+            # this is setdiag(0), but faster, since it doesn't change the sparsity structure of the
+            # matrix (https://github.com/scipy/scipy/issues/11600)
+            nonzero, = backward.diagonal().nonzero()
+            backward[nonzero, nonzero] = 0
+
             adj += backward
 
         # this is a multigraph, let's eliminate any duplicate entries

--- a/tests/core/test_graph.py
+++ b/tests/core/test_graph.py
@@ -889,6 +889,16 @@ def test_to_adjacency_matrix():
     assert np.array_equal(matrix, actual)
 
 
+@pytest.mark.benchmark(group="StellarGraph to_adjacency_matrix")
+@pytest.mark.parametrize("is_directed", [False, True])
+def test_benchmark_to_adjacency_matrix(is_directed, benchmark):
+    nodes, edges = example_benchmark_graph(n_nodes=1000, n_edges=5000)
+    cls = StellarDiGraph if is_directed else StellarGraph
+    g = cls(nodes, edges)
+
+    benchmark(lambda: g.to_adjacency_matrix())
+
+
 def test_edge_weights_undirected():
     g = example_hin_1(is_directed=False, self_loop=True)
 


### PR DESCRIPTION
On a [CSR matrix](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.csr_matrix.html), `setdiag` will change the sparsity structure, meaning it has to introduce new elements into the optimised `numpy` arrays that it stores under the hood (which is `O(edges)` in our case). This is true even when setting the diagonal to `0` which theoretically only needs to clear the elements that exist, not add new ones (https://github.com/scipy/scipy/issues/11600). Per that issue, it's faster to manually find the zero elements in the diagonal, and clear only them to avoid changing the sparsity structure, which is `O(nodes)`.

This improves the included benchmark on undirected graphs with 1000 nodes and 5000 edges significantly (15&times;), and will likely have a large improvement on larger graphs. (Times in microseconds.)

| type | code | min (s) | mean (s) | stddev (s) |
|---|---|---:|---:|--:|
| directed | this PR | 484 | 565 | 88 |
| directed | develop |  485 | 573 | 92 | 
| undirected | this PR | 937 | 1060 | 155 |
| undirected | develop | 12900 | 15100 | 1240 |

(The directed code path doesn't change and those observations are within noise of each other.)

This also switches to `transpose` rather than constructing a whole new separate matrix for the backwards links, because that's also faster (min time: 1110us -> 937us).

See: #931