### PR TITLE
Use `if ...: raise ...` for input validation, not `assert`

### DIFF
--- a/stellargraph/layer/graph_attention.py
+++ b/stellargraph/layer/graph_attention.py
@@ -857,9 +857,9 @@ class GAT:
         Returns: Output tensor of the GAT layers stack
 
         """
-        assert isinstance(inputs, list), "input must be a list, got {} instead".format(
-            type(inputs)
-        )
+        if not isinstance(inputs, list):
+            raise TypeError(f"inputs: expected list, found {type(inputs).__name__}")
+
         x_in, out_indices, *As = inputs
 
         # Currently we require the batch dimension to be one for full-batch methods


### PR DESCRIPTION
`assert`s in Python can disappear, if `-O` is specified. This means that they should be used for optional internal consistency checks, rather than input validation that must happen.

Code Climate flags asserts for this reason, [including this instance](https://codeclimate.com/github/stellargraph/stellargraph/stellargraph/layer/graph_attention.py/source#issue-340917ec283449fd7ae831f96b47c067) of input validation.

Related to #954.