### PR TITLE
Use path: . instead of url/sha256 to define conda package

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -1,16 +1,9 @@
-# yamllint disable-file
-# This file is not valid YAML because of the jinja templating
-
-{% set name = "stellargraph" %}
-{% set version = "0.9.0" %}
-
 package:
-  name: "{{ name|lower }}"
-  version: "{{ version }}"
+  name: "stellargraph"
+  version: "0.10.0b"
 
 source:
-  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
-  sha256: caecc5eab0e8dcd0949435446573bfb019dd73c80df6cfedadce69e6664fb50c
+  path: .
 
 build:
   noarch: python

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,3 +1,4 @@
+---
 package:
   name: "stellargraph"
   version: "0.10.0b"
@@ -9,7 +10,7 @@ build:
   noarch: python
   number: 0
   script: "{{ PYTHON }} -m pip install . -vv"
-  skip: True # [py<36]
+  skip: true # [py<36]
 
 requirements:
   host:


### PR DESCRIPTION
Using `path: .` makes it easy to build a package from the current state of the source tree, without having to first upload to PyPI, and then pull out the URL and sha256 hash of the uploaded package. As a test, `conda build .` is successful with this change.

This does rely on the tree being the appropriate version to be published, but this should be true for someone following the release procedure.

See: #742