### PR TITLE
moved the GraphWave "args" doc into the main class docstring

### DIFF
--- a/stellargraph/mapper/graphwave_generator.py
+++ b/stellargraph/mapper/graphwave_generator.py
@@ -29,7 +29,7 @@ from ..core.experimental import experimental
 class GraphWaveGenerator:
     """
     Implementation of the GraphWave structural embedding algorithm from the paper:
-        "Learning Structural Node Embeddings via Diffusion Wavelets" (https://arxiv.org/pdf/1710.10321.pdf)
+    "Learning Structural Node Embeddings via Diffusion Wavelets" (https://arxiv.org/pdf/1710.10321.pdf)
 
     This class is minimally with a StellarGraph object. Calling the flow function will return a tensorflow
     DataSet that contains the GraphWave embeddings.

--- a/stellargraph/mapper/graphwave_generator.py
+++ b/stellargraph/mapper/graphwave_generator.py
@@ -37,15 +37,14 @@ class GraphWaveGenerator:
     This implementation differs from the paper by removing the automatic method of calculating scales. This method was
     found to not work well in practice, and replicating the results of the paper requires manually specifying much larger
     scales than those automatically calculated.
+
+    Args:
+        G (StellarGraph): the StellarGraph object.
+        scales (iterable of floats): the wavelet scales to use. Smaller values embed smaller scale structural
+            features, and larger values embed larger structural features.
     """
 
     def __init__(self, G, scales=(5, 10)):
-        """
-        Args:
-            G (StellarGraph): the StellarGraph object.
-            scales (iterable of floats): the wavelet scales to use. Smaller values embed smaller scale structural
-                features, and larger values embed larger structural features.
-        """
 
         if not isinstance(G, StellarGraph):
             raise TypeError("G must be a StellarGraph object.")


### PR DESCRIPTION
This PR fixes the `GraphWave` docstring issue in #942 