### PR TITLE
update docker-compose plugin to v3.2.0

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -20,7 +20,7 @@ steps:
     key: "runner-3_6"
     plugins:
       <<: *plugins
-      docker-compose#v3.1.0:
+      docker-compose#v3.2.0:
         <<: *compose-config
         build: runner-3_6
         image-repository: index.docker.io/stellargraph/stellargraph-ci-runner
@@ -39,7 +39,7 @@ steps:
     key: "runner-3_7"
     plugins:
       <<: *plugins
-      docker-compose#v3.1.0:
+      docker-compose#v3.2.0:
         <<: *compose-config
         build: runner-3_7
         image-repository: index.docker.io/stellargraph/stellargraph-ci-runner
@@ -60,7 +60,7 @@ steps:
     command: ".buildkite/steps/script.sh"
     plugins:
       <<: *plugins
-      docker-compose#v3.1.0:
+      docker-compose#v3.2.0:
         <<: *compose-config
         run: runner-3_6
     agents:
@@ -73,7 +73,7 @@ steps:
     command: ".buildkite/steps/script.sh"
     plugins:
       <<: *plugins
-      docker-compose#v3.1.0:
+      docker-compose#v3.2.0:
         <<: *compose-config
         run: runner-3_7
     agents:
@@ -87,7 +87,7 @@ steps:
     command: ".buildkite/steps/test-demo-notebooks.sh"
     plugins:
       <<: *plugins
-      docker-compose#v3.1.0:
+      docker-compose#v3.2.0:
         <<: *compose-config
         run: runner-3_6
     agents:
@@ -108,7 +108,7 @@ steps:
     command: "python scripts/format_notebooks.py --default --ci demos/"
     plugins:
       <<: *plugins
-      docker-compose#v3.1.0:
+      docker-compose#v3.2.0:
         <<: *compose-config
         run: runner-3_6
     agents:
@@ -177,7 +177,7 @@ steps:
     <<: *timeout
     plugins:
       <<: *plugins
-      docker-compose#v3.1.0:
+      docker-compose#v3.2.0:
         <<: *compose-config
         build:
           - stellargraph
@@ -198,7 +198,7 @@ steps:
     <<: *timeout
     plugins:
       <<: *plugins
-      docker-compose#v3.1.0:
+      docker-compose#v3.2.0:
         <<: *compose-config
         push:
           - stellargraph:index.docker.io/stellargraph/stellargraph:${IMAGE_TAG}


### PR DESCRIPTION
PR updates the Buildkite's docker-compose plugin to [v3.2.0](https://github.com/buildkite-plugins/docker-compose-buildkite-plugin/releases/tag/v3.2.0)