### PR TITLE
Truncate info() to the 20 most common node and edge types by default

### DIFF
--- a/demos/node-classification/rgcn/rgcn-aifb-node-classification-example.ipynb
+++ b/demos/node-classification/rgcn/rgcn-aifb-node-classification-example.ipynb
@@ -85,6 +85,52 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "StellarDiGraph: Directed multigraph\n",
+      " Nodes: 8285, Edges: 29043\n",
+      "\n",
+      " Node types:\n",
+      "  default: [8285]\n",
+      "    Features: float32 vector, length 8285\n",
+      "    Edge types: default-http://swrc.ontoware.org/ontology#abstract->default, default-http://swrc.ontoware.org/ontology#address->default, default-http://swrc.ontoware.org/ontology#author->default, default-http://swrc.ontoware.org/ontology#booktitle->default, default-http://swrc.ontoware.org/ontology#carriedOutBy->default, ... (40 more)\n",
+      "\n",
+      " Edge types:\n",
+      "    default-http://swrc.ontoware.org/ontology#publication->default: [4163]\n",
+      "    default-http://www.w3.org/1999/02/22-rdf-syntax-ns#type->default: [4124]\n",
+      "    default-http://swrc.ontoware.org/ontology#author->default: [3986]\n",
+      "    default-http://swrc.ontoware.org/ontology#isAbout->default: [2477]\n",
+      "    default-http://swrc.ontoware.org/ontology#name->default: [1302]\n",
+      "    default-http://swrc.ontoware.org/ontology#year->default: [1227]\n",
+      "    default-http://swrc.ontoware.org/ontology#title->default: [1227]\n",
+      "    default-http://swrc.ontoware.org/ontology#publishes->default: [1217]\n",
+      "    default-http://swrc.ontoware.org/ontology#projectInfo->default: [952]\n",
+      "    default-http://swrc.ontoware.org/ontology#hasProject->default: [952]\n",
+      "    default-http://swrc.ontoware.org/ontology#booktitle->default: [765]\n",
+      "    default-http://swrc.ontoware.org/ontology#month->default: [759]\n",
+      "    default-http://swrc.ontoware.org/ontology#isWorkedOnBy->default: [571]\n",
+      "    default-http://swrc.ontoware.org/ontology#pages->default: [548]\n",
+      "    default-http://swrc.ontoware.org/ontology#abstract->default: [534]\n",
+      "    default-http://swrc.ontoware.org/ontology#dealtWithIn->default: [357]\n",
+      "    default-http://swrc.ontoware.org/ontology#member->default: [339]\n",
+      "    default-http://swrc.ontoware.org/ontology#volume->default: [311]\n",
+      "    default-http://swrc.ontoware.org/ontology#series->default: [298]\n",
+      "    default-http://swrc.ontoware.org/ontology#homepage->default: [239]\n",
+      "    ... (25 more)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(G.info())"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -102,7 +148,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -113,7 +159,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -136,7 +182,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -152,7 +198,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -168,7 +214,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -224,7 +270,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -253,7 +299,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -287,7 +333,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -302,7 +348,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -323,7 +369,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {

--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -32,7 +32,7 @@ from .schema import GraphSchema, EdgeType
 from .experimental import experimental, ExperimentalWarning
 from .element_data import NodeData, EdgeData, ExternalIdIndex
 from .utils import is_real_iterable
-from .validation import comma_sep
+from .validation import comma_sep, separated
 from . import convert
 
 
@@ -779,7 +779,7 @@ class StellarGraph:
 
         return zip(*unique_ets)
 
-    def info(self, show_attributes=True, sample=None):
+    def info(self, show_attributes=True, sample=None, truncate=20):
         """
         Return an information string summarizing information on the current graph.
         This includes node and edge type information and their attributes.
@@ -791,50 +791,83 @@ class StellarGraph:
             show_attributes (bool, default True): If True, include attributes information
             sample (int): To speed up the graph analysis, use only a random sample of
                           this many nodes and edges.
-
+            truncate (int, optional): If an integer, show only the ``truncate`` most common node and
+                edge type triples; if ``None``, list each one individually.
         Returns:
             An information string.
         """
-        directed_str = "Directed" if self.is_directed() else "Undirected"
-        lines = [
-            f"{type(self).__name__}: {directed_str} multigraph",
-            f" Nodes: {self.number_of_nodes()}, Edges: {self.number_of_edges()}",
-        ]
+        # always truncate the edge types listed for each node type, since they're redundant with the
+        # individual listing of edge types, and make for a single very long line
+        truncate_edge_types_per_node = 5
+        if truncate is not None:
+            truncate_edge_types_per_node = min(truncate_edge_types_per_node, truncate)
 
         # Numpy processing is much faster than NetworkX processing, so we don't bother sampling.
         gs = self.create_graph_schema()
+
+        feature_info = self._nodes.feature_info()
 
         def str_edge_type(et):
             n1, rel, n2 = et
             return f"{n1}-{rel}->{n2}"
 
-        lines.append("")
-        lines.append(" Node types:")
-
-        feature_info = self._nodes.feature_info()
-        for nt in gs.node_types:
-            nodes = self.nodes_of_type(nt)
-            lines.append(f"  {nt}: [{len(nodes)}]")
-
+        def str_node_type(count, nt):
             feature_size, feature_dtype = feature_info[nt]
             if feature_size > 0:
                 feature_text = f"{feature_dtype.name} vector, length {feature_size}"
             else:
                 feature_text = "none"
-            lines.append(f"    Features: {feature_text}")
 
-            edge_types = ", ".join(str_edge_type(et) for et in gs.schema[nt])
-            lines.append(f"    Edge types: {edge_types}")
+            edge_types = comma_sep(
+                [str_edge_type(et) for et in gs.schema[nt]],
+                limit=truncate_edge_types_per_node,
+                stringify=str,
+            )
+            return f"{nt}: [{count}]\n    Features: {feature_text}\n    Edge types: {edge_types}"
+
+        # sort the node types in decreasing order of frequency
+        node_types = sorted(
+            ((len(self.nodes_of_type(nt)), nt) for nt in gs.node_types), reverse=True
+        )
+        nodes = separated(
+            [str_node_type(count, nt) for count, nt in node_types],
+            limit=truncate,
+            stringify=str,
+            sep="\n  ",
+        )
+
+        # FIXME: it would be better for the schema to just include the counts directly
+        unique_ets = self._unique_type_triples(return_counts=True)
+        edge_types = sorted(
+            (
+                (count, EdgeType(src_ty, rel_ty, tgt_ty))
+                for src_ty, rel_ty, tgt_ty, count in unique_ets
+            ),
+            reverse=True,
+        )
+
+        edges = separated(
+            [f"{str_edge_type(et)}: [{count}]" for count, et in edge_types],
+            limit=truncate,
+            stringify=str,
+            sep="\n    ",
+        )
+
+        directed_str = "Directed" if self.is_directed() else "Undirected"
+        lines = [
+            f"{type(self).__name__}: {directed_str} multigraph",
+            f" Nodes: {self.number_of_nodes()}, Edges: {self.number_of_edges()}",
+            "",
+            " Node types:",
+        ]
+        if nodes:
+            lines.append("  " + nodes)
 
         lines.append("")
         lines.append(" Edge types:")
 
-        # FIXME: it would be better for the schema to just include the counts directly
-        for src_ty, rel_ty, tgt_ty, count in self._unique_type_triples(
-            return_counts=True
-        ):
-            et = EdgeType(src_ty, rel_ty, tgt_ty)
-            lines.append(f"    {str_edge_type(et)}: [{count}]")
+        if edges:
+            lines.append("    " + edges)
 
         return "\n".join(lines)
 

--- a/stellargraph/core/validation.py
+++ b/stellargraph/core/validation.py
@@ -16,6 +16,27 @@
 import numpy as np
 
 
+def separated(values, *, limit, stringify, sep):
+    """
+    Print up to ``limit`` values with a separator.
+
+    Args:
+        values (list): the values to print
+        limit (optional, int): the maximum number of values to print (None for no limit)
+        stringify (callable): a function to use to convert values to strings
+        sep (str): the separator to use between elements (and the "... (NNN more)" continuation)
+    """
+    count = len(values)
+    if limit is not None and count > limit:
+        values = values[:limit]
+        continuation = f"{sep}... ({count - limit} more)" if count > limit else ""
+    else:
+        continuation = ""
+
+    rendered = sep.join(stringify(x) for x in values)
+    return rendered + continuation
+
+
 def comma_sep(values, limit=20, stringify=repr):
     """
     Print up to ``limit`` values, comma separated.
@@ -25,15 +46,7 @@ def comma_sep(values, limit=20, stringify=repr):
         limit (optional, int): the maximum number of values to print (None for no limit)
         stringify (callable): a function to use to convert values to strings
     """
-    count = len(values)
-    if limit is not None and count > limit:
-        values = values[:limit]
-        continuation = f", ... ({count - limit} more)" if count > limit else ""
-    else:
-        continuation = ""
-
-    rendered = ", ".join(stringify(x) for x in values)
-    return rendered + continuation
+    return separated(values, limit=limit, stringify=stringify, sep=", ")
 
 
 def require_dataframe_has_columns(name, df, columns):

--- a/tests/core/test_graph.py
+++ b/tests/core/test_graph.py
@@ -764,6 +764,14 @@ def test_isolated_node_neighbor_methods(is_directed):
     assert graph.out_nodes(1) == []
 
 
+def in_sequence(s, *others):
+    for x in others:
+        assert x in s
+
+    for a, b in zip(others, others[1:]):
+        assert s.index(a) < s.index(b), s
+
+
 @pytest.mark.parametrize("is_directed", [False, True])
 def test_info_homogeneous(is_directed):
 
@@ -799,6 +807,74 @@ def test_info_heterogeneous():
 
     assert " A-R->B: [5]"
     assert " B-F->B: [1]"
+
+
+def test_info_truncate():
+    max_node_type = 22
+    max_node = (max_node_type + 1) * (max_node_type + 1) - 1
+
+    def edges(i):
+        ids = range(i * i, (i + 1) * (i + 1))
+        return pd.DataFrame(
+            {"source": max_node - i, "target": max_node - i - 1}, index=ids
+        )
+
+    graph = StellarGraph(
+        {
+            f"n_{i}": pd.DataFrame(index=range(i * i, (i + 1) * (i + 1)))
+            for i in range(max_node_type + 1)
+        },
+        {f"e_{i}": edges(i) for i in range(45)},
+    )
+
+    in_sequence(
+        graph.info(),
+        "\n Node types:",
+        "\n  n_22: [45]",
+        "\n    Edge types: n_22-e_0->n_22, n_22-e_1->n_22, n_22-e_10->n_22, n_22-e_11->n_22, n_22-e_12->n_22, ... (40 more)",
+        "\n  n_21: [43]",
+        "\n    Edge types: n_21-e_44->n_22\n",
+        "\n  n_20: [41]",
+        "\n  n_3: [7]",
+        "\n  ... (3 more)",
+        "\n Edge types:",
+        "\n    n_22-e_44->n_21: [89]",
+        "\n    n_22-e_43->n_22: [87]",
+        "\n    n_22-e_42->n_22: [85]",
+        "\n    n_22-e_25->n_22: [51]",
+        "\n    ... (25 more)",
+    )
+
+    in_sequence(
+        graph.info(truncate=2),
+        "\n Node types:",
+        "\n  n_22: [45]",
+        "\n    Edge types: n_22-e_0->n_22, n_22-e_1->n_22, ... (43 more)",
+        "\n  n_21: [43]",
+        "\n    Edge types: n_21-e_44->n_22\n",
+        "\n  ... (21 more)",
+        "\n Edge types:",
+        "\n    n_22-e_44->n_21: [89]",
+        "\n    n_22-e_43->n_22: [87]",
+        "\n    ... (43 more)",
+    )
+
+    in_sequence(
+        graph.info(truncate=None),
+        "\n Node types:",
+        "\n  n_22: [45]",
+        # individual listing is still truncated
+        "\n    Edge types: n_22-e_0->n_22, n_22-e_1->n_22, n_22-e_10->n_22, n_22-e_11->n_22, n_22-e_12->n_22, ... (40 more)",
+        "\n  n_21: [43]",
+        "\n  n_20: [41]",
+        "\n  n_1: [3]",
+        "\n  n_0: [1]",
+        "\n Edge types:",
+        "\n    n_22-e_44->n_21: [89]",
+        "\n    n_22-e_43->n_22: [87]",
+        "\n    n_22-e_1->n_22: [3]",
+        "\n    n_22-e_0->n_22: [1]",
+    )
 
 
 def test_edges_include_weights():


### PR DESCRIPTION
Knowledge graphs can end up with hundreds or thousands of types (e.g. FB15k has 1237 edge types), and `.info()` is not useful in these cases, because it ends up with long lines and a very long list of possibilities.

This patch changes `info` to truncate at 20 node types and 20 edge types by default (arbitrarily configurable), as well as truncating the per-node-type listing of edge types at most 5 (non-configurable).

It then uses this new functionality in the RGCN notebook, which uses the AIFB dataset where the graph has 45 edge types.

See: #984