### PR TITLE
Clear session after reproducibility test

### DIFF
--- a/tests/reproducibility/fixtures.py
+++ b/tests/reproducibility/fixtures.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import numpy as np
+import tensorflow as tf
 
 
 def models_equals(model1, model2):
@@ -39,3 +40,6 @@ def assert_reproducible(func, num_iter=20):
             model.get_weights(),
             model_new.get_weights(),
         )
+
+    # clear the tensorflow session to free memory
+    tf.keras.backend.clear_session()


### PR DESCRIPTION
Took inspiration from this issue: https://github.com/tensorflow/tensorflow/issues/14181

I logged the memory usage after each test using `resource.getrusage(resource.RUSAGE_SELF).ru_maxrss` and collected them into a list

## memory usage before
[648810496, 968466432, 1147457536, 1334071296]

## memory usage after
[647651328, 678608896, 717193216, 719740928]
