### PR TITLE
replaced importation of ABCs from collections to collection.abc

### DIFF
--- a/stellargraph/core/utils.py
+++ b/stellargraph/core/utils.py
@@ -31,7 +31,7 @@ def is_real_iterable(x):
     Returns:
         True if x is an iterable (but not a string) and False otherwise
     """
-    return isinstance(x, collections.Iterable) and not isinstance(x, (str, bytes))
+    return isinstance(x, collections.abc.Iterable) and not isinstance(x, (str, bytes))
 
 
 def normalize_adj(adj, symmetric=True):

--- a/stellargraph/mapper/sampled_link_generators.py
+++ b/stellargraph/mapper/sampled_link_generators.py
@@ -122,7 +122,7 @@ class BatchedLinkGenerator(abc.ABC):
             return OnDemandLinkSequence(self.sample_features, self.batch_size, link_ids)
 
         # Otherwise pass iterable (check?) to standard LinkSequence
-        elif isinstance(link_ids, collections.Iterable):
+        elif isinstance(link_ids, collections.abc.Iterable):
             # Check all IDs are actually in the graph and are of expected type
             for link in link_ids:
                 if len(link) != 2:

--- a/stellargraph/mapper/sequences.py
+++ b/stellargraph/mapper/sequences.py
@@ -83,7 +83,7 @@ class NodeSequence(Sequence):
             self.targets = None
 
         # Store the generator to draw samples from graph
-        if isinstance(sample_function, collections.Callable):
+        if isinstance(sample_function, collections.abc.Callable):
             self._sample_function = sample_function
         else:
             raise TypeError(
@@ -187,7 +187,7 @@ class LinkSequence(Sequence):
             raise ValueError("Length of link ids must match length of link targets")
 
         # Store the generator to draw samples from graph
-        if isinstance(sample_function, collections.Callable):
+        if isinstance(sample_function, collections.abc.Callable):
             self._sample_features = sample_function
         else:
             raise TypeError(
@@ -266,7 +266,7 @@ class OnDemandLinkSequence(Sequence):
 
     def __init__(self, sample_function, batch_size, walker, shuffle=True):
         # Store the generator to draw samples from graph
-        if isinstance(sample_function, collections.Callable):
+        if isinstance(sample_function, collections.abc.Callable):
             self._sample_features = sample_function
         else:
             raise TypeError(


### PR DESCRIPTION
This PR fixes our import of `collections` `ABC` classes to be imported from `collections.abc` not `collections.` removing the deprecation warnings. See #951 