### PR TITLE
Disable some SonarPython checks on Code Climate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -25,7 +25,18 @@ plugins:
     enabled: false
 
   sonar-python:
-    enabled: false
+    enabled: true
+    checks:
+      # number of function parameters
+      python:S107:
+        enabled: false
+      # cognitive complexity
+      python:S3776:
+        enabled: false
+      # FIXME comments
+      python:S1134:
+        enabled: false
+
 
 exclude_patterns:
   # default exclude patterns:

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -37,7 +37,6 @@ plugins:
       python:S1134:
         enabled: false
 
-
 exclude_patterns:
   # default exclude patterns:
   - "config/"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -25,7 +25,7 @@ plugins:
     enabled: false
 
   sonar-python:
-    enabled: true
+    enabled: false
 
 exclude_patterns:
   # default exclude patterns:


### PR DESCRIPTION
This disables three SonarPython checks to reduce noise and make it more likely that the things it flags are useful/relevant. The checks disabled are:

- number of parameters in a function: we generally allow many parameters, because we often have many with defaults
- cognitive complexity: these are, arguably, not actually a useful measure (see also #595)
- FIXME comments: we have `# FIXME(#someissue)` comments recording future work by connecting to our issue tracker

This silences 39 issues (out of 145 total, and 72 from SonarPython specifically) on Code Climate.

See: #954