### PR TITLE
Restore demo script for link prediction via random walks (#895)

### DIFF
--- a/demos/link-prediction/random-walks/README.md
+++ b/demos/link-prediction/random-walks/README.md
@@ -1,5 +1,7 @@
 # Link Prediction demo
 
+The notebook `cora-lp-demo.ipynb` demonstrates how to predict citation links/edges between papers in the homogeneous CORA dataset using the random walk-based representation learning method Node2Vec.
+
 The main.py script runs link prediction on a homogeneous or heterogeneous graph. When
 the graph is heterogeneous, it can optionally be treated as homogeneous for representation learning; in
 this case, the link prediction script can be thought of as a baseline for more advanced
@@ -21,6 +23,94 @@ used for training, and data after that same date are put aside for predicting/te
 This example assumes the `stellargraph` library and its requirements have been
 installed by following the installation instructions in the README
 of the library's [root directory](https://github.com/stellargraph/stellargraph).
+
+### Usage
+
+#### Command Line Arguments
+The script accepts the following command line arguments:
+
+- `input_graph <str>`  The directory where the graph is stored, either as an edge list or a pickled networkx object.
+- `output_node_features <str>` The file where the node features from representation learning are written
+for future reference.
+- `subsample` If specified, the graph is subsampled (number of nodes reduced) by a default 0.1 factor, e.g,
+10 percent of the original graph. This option is useful for speeding up testing on large graphs.
+- `subgraph_size <float>` Valid values are in the interval (0, 1]. It reduces the graph size by the given factor.
+Size reduction is performed by reducing the number of nodes in the graph by the given factor and removing all other
+nodes and edges connecting those nodes.
+- `sampling_method <str>` Valid values are 'local' and 'global'. Specifies how pairs of nodes that are not connected are
+selected as negative edge samples. The 'global' method, selects pairs of nodes uniformly at random from all nodes in
+the graph that are not connected by an edge. The 'local' methods first samples a distance (number of edges) from a
+source node (selected uniformly at random from all nodes int he graph) and then selects the first node at this distance
+as the target node for the negative edge sample. The distance is sampled based on a probability distribution that can
+be specified using the probs command line parameter.
+- `sampling_probs <str: comma separated list of floats>` The probability distribution for sampling distances between
+source and target nodes. The first value should always be 0.0 and the remaining values should sum to one. An example for
+sampling target nodes up to 4 edges away from source is `"0.0, 0.25, 0.25, 0.5"`.
+- `p <float>` If specified, it indicates the number of positive and negative edges to be used for training
+the link prediction classifier. The value indicates a percentage with respect to the relevant number of
+edges in the input graph. The default value is 0.1 and valid values are in the range (0,1).
+- `hin` If specified, it indicates that the input graph is heterogeneous. If not specified, a heterogeneous graph is
+simplified to homogeneous and the options `edge_type`, `edge_attribute_label`, `edge_attribute_threshold`, and
+`attribute_is_datetime` are ignored even if given.
+- `metapaths <str>` For heterogeneous graphs (must specify `hin` option), this option can be used to specify the
+metapaths for the random walks. A metapath is a `,` separated list of node labels; more than one metapaths can
+be specified separated by a `;`. An example specifying 2 metapaths assuming node labels `author, paper, venue` is
+`"author, paper, author; author, paper, venue, paper, author"`.
+- `edge_type <str>` For heterogeneous graphs, this option is used to specify the type of edge (by its label) to
+predict.
+- `edge_attribute_label <str>` For heterogeneous graphs, this option is used to specify the edges that should be
+predicted based on an attribute; the only valid attribute is a date in the format dd/mm/yyyy, e.g., 10/2/2018. This
+option should be used together with `edge_type`.
+- `attribute_is_datetime` If specified together with `edge_attribute_label` it indicates that the type of attribute
+to use for selecting edges to predict is a date with format dd/mm/yyyy. Currently, only date attributes are allowed so
+this flag should always specified together with `edge_attribute_label`. Later implementations will support numeric
+edge attributes in additions to dates.
+- `edge_attribute_threshold <str>` For heterogeneous graphs and used together with `edge_attribute_label` it specifies
+a value (date as only dates are currently supported) for edges to predict.
+- `show_hist` If this flag is specified, then a histogram of the distances between source and target nodes comprising
+negative edge samples is plotted.
+
+#### Examples
+
+For the examples we use 2 different datasets. The **Cora** dataset that is a homogeneous network and the
+**BlogCatalog3** dataset that is a heterogeneous network.
+
+**Cora** can be downloaded from [here.](https://linqs-data.soe.ucsc.edu/public/lbc/cora.tgz)
+
+**BlogCatalog3** can be downloaded from [here.]( http://socialcomputing.asu.edu/datasets/BlogCatalog3)
+
+The **BlogCatalog3** dataset must be loaded into a `networkx` graph object. The `stellargraph` library provides a
+utility method, `stellargraph.datasets.BlogCatalog3.load()`, that loads the dataset,
+and returns a `StellarGraph` graph object. The following 3 lines of code will prepare the dataset for use in the below examples.
+
+```
+import networkx as nx
+import os
+from stellargraph.datasets import BlogCatalog3
+g = BlogCatalog3().load()
+nx.write_gpickle(g.to_networkx(), os.path.expanduser('~/data/BlogCatalog3.gpickle'))
+```
+
+
+**Example 1: Homogeneous graph with global sampling method for negative example**
+```
+python main.py --input_graph=~/data/cora.cites --output_node_features=~/data/cora.emb --sampling_method='global'
+```
+
+**Example 2: Homogeneous graph with local sampling method for negative examples**
+```
+python main.py --input_graph=~/data/cora.cites --output_node_features=~/data/cora.emb --sampling_method='local' --sampling_probs="0.0, 0.0, 0.0, 0.5, 0.5"
+```
+
+**Example 3: Heterogeneous graph treated as homogeneous**
+```
+python main.py --input_graph=~/data/BlogCatalog3.gpickle --output_node_features=~/data/bc3.emb --sampling_method='global'
+```
+
+**Example 4: Heterogeneous graph predicting edges based on edge type**
+```
+python main.py --hin --input_graph=~/data/BlogCatalog3.gpickle --output_node_features=~/data/bc3.emb  --edge_type="friend" --sampling_method='global'
+```
 
 ### References
 

--- a/demos/link-prediction/random-walks/README.md
+++ b/demos/link-prediction/random-walks/README.md
@@ -75,7 +75,12 @@ negative edge samples is plotted.
 For the examples we use 2 different datasets. The **Cora** dataset that is a homogeneous network and the
 **BlogCatalog3** dataset that is a heterogeneous network.
 
-**Cora** can be downloaded from [here.](https://linqs-data.soe.ucsc.edu/public/lbc/cora.tgz)
+**Cora** can be downloaded from [here:](https://linqs-data.soe.ucsc.edu/public/lbc/cora.tgz)
+
+```
+from stellargraph.datasets import Cora
+Cora().download()
+```
 
 **BlogCatalog3** can be downloaded from [here.]( http://socialcomputing.asu.edu/datasets/BlogCatalog3)
 
@@ -94,12 +99,12 @@ nx.write_gpickle(g.to_networkx(), os.path.expanduser('~/data/BlogCatalog3.gpickl
 
 **Example 1: Homogeneous graph with global sampling method for negative example**
 ```
-python main.py --input_graph=~/data/cora.cites --output_node_features=~/data/cora.emb --sampling_method='global'
+python main.py --input_graph=~/stellargraph-datasets/cora/cora.cites --output_node_features=~/data/cora.emb --sampling_method='global'
 ```
 
 **Example 2: Homogeneous graph with local sampling method for negative examples**
 ```
-python main.py --input_graph=~/data/cora.cites --output_node_features=~/data/cora.emb --sampling_method='local' --sampling_probs="0.0, 0.0, 0.0, 0.5, 0.5"
+python main.py --input_graph=~/stellargraph-datasets/cora/cora.cites --output_node_features=~/data/cora.emb --sampling_method='local' --sampling_probs="0.0, 0.0, 0.0, 0.5, 0.5"
 ```
 
 **Example 3: Heterogeneous graph treated as homogeneous**

--- a/demos/link-prediction/random-walks/main.py
+++ b/demos/link-prediction/random-walks/main.py
@@ -1,0 +1,254 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2017-2020 Data61, CSIRO
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import matplotlib.pyplot as plt
+from math import isclose
+import os
+import networkx as nx
+import numpy as np
+from stellargraph.data import EdgeSplitter
+from stellargraph import StellarGraph
+from utils.cl_arguments_parser import parse_args
+from utils.read_graph import read_graph
+from utils.predictors import *
+from collections import Counter
+import multiprocessing
+
+
+# Default parameters for Node2Vec
+parameters = {
+    "p": 1.0,  # Parameter p
+    "q": 1.0,  # Parameter q
+    "dimensions": 128,  # dimensionality of node2vec embeddings
+    "num_walks": 10,  # Number of walks from each node
+    "walk_length": 80,  # Walk length
+    "window_size": 10,  # Context size for word2vec
+    "iter": 1,  # number of SGD iterations (epochs)
+    "workers": multiprocessing.cpu_count(),  # number of workers for word2vec
+    "weighted": False,  # is graph weighted?
+    "directed": False,  # are edges directed?
+}
+
+
+def print_distance_probabilities(node_distances):
+    counts = Counter(node_distances)
+    d_total = sum(counts.values())
+    counts_normalized = {k: v / d_total for k, v in counts.items()}
+    counts_normalized = sorted(counts_normalized.items(), key=lambda x: x[0])
+    counts = [v for k, v in counts_normalized]
+    print(
+        "Normalized distances between source and target nodes in negative samples: {}".format(
+            counts
+        )
+    )
+
+
+def get_metapaths_from_str(metapaths_str):
+    """
+    Metapaths are given as a string with the following format "p, v, p; a, p, v, p, a" where two metapaths
+    are given separated by ; and each metapath consists of node labels (treated as string) separated by commas.
+    Args:
+        metapaths_str: Metapaths in string format
+
+    Returns: A list of list of node labels where each list specifies a metapath.
+
+    """
+    if len(metapaths_str) == 0:
+        metapaths = [
+            ["group", "user", "group"],
+            ["user", "group", "user"],
+            ["user", "group", "user", "user"],
+            ["user", "user"],
+        ]
+    else:
+        metapaths = []
+        m_tokens = metapaths_str.split(";")
+
+        for metapath in m_tokens:
+            metapaths.append(list(metapath.split(",")))
+
+    return metapaths
+
+
+if __name__ == "__main__":
+    args = parse_args()
+
+    p = float(args.p)
+    if p <= 0 or p >= 1:
+        print("** Invalid value: p should be in the interval (0, 1) **")
+        exit(0)
+
+    subgraph_size = float(args.subgraph_size)
+    if subgraph_size <= 0 or subgraph_size > 1:
+        print("** Invalid value: subgraph_size should be in the interval (0, 1] **")
+        exit(0)
+
+    print("Negative edges sampling method is set to {}.".format(args.sampling_method))
+    sampling_probs = np.array([float(n) for n in args.sampling_probs.split(",")])
+    if not isclose(sum(sampling_probs), 1.0):
+        print(
+            "WARNING: Negative edge distance sampling probabilities do not sum to 1.0. They will be normalized to continue."
+        )
+        sampling_probs = sampling_probs / np.sum(
+            sampling_probs
+        )  # make sure that the probabilities sum to 1.0
+        print("  Normalized Sampling Probabilities: {}".format(sampling_probs))
+
+    graph_filename = os.path.expanduser(args.input_graph)
+    dataset_name = args.dataset_name
+    # Load the graph from disk
+    g_nx = read_graph(
+        graph_file=graph_filename,
+        dataset_name=dataset_name,
+        is_directed=parameters["directed"],
+        is_weighted=parameters["weighted"],
+    )
+
+    if args.subsample_graph:
+        # subsample g_nx
+        nodes = g_nx.nodes(data=False)
+        np.random.shuffle(nodes)
+        subgraph_num_nodes = int(len(nodes) * subgraph_size)
+        g_nx = g_nx.subgraph(nodes[0:subgraph_num_nodes])
+
+    # Check if graph is connected; if not, then select the largest subgraph to continue
+    if nx.is_connected(g_nx):
+        print("Graph is connected")
+    else:
+        print("Graph is not connected")
+        # take the largest connected component as the data
+        g_nx_ccs = (g_nx.subgraph(c).copy() for c in nx.connected_components(g_nx))
+        g_nx = max(g_nx_ccs, key=len)
+        print(
+            "Largest subgraph statistics: {} nodes, {} edges".format(
+                g_nx.number_of_nodes(), g_nx.number_of_edges()
+            )
+        )
+
+    # From the original graph, extract E_test and G_test
+    edge_splitter_test = EdgeSplitter(g_nx)
+    if args.hin:
+        (
+            g_test,
+            edge_data_ids_test,
+            edge_data_labels_test,
+        ) = edge_splitter_test.train_test_split(
+            p=p,
+            edge_label=args.edge_type,
+            edge_attribute_label=args.edge_attribute_label,
+            edge_attribute_threshold=args.edge_attribute_threshold,
+            attribute_is_datetime=args.attribute_is_datetime,
+            method=args.sampling_method,
+            probs=sampling_probs,
+        )
+    else:
+        (
+            g_test,
+            edge_data_ids_test,
+            edge_data_labels_test,
+        ) = edge_splitter_test.train_test_split(
+            p=p, method=args.sampling_method, probs=sampling_probs
+        )
+    if args.show_histograms:
+        if args.sampling_method == "local":
+            bins = np.arange(1, len(sampling_probs) + 2)
+        else:
+            bins = np.arange(
+                1, np.max(edge_splitter_test.negative_edge_node_distances) + 2
+            )
+
+        plt.hist(
+            edge_splitter_test.negative_edge_node_distances,
+            bins=bins,
+            rwidth=0.5,
+            align="left",
+        )
+        plt.show()
+
+    if args.sampling_method == "local":
+        print_distance_probabilities(edge_splitter_test.negative_edge_node_distances)
+
+    edge_splitter_train = EdgeSplitter(g_test, g_nx)
+    if args.hin:
+        (
+            g_train,
+            edge_data_ids_train,
+            edge_data_labels_train,
+        ) = edge_splitter_train.train_test_split(
+            p=p,
+            edge_label=args.edge_type,
+            edge_attribute_label=args.edge_attribute_label,
+            edge_attribute_threshold=args.edge_attribute_threshold,
+            attribute_is_datetime=args.attribute_is_datetime,
+            method=args.sampling_method,
+            probs=sampling_probs,
+        )
+    else:
+        (
+            g_train,
+            edge_data_ids_train,
+            edge_data_labels_train,
+        ) = edge_splitter_train.train_test_split(
+            p=p, method=args.sampling_method, probs=sampling_probs
+        )
+    if args.show_histograms:
+        if args.sampling_method == "local":
+            bins = np.arange(1, len(sampling_probs) + 2)
+        else:
+            bins = np.arange(
+                1, np.max(edge_splitter_train.negative_edge_node_distances) + 2
+            )
+        plt.hist(
+            edge_splitter_train.negative_edge_node_distances,
+            bins=bins,
+            rwidth=0.5,
+            align="left",
+        )
+        plt.show()
+
+    if args.sampling_method == "local":
+        print_distance_probabilities(edge_splitter_train.negative_edge_node_distances)
+
+    # this is so that Node2Vec works because it expects Graph not MultiGraph type
+    g_test = nx.Graph(g_test)
+    g_train = nx.Graph(g_train)
+
+    if args.hin:
+        # prepare the metapaths if given in the command line
+        metapaths = get_metapaths_from_str(args.metapaths)
+
+        train_heterogeneous_graph(
+            g_train=StellarGraph(g_train),
+            g_test=StellarGraph(g_test),
+            output_node_features=args.output_node_features,
+            edge_data_ids_train=edge_data_ids_train,
+            edge_data_labels_train=edge_data_labels_train,
+            edge_data_ids_test=edge_data_ids_test,
+            edge_data_labels_test=edge_data_labels_test,
+            metapaths=metapaths,
+            parameters=parameters,
+        )
+    else:
+        train_homogeneous_graph(
+            g_train=g_train,
+            g_test=g_test,
+            output_node_features=args.output_node_features,
+            edge_data_ids_train=edge_data_ids_train,
+            edge_data_labels_train=edge_data_labels_train,
+            edge_data_ids_test=edge_data_ids_test,
+            edge_data_labels_test=edge_data_labels_test,
+            parameters=parameters,
+        )

--- a/demos/link-prediction/random-walks/utils/cl_arguments_parser.py
+++ b/demos/link-prediction/random-walks/utils/cl_arguments_parser.py
@@ -1,0 +1,134 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2017-2020 Data61, CSIRO
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+
+
+def parse_args():
+    """
+    Parses the command line arguments.
+
+    Returns:
+    """
+    parser = argparse.ArgumentParser(
+        description="Run link prediction on homogeneous and heterogeneous graphs."
+    )
+
+    parser.add_argument(
+        "--dataset_name",
+        nargs="?",
+        default="cora",
+        help="The dataset name as stored in graphs.json",
+    )
+
+    parser.add_argument(
+        "--metapaths",
+        nargs="?",
+        default="",
+        help="The metapaths to use for random walks in the metapath2vec algorithm on heterogeneous networks",
+    )
+
+    parser.add_argument(
+        "--p",
+        nargs="?",
+        default=0.1,
+        help="Percent of edges to sample for positive and negative examples (valid values 0 < p < 1)",
+    )
+
+    parser.add_argument(
+        "--subgraph_size",
+        nargs="?",
+        default=0.1,
+        help="Percent of nodes for a subgraph of the input data when --subsample is specified (valid values 0 < subgraph_size < 1)",
+    )
+
+    parser.add_argument(
+        "--edge_type", nargs="?", default="friend", help="The edge type to predict"
+    )
+
+    parser.add_argument(
+        "--edge_attribute_label",
+        nargs="?",
+        default="date",
+        help="The attribute label by which to split edges",
+    )
+
+    parser.add_argument(
+        "--edge_attribute_threshold",
+        nargs="?",
+        default=None,
+        help="Any edge with attribute value less that the threshold cannot be removed from graph",
+    )
+
+    parser.add_argument(
+        "--attribute_is_datetime",
+        dest="attribute_is_datetime",
+        action="store_true",
+        help="If specified, the edge attribute to split on is considered datetime in format dd/mm/yyyy",
+    )
+
+    parser.add_argument(
+        "--hin",
+        dest="hin",
+        action="store_true",
+        help="If specified, it indicates that the input graph in a heterogenous network; otherwise, the input graph is assumed homogeneous",
+    )
+
+    parser.add_argument(
+        "--input_graph",
+        nargs="?",
+        default="~/Projects/data/cora/cora.epgm/",
+        help="Input graph filename",
+    )
+
+    parser.add_argument(
+        "--output_node_features",
+        nargs="?",
+        default="~/Projects/data/cora/cora.features/cora.emb",
+        help="Input graph filename",
+    )
+
+    parser.add_argument(
+        "--sampling_method",
+        nargs="?",
+        default="global",
+        help="Negative edge sampling method: local or global",
+    )
+
+    parser.add_argument(
+        "--sampling_probs",
+        nargs="?",
+        default="0.0, 0.25, 0.50, 0.25",
+        help="Negative edge sample probabilities (for local sampling method) with respect to distance from starting node",
+    )
+
+    parser.add_argument(
+        "--show_hist",
+        dest="show_histograms",
+        action="store_true",
+        help="If specified, a histogram of the distances between source and target nodes for \
+                         negative edge samples will be plotted.",
+    )
+
+    parser.add_argument(
+        "--subsample",
+        dest="subsample_graph",
+        action="store_true",
+        help="If specified, then the original graph is randomly subsampled to 10% of the original size, \
+                        with respect to the number of nodes",
+    )
+
+    return parser.parse_args()


### PR DESCRIPTION
This PR restores the random walk link prediction demo script that was (accidentally) removed for #889 - this script does more than the CORA notebook demo (eg `BlogCatalog3` heterogeneous demo).

Future work for a better notebook in #934. 