### PR TITLE
Disable the method-lines length check on Code Climate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -14,7 +14,7 @@ checks:
   method-count:
     enabled: false
 
-  method-length:
+  method-lines:
     enabled: false
 
   similar-code:

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -14,6 +14,9 @@ checks:
   method-count:
     enabled: false
 
+  method-length:
+    enabled: false
+
   similar-code:
     enabled: false
 


### PR DESCRIPTION
For the moment, we don't care about long methods, so reducing the noise from this check by turning it off is better than continuing to manually ignore it.

This silences 2 issues on Code Climate.

See: #954