### PR TITLE
Remove legacy construction from graphs.py (and thus other files)

### DIFF
--- a/tests/layer/test_appnp.py
+++ b/tests/layer/test_appnp.py
@@ -29,16 +29,6 @@ from ..test_utils.graphs import create_graph_features
 
 def test_APPNP_edge_cases():
     G, features = create_graph_features()
-    adj = nx.to_scipy_sparse_matrix(G)
-    features, adj = GCN_Aadj_feats_op(features, adj)
-    adj = np.array(adj.todense()[None, :, :])
-    n_nodes = features.shape[0]
-
-    nodes = G.nodes()
-    node_features = pd.DataFrame.from_dict(
-        {n: f for n, f in zip(nodes, features)}, orient="index"
-    )
-    G = StellarGraph(G, node_features=node_features)
 
     generator = FullBatchNodeGenerator(G, sparse=False, method="gcn")
 
@@ -102,16 +92,9 @@ def test_APPNP_edge_cases():
 
 def test_APPNP_apply_dense():
     G, features = create_graph_features()
-    adj = nx.to_scipy_sparse_matrix(G)
+    adj = G.to_adjacency_matrix()
     features, adj = GCN_Aadj_feats_op(features, adj)
     adj = np.array(adj.todense()[None, :, :])
-    n_nodes = features.shape[0]
-
-    nodes = G.nodes()
-    node_features = pd.DataFrame.from_dict(
-        {n: f for n, f in zip(nodes, features)}, orient="index"
-    )
-    G = StellarGraph(G, node_features=node_features)
 
     generator = FullBatchNodeGenerator(G, sparse=False, method="gcn")
     appnpModel = APPNP([2], generator=generator, activations=["relu"], dropout=0.5)
@@ -134,17 +117,11 @@ def test_APPNP_apply_dense():
 def test_APPNP_apply_sparse():
 
     G, features = create_graph_features()
-    adj = nx.to_scipy_sparse_matrix(G)
+    adj = G.to_adjacency_matrix()
     features, adj = GCN_Aadj_feats_op(features, adj)
     adj = adj.tocoo()
     A_indices = np.expand_dims(np.hstack((adj.row[:, None], adj.col[:, None])), 0)
     A_values = np.expand_dims(adj.data, 0)
-
-    nodes = G.nodes()
-    node_features = pd.DataFrame.from_dict(
-        {n: f for n, f in zip(nodes, features)}, orient="index"
-    )
-    G = StellarGraph(G, node_features=node_features)
 
     generator = FullBatchNodeGenerator(G, sparse=True, method="gcn")
     appnpnModel = APPNP([2], generator=generator, activations=["relu"], dropout=0.5)
@@ -166,14 +143,8 @@ def test_APPNP_apply_sparse():
 
 def test_APPNP_linkmodel_apply_dense():
     G, features = create_graph_features()
-    adj = nx.to_numpy_array(G)[None, :, :]
-    n_nodes = features.shape[0]
-
-    nodes = G.nodes()
-    node_features = pd.DataFrame.from_dict(
-        {n: f for n, f in zip(nodes, features)}, orient="index"
-    )
-    G = StellarGraph(G, node_features=node_features)
+    adj = G.to_adjacency_matrix()
+    adj = np.array(adj.todense()[None, :, :])
 
     generator = FullBatchLinkGenerator(G, sparse=False, method="none")
     appnpnModel = APPNP([3], generator, activations=["relu"], dropout=0.5)
@@ -196,17 +167,11 @@ def test_APPNP_linkmodel_apply_dense():
 def test_APPNP_linkmodel_apply_sparse():
 
     G, features = create_graph_features()
-    adj = nx.to_scipy_sparse_matrix(G)
+    adj = G.to_adjacency_matrix()
     features, adj = GCN_Aadj_feats_op(features, adj)
     adj = adj.tocoo()
     A_indices = np.expand_dims(np.hstack((adj.row[:, None], adj.col[:, None])), 0)
     A_values = np.expand_dims(adj.data, 0)
-
-    nodes = G.nodes()
-    node_features = pd.DataFrame.from_dict(
-        {n: f for n, f in zip(nodes, features)}, orient="index"
-    )
-    G = StellarGraph(G, node_features=node_features)
 
     generator = FullBatchLinkGenerator(G, sparse=True, method="gcn")
     appnpnModel = APPNP(
@@ -230,16 +195,9 @@ def test_APPNP_linkmodel_apply_sparse():
 
 def test_APPNP_apply_propagate_model_dense():
     G, features = create_graph_features()
-    adj = nx.to_scipy_sparse_matrix(G)
+    adj = G.to_adjacency_matrix()
     features, adj = GCN_Aadj_feats_op(features, adj)
     adj = np.array(adj.todense()[None, :, :])
-    n_nodes = features.shape[0]
-
-    nodes = G.nodes()
-    node_features = pd.DataFrame.from_dict(
-        {n: f for n, f in zip(nodes, features)}, orient="index"
-    )
-    G = StellarGraph(G, node_features=node_features)
 
     generator = FullBatchNodeGenerator(G, sparse=False, method="gcn")
     appnpnModel = APPNP([2], generator=generator, activations=["relu"], dropout=0.5)
@@ -265,17 +223,11 @@ def test_APPNP_apply_propagate_model_dense():
 def test_APPNP_apply_propagate_model_sparse():
 
     G, features = create_graph_features()
-    adj = nx.to_scipy_sparse_matrix(G)
+    adj = G.to_adjacency_matrix()
     features, adj = GCN_Aadj_feats_op(features, adj)
     adj = adj.tocoo()
     A_indices = np.expand_dims(np.hstack((adj.row[:, None], adj.col[:, None])), 0)
     A_values = np.expand_dims(adj.data, 0)
-
-    nodes = G.nodes()
-    node_features = pd.DataFrame.from_dict(
-        {n: f for n, f in zip(nodes, features)}, orient="index"
-    )
-    G = StellarGraph(G, node_features=node_features)
 
     generator = FullBatchNodeGenerator(G, sparse=True, method="gcn")
     appnpnModel = APPNP([2], generator=generator, activations=["relu"], dropout=0.5)

--- a/tests/layer/test_cluster_gcn.py
+++ b/tests/layer/test_cluster_gcn.py
@@ -29,7 +29,7 @@ import pandas as pd
 import numpy as np
 from tensorflow import keras
 import pytest
-from ..test_utils.graphs import create_graph_features, create_stellargraph
+from ..test_utils.graphs import create_graph_features
 
 
 def test_ClusterGraphConvolution_config():
@@ -117,7 +117,7 @@ def test_ClusterGCN_init():
 
 def test_ClusterGCN_apply():
 
-    G = create_stellargraph()
+    G, _ = create_graph_features()
 
     generator = ClusterNodeGenerator(G)
 
@@ -135,7 +135,7 @@ def test_ClusterGCN_apply():
 
 def test_ClusterGCN_activations():
 
-    G = create_stellargraph()
+    G, _ = create_graph_features()
     generator = ClusterNodeGenerator(G)
 
     # Test activations are set correctly
@@ -170,7 +170,7 @@ def test_ClusterGCN_activations():
 
 
 def test_ClusterGCN_regularisers():
-    G = create_stellargraph()
+    G, _ = create_graph_features()
 
     generator = ClusterNodeGenerator(G)
 

--- a/tests/layer/test_cluster_gcn.py
+++ b/tests/layer/test_cluster_gcn.py
@@ -24,7 +24,6 @@ from stellargraph.layer.cluster_gcn import *
 from stellargraph.mapper import ClusterNodeGenerator
 from stellargraph.core.graph import StellarGraph
 
-import networkx as nx
 import pandas as pd
 import numpy as np
 from tensorflow import keras
@@ -64,7 +63,7 @@ def test_GraphConvolution():
     output_indices_t = Input(batch_shape=(1, None), dtype="int32", name="outind")
 
     # Note we add a batch dimension of 1 to model inputs
-    adj = nx.to_numpy_array(G)[None, :, :]
+    adj = G.to_adjacency_matrix().toarray()[None, :, :]
     out_indices = np.array([[0, 1]], dtype="int32")
     x = features[None, :, :]
 
@@ -99,11 +98,6 @@ def test_GraphConvolution():
 
 def test_ClusterGCN_init():
     G, features = create_graph_features()
-    nodes = G.nodes()
-    node_features = pd.DataFrame.from_dict(
-        {n: f for n, f in zip(nodes, features)}, orient="index"
-    )
-    G = StellarGraph(G, node_type_name="node", node_features=node_features)
 
     generator = ClusterNodeGenerator(G)
     cluster_gcn_model = ClusterGCN(

--- a/tests/layer/test_gcn.py
+++ b/tests/layer/test_gcn.py
@@ -65,7 +65,7 @@ def test_GraphConvolution_dense():
     output_indices_t = Input(batch_shape=(1, None), dtype="int32", name="outind")
 
     # Note we add a batch dimension of 1 to model inputs
-    adj = nx.to_numpy_array(G)[None, :, :]
+    adj = G.to_adjacency_matrix().toarray()[None, :, :]
     out_indices = np.array([[0, 1]], dtype="int32")
     x = features[None, :, :]
 
@@ -109,7 +109,7 @@ def test_GraphConvolution_sparse():
     out = GraphConvolution(2, final_layer=False)([x_t, output_indices_t, A_mat])
 
     # Note we add a batch dimension of 1 to model inputs
-    adj = nx.to_scipy_sparse_matrix(G, format="coo")
+    adj = G.to_adjacency_matrix().tocoo()
     A_indices = np.expand_dims(np.hstack((adj.row[:, None], adj.col[:, None])), 0)
     A_values = np.expand_dims(adj.data, 0)
     out_indices = np.array([[0, 1]], dtype="int32")
@@ -127,12 +127,7 @@ def test_GraphConvolution_sparse():
 
 
 def test_GCN_init():
-    G, features = create_graph_features()
-    nodes = G.nodes()
-    node_features = pd.DataFrame.from_dict(
-        {n: f for n, f in zip(nodes, features)}, orient="index"
-    )
-    G = StellarGraph(G, node_type_name="node", node_features=node_features)
+    G, _ = create_graph_features()
 
     generator = FullBatchNodeGenerator(G)
     gcnModel = GCN([2], generator, activations=["relu"], dropout=0.5)
@@ -144,14 +139,8 @@ def test_GCN_init():
 
 def test_GCN_apply_dense():
     G, features = create_graph_features()
-    adj = nx.to_numpy_array(G)[None, :, :]
+    adj = G.to_adjacency_matrix().toarray()[None, :, :]
     n_nodes = features.shape[0]
-
-    nodes = G.nodes()
-    node_features = pd.DataFrame.from_dict(
-        {n: f for n, f in zip(nodes, features)}, orient="index"
-    )
-    G = StellarGraph(G, node_features=node_features)
 
     generator = FullBatchNodeGenerator(G, sparse=False, method="none")
     gcnModel = GCN([2], generator, activations=["relu"], dropout=0.5)
@@ -174,17 +163,11 @@ def test_GCN_apply_dense():
 def test_GCN_apply_sparse():
 
     G, features = create_graph_features()
-    adj = nx.to_scipy_sparse_matrix(G)
+    adj = G.to_adjacency_matrix()
     features, adj = GCN_Aadj_feats_op(features, adj)
     adj = adj.tocoo()
     A_indices = np.expand_dims(np.hstack((adj.row[:, None], adj.col[:, None])), 0)
     A_values = np.expand_dims(adj.data, 0)
-
-    nodes = G.nodes()
-    node_features = pd.DataFrame.from_dict(
-        {n: f for n, f in zip(nodes, features)}, orient="index"
-    )
-    G = StellarGraph(G, node_features=node_features)
 
     generator = FullBatchNodeGenerator(G, sparse=True, method="gcn")
     gcnModel = GCN(
@@ -208,14 +191,8 @@ def test_GCN_apply_sparse():
 
 def test_GCN_linkmodel_apply_dense():
     G, features = create_graph_features()
-    adj = nx.to_numpy_array(G)[None, :, :]
+    adj = G.to_adjacency_matrix().toarray()[None, :, :]
     n_nodes = features.shape[0]
-
-    nodes = G.nodes()
-    node_features = pd.DataFrame.from_dict(
-        {n: f for n, f in zip(nodes, features)}, orient="index"
-    )
-    G = StellarGraph(G, node_features=node_features)
 
     generator = FullBatchLinkGenerator(G, sparse=False, method="none")
     gcnModel = GCN([3], generator, activations=["relu"], dropout=0.5)
@@ -238,17 +215,11 @@ def test_GCN_linkmodel_apply_dense():
 def test_GCN_linkmodel_apply_sparse():
 
     G, features = create_graph_features()
-    adj = nx.to_scipy_sparse_matrix(G)
+    adj = G.to_adjacency_matrix()
     features, adj = GCN_Aadj_feats_op(features, adj)
     adj = adj.tocoo()
     A_indices = np.expand_dims(np.hstack((adj.row[:, None], adj.col[:, None])), 0)
     A_values = np.expand_dims(adj.data, 0)
-
-    nodes = G.nodes()
-    node_features = pd.DataFrame.from_dict(
-        {n: f for n, f in zip(nodes, features)}, orient="index"
-    )
-    G = StellarGraph(G, node_features=node_features)
 
     generator = FullBatchLinkGenerator(G, sparse=True, method="gcn")
     gcnModel = GCN(
@@ -272,14 +243,8 @@ def test_GCN_linkmodel_apply_sparse():
 
 def test_GCN_activations():
     G, features = create_graph_features()
-    adj = nx.to_numpy_array(G)[None, :, :]
+    adj = G.to_adjacency_matrix().toarray()[None, :, :]
     n_nodes = features.shape[0]
-
-    nodes = G.nodes()
-    node_features = pd.DataFrame.from_dict(
-        {n: f for n, f in zip(nodes, features)}, orient="index"
-    )
-    G = StellarGraph(G, node_features=node_features)
 
     generator = FullBatchNodeGenerator(G, sparse=False, method="none")
 
@@ -307,14 +272,8 @@ def test_GCN_activations():
 
 def test_GCN_regularisers():
     G, features = create_graph_features()
-    adj = nx.to_numpy_array(G)[None, :, :]
+    adj = G.to_adjacency_matrix().toarray()[None, :, :]
     n_nodes = features.shape[0]
-
-    nodes = G.nodes()
-    node_features = pd.DataFrame.from_dict(
-        {n: f for n, f in zip(nodes, features)}, orient="index"
-    )
-    G = StellarGraph(G, node_features=node_features)
 
     generator = FullBatchNodeGenerator(G, sparse=False, method="none")
 

--- a/tests/layer/test_ppnp.py
+++ b/tests/layer/test_ppnp.py
@@ -29,14 +29,8 @@ from ..test_utils.graphs import create_graph_features
 
 def test_PPNP_edge_cases():
     G, features = create_graph_features()
-    adj = nx.to_scipy_sparse_matrix(G)
+    adj = G.to_adjacency_matrix()
     features, adj = PPNP_Aadj_feats_op(features, adj)
-
-    nodes = G.nodes()
-    node_features = pd.DataFrame.from_dict(
-        {n: f for n, f in zip(nodes, features)}, orient="index"
-    )
-    G = StellarGraph(G, node_features=node_features)
 
     ppnp_sparse_failed = False
     try:
@@ -62,15 +56,9 @@ def test_PPNP_edge_cases():
 
 def test_PPNP_apply_dense():
     G, features = create_graph_features()
-    adj = nx.to_scipy_sparse_matrix(G)
+    adj = G.to_adjacency_matrix()
     features, adj = PPNP_Aadj_feats_op(features, adj)
     adj = adj[None, :, :]
-
-    nodes = G.nodes()
-    node_features = pd.DataFrame.from_dict(
-        {n: f for n, f in zip(nodes, features)}, orient="index"
-    )
-    G = StellarGraph(G, node_features=node_features)
 
     generator = FullBatchNodeGenerator(G, sparse=False, method="ppnp")
     ppnpModel = PPNP([2], generator=generator, activations=["relu"], dropout=0.5)

--- a/tests/mapper/test_node_mappers.py
+++ b/tests/mapper/test_node_mappers.py
@@ -808,7 +808,7 @@ class Test_FullBatchNodeGenerator:
             generator.flow(node_ids, node_targets)
 
     def test_fullbatch_generator_init_1(self):
-        G, _ = create_graph_features()
+        G, feats = create_graph_features()
         generator = FullBatchNodeGenerator(G, method=None)
         assert np.array_equal(feats, generator.features)
 

--- a/tests/mapper/test_node_mappers.py
+++ b/tests/mapper/test_node_mappers.py
@@ -808,36 +808,19 @@ class Test_FullBatchNodeGenerator:
             generator.flow(node_ids, node_targets)
 
     def test_fullbatch_generator_init_1(self):
-        G, feats = create_graph_features()
-        nodes = G.nodes()
-        node_features = pd.DataFrame.from_dict(
-            {n: f for n, f in zip(nodes, feats)}, orient="index"
-        )
-        G = StellarGraph(G, node_type_name="node", node_features=node_features)
-
+        G, _ = create_graph_features()
         generator = FullBatchNodeGenerator(G, method=None)
         assert np.array_equal(feats, generator.features)
 
     def test_fullbatch_generator_init_3(self):
-        G, feats = create_graph_features()
-        nodes = G.nodes()
-        node_features = pd.DataFrame.from_dict(
-            {n: f for n, f in zip(nodes, feats)}, orient="index"
-        )
-        G = StellarGraph(G, node_type_name="node", node_features=node_features)
-
+        G, _ = create_graph_features()
         func = "Not callable"
 
         with pytest.raises(ValueError):
             generator = FullBatchNodeGenerator(G, "test", transform=func)
 
     def test_fullbatch_generator_transform(self):
-        G, feats = create_graph_features()
-        nodes = G.nodes()
-        node_features = pd.DataFrame.from_dict(
-            {n: f for n, f in zip(nodes, feats)}, orient="index"
-        )
-        G = StellarGraph(G, node_type_name="node", node_features=node_features)
+        G, _ = create_graph_features()
 
         def func(features, A, **kwargs):
             return features, A.dot(A)

--- a/tests/test_utils/graphs.py
+++ b/tests/test_utils/graphs.py
@@ -25,29 +25,24 @@ import pytest
 
 def create_graph_features():
     # APPNP, ClusterGCN, GCN, PPNP, node_mappers
-    graph = nx.Graph()
-    graph.add_nodes_from(["a", "b", "c"])
-    graph.add_edges_from([("a", "b"), ("b", "c"), ("a", "c")])
-    graph = graph.to_undirected()
-    return graph, np.array([[1, 1], [1, 0], [0, 1]])
+    features = np.array([[1, 1], [1, 0], [0, 1]])
+    nodes = pd.DataFrame(features, index=["a", "b", "c"])
+    edges = pd.DataFrame([("a", "b"), ("b", "c"), ("a", "c")], columns=["source", "target"])
+    return StellarGraph(nodes, edges), features
 
 
 def relational_create_graph_features(is_directed=False):
     # RGCN, relational node mappers
     r1 = {"label": "r1"}
     r2 = {"label": "r2"}
-    nodes = ["a", "b", "c"]
     features = np.array([[1, 1], [1, 0], [0, 1]])
-    node_features = pd.DataFrame.from_dict(
-        {n: f for n, f in zip(nodes, features)}, orient="index"
-    )
-
-    graph = nx.MultiDiGraph() if is_directed else nx.MultiGraph()
-    graph.add_nodes_from(nodes)
-    graph.add_edges_from([("a", "b", r1), ("b", "c", r1), ("a", "c", r2)])
-
+    nodes = pd.DataFrame(features, index=["a", "b", "c"])
+    edges = {
+        "r1": pd.DataFrame([("a", "b"), ("b", "c")], columns=["source", "target"]),
+        "r2": pd.DataFrame([("a", "c")], columns=["source", "target"], index=[2])
+    }
     SG = StellarDiGraph if is_directed else StellarGraph
-    return SG(graph, node_features=node_features), features
+    return SG(nodes, edges), features
 
 
 def example_graph_nx(
@@ -149,10 +144,12 @@ def example_hin_1(
     return cls(nodes={"A": a, "B": b}, edges={"R": r, "F": f})
 
 
-def create_test_graph_nx(is_directed=False):
-    # unsupervised sampler
-    graph = nx.DiGraph() if is_directed else nx.Graph()
-    edges = [
+def create_test_graph(is_directed=False):
+    # biased random walker, breadth first walker, directed breadth first walker, uniform random walker
+
+    nodes = pd.DataFrame(index=["0", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, "self loner", "loner"])
+    edges = pd.DataFrame(
+        [
         ("0", 1),
         ("0", 2),
         (1, 3),
@@ -174,49 +171,26 @@ def create_test_graph_nx(is_directed=False):
         (5, 5),
         (9, 9),
         ("self loner", "self loner"),  # an isolated node with a self link
-    ]
-
-    graph.add_edges_from(edges)
-
-    graph.add_node("loner")  # an isolated node without self link
-    return graph
-
-
-def create_test_graph(is_directed=False):
-    # biased random walker, breadth first walker, directed breadth first walker, uniform random walker
-    if is_directed:
-        return StellarDiGraph(create_test_graph_nx(is_directed))
-    else:
-        return StellarGraph(create_test_graph_nx(is_directed))
-
-
-def create_stellargraph():
-    # cluster gcn, cluster gcn node mapper
-    Gnx, features = create_graph_features()
-    nodes = Gnx.nodes()
-    node_features = pd.DataFrame.from_dict(
-        {n: f for n, f in zip(nodes, features)}, orient="index"
+        ],
+        columns=["source", "target"]
     )
-    graph = StellarGraph(Gnx, node_features=node_features)
-
-    return graph
+    cls = StellarDiGraph  if is_directed else StellarGraph
+    return cls(nodes, edges)
 
 
 def example_graph_1_saliency_maps(feature_size=None):
     # saliency gcn, saliency gat
-    graph = nx.Graph()
-    elist = [(0, 1), (0, 2), (2, 3), (3, 4), (0, 0), (1, 1), (2, 2), (3, 3), (4, 4)]
-    graph.add_nodes_from([0, 1, 2, 3, 4], label="default")
-    graph.add_edges_from(elist, label="default")
-
-    # Add example features
-    if feature_size is not None:
-        for v in graph.nodes():
-            graph.nodes[v]["feature"] = np.ones(feature_size)
-        return StellarGraph(graph, node_features="feature")
-
+    nlist = [0, 1, 2, 3, 4]
+    if feature_size is None:
+        nodes = pd.DataFrame(index=nlist)
     else:
-        return StellarGraph(graph)
+        # Example features
+        nodes = pd.DataFrame(np.ones((len(nlist), feature_size)), index=nlist)
+
+    elist = [(0, 1), (0, 2), (2, 3), (3, 4), (0, 0), (1, 1), (2, 2), (3, 3), (4, 4)]
+    edges = pd.DataFrame(elist, columns=["source", "target"])
+
+    return StellarGraph(nodes, edges)
 
 
 def example_graph_random(
@@ -225,27 +199,24 @@ def example_graph_random(
     # core/utils, link mapper, node mapper graph 3
 
     if is_directed:
-        graph = nx.DiGraph()
         cls = StellarDiGraph
     else:
-        graph = nx.Graph()
         cls = StellarGraph
 
+    node_ids = range(n_nodes)
+    if feature_size is None:
+        nodes = pd.DataFrame(index=node_ids)
+    else:
+        # Example features
+        nodes = pd.DataFrame(np.ones((len(node_ids), feature_size)), index=node_ids)
+
     n_noniso = n_nodes - n_isolates
-    edges = [
+    elist = [
         (random.randint(0, n_noniso - 1), random.randint(0, n_noniso - 1))
         for _ in range(n_edges)
     ]
-    graph.add_nodes_from(range(n_nodes))
-    graph.add_edges_from(edges, label="default")
-
-    # Add example features
-    if feature_size is not None:
-        for v in graph.nodes():
-            graph.nodes[v]["feature"] = int(v) * np.ones(feature_size, dtype="int")
-        return cls(graph, node_features="feature")
-    else:
-        return cls(graph)
+    edges = pd.DataFrame(elist, columns=["source", "target"])
+    return cls(nodes, edges)
 
 
 def node_features(seed=0) -> pd.DataFrame:
@@ -257,15 +228,14 @@ def node_features(seed=0) -> pd.DataFrame:
 @pytest.fixture
 def petersen_graph() -> StellarGraph:
     nxg = nx.petersen_graph()
-    return StellarGraph(nxg, node_features=node_features())
+    return StellarGraph.from_networkx(nxg, node_features=node_features())
 
 
 @pytest.fixture
 def line_graph() -> StellarGraph:
-    nxg = nx.MultiGraph()
-    nxg.add_nodes_from(range(10))
-    nxg.add_edges_from([(i, i + 1) for i in range(9)])
-    return StellarGraph(nxg, node_features=node_features())
+    nodes = node_features()
+    edges = pd.DataFrame([(i, i + 1) for i in range(9)], columns=["source", "target"])
+    return StellarGraph(nodes, edges)
 
 
 @pytest.fixture

--- a/tests/test_utils/graphs.py
+++ b/tests/test_utils/graphs.py
@@ -27,7 +27,9 @@ def create_graph_features():
     # APPNP, ClusterGCN, GCN, PPNP, node_mappers
     features = np.array([[1, 1], [1, 0], [0, 1]])
     nodes = pd.DataFrame(features, index=["a", "b", "c"])
-    edges = pd.DataFrame([("a", "b"), ("b", "c"), ("a", "c")], columns=["source", "target"])
+    edges = pd.DataFrame(
+        [("a", "b"), ("b", "c"), ("a", "c")], columns=["source", "target"]
+    )
     return StellarGraph(nodes, edges), features
 
 
@@ -39,7 +41,7 @@ def relational_create_graph_features(is_directed=False):
     nodes = pd.DataFrame(features, index=["a", "b", "c"])
     edges = {
         "r1": pd.DataFrame([("a", "b"), ("b", "c")], columns=["source", "target"]),
-        "r2": pd.DataFrame([("a", "c")], columns=["source", "target"], index=[2])
+        "r2": pd.DataFrame([("a", "c")], columns=["source", "target"], index=[2]),
     }
     SG = StellarDiGraph if is_directed else StellarGraph
     return SG(nodes, edges), features
@@ -147,34 +149,36 @@ def example_hin_1(
 def create_test_graph(is_directed=False):
     # biased random walker, breadth first walker, directed breadth first walker, uniform random walker
 
-    nodes = pd.DataFrame(index=["0", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, "self loner", "loner"])
+    nodes = pd.DataFrame(
+        index=["0", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, "self loner", "loner"]
+    )
     edges = pd.DataFrame(
         [
-        ("0", 1),
-        ("0", 2),
-        (1, 3),
-        (1, 4),
-        (3, 6),
-        (4, 7),
-        (4, 8),
-        (2, 5),
-        (5, 9),
-        (5, 10),
-        ("0", "0"),
-        (1, 1),
-        (3, 3),
-        (6, 6),
-        (4, 4),
-        (7, 7),
-        (8, 8),
-        (2, 2),
-        (5, 5),
-        (9, 9),
-        ("self loner", "self loner"),  # an isolated node with a self link
+            ("0", 1),
+            ("0", 2),
+            (1, 3),
+            (1, 4),
+            (3, 6),
+            (4, 7),
+            (4, 8),
+            (2, 5),
+            (5, 9),
+            (5, 10),
+            ("0", "0"),
+            (1, 1),
+            (3, 3),
+            (6, 6),
+            (4, 4),
+            (7, 7),
+            (8, 8),
+            (2, 2),
+            (5, 5),
+            (9, 9),
+            ("self loner", "self loner"),  # an isolated node with a self link
         ],
-        columns=["source", "target"]
+        columns=["source", "target"],
     )
-    cls = StellarDiGraph  if is_directed else StellarGraph
+    cls = StellarDiGraph if is_directed else StellarGraph
     return cls(nodes, edges)
 
 


### PR DESCRIPTION
This switches away from NetworkX to the new StellarGraph in the `tests/test_utils/graphs.py` file as much as possible, which includes updating some other files (for `create_graph_features` changing to return a `StellarGraph` instance).

See: #717