### PR TITLE
Remove legacy construction from tests/data files

### DIFF
--- a/tests/data/test_biased_random_walker.py
+++ b/tests/data/test_biased_random_walker.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import numpy as np
+import pandas as pd
 import pytest
 import networkx as nx
 from stellargraph.data.explorer import BiasedRandomWalk
@@ -29,38 +30,46 @@ def create_test_weighted_graph(is_multigraph=False):
 
     :return: .
     """
-    g = nx.MultiGraph() if is_multigraph else nx.Graph()
-    edges = [
-        ("0", 1, 3),
-        ("0", 2, 4),
-        (1, 3, 1),
-        (1, 4, 7),
-        (3, 6, 9),
-        (4, 7, 2),
-        (4, 8, 5),
-        (2, 5, 7),
-        (5, 9, 5),
-        (5, 10, 6),
-        ("0", "0", 7),
-        (1, 1, 8),
-        (3, 3, 8),
-        (6, 6, 9),
-        (4, 4, 1),
-        (7, 7, 2),
-        (8, 8, 3),
-        (2, 2, 4),
-        (5, 5, 5),
-        (9, 9, 6),
-        ("self loner", "self loner", 0),  # an isolated node with a self link
-    ]
+    nodes = pd.DataFrame(
+        index=["0", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, "self loner", "loner"]
+    )
+    edges = pd.DataFrame(
+        [
+            ("0", 1, 3),
+            ("0", 2, 4),
+            (1, 3, 1),
+            (1, 4, 7),
+            (3, 6, 9),
+            (4, 7, 2),
+            (4, 8, 5),
+            (2, 5, 7),
+            (5, 9, 5),
+            (5, 10, 6),
+            ("0", "0", 7),
+            (1, 1, 8),
+            (3, 3, 8),
+            (6, 6, 9),
+            (4, 4, 1),
+            (7, 7, 2),
+            (8, 8, 3),
+            (2, 2, 4),
+            (5, 5, 5),
+            (9, 9, 6),
+            ("self loner", "self loner", 0),  # an isolated node with a self link
+        ],
+        columns=["source", "target", "weight"],
+    )
 
-    g.add_weighted_edges_from(edges)
+    return StellarGraph(nodes, edges)
 
-    g.add_node("loner")  # an isolated node without self link
 
-    g = StellarGraph(g)
-
-    return g
+def weighted(a, b, c, d):
+    nodes = pd.DataFrame(index=[1, 2, 3, 4])
+    edges = pd.DataFrame(
+        [(1, 2, a), (2, 3, b), (3, 4, c), (4, 1, d)],
+        columns=["source", "target", "weight"],
+    )
+    return StellarGraph(nodes, edges)
 
 
 class TestBiasedWeightedRandomWalk(object):
@@ -84,11 +93,7 @@ class TestBiasedWeightedRandomWalk(object):
     def test_identity_unweighted_weighted_1_walks(self):
 
         # graph with all edge weights = 1
-        g = nx.Graph()
-        edges = [(1, 2, 1), (2, 3, 1), (3, 4, 1), (4, 1, 1)]
-        g.add_weighted_edges_from(edges)
-        g = StellarGraph(g)
-
+        g = weighted(1, 1, 1, 1)
         nodes = g.nodes()
         n = 4
         length = 4
@@ -106,11 +111,7 @@ class TestBiasedWeightedRandomWalk(object):
     def test_weighted_walks(self):
 
         # all positive walks
-        g = nx.Graph()
-        edges = [(1, 2, 1), (2, 3, 2), (3, 4, 3), (4, 1, 4)]
-
-        g.add_weighted_edges_from(edges)
-        g = StellarGraph(g)
+        g = weighted(1, 2, 3, 4)
 
         nodes = list(g.nodes())
         n = 1
@@ -130,11 +131,7 @@ class TestBiasedWeightedRandomWalk(object):
         )
 
         # negative edge
-        g = nx.Graph()
-        edges = [(1, 2, 1), (2, 3, -2), (3, 4, 3), (4, 1, 4)]
-
-        g.add_weighted_edges_from(edges)
-        g = StellarGraph(g)
+        g = weighted(1, -2, 3, 4)
 
         biasedrw = BiasedRandomWalk(g)
 
@@ -144,11 +141,7 @@ class TestBiasedWeightedRandomWalk(object):
             )
 
         # edge with weight infinity
-        g = nx.Graph()
-        edges = [(1, 2, 1), (2, 3, np.inf), (3, 4, 3), (4, 1, 4)]
-
-        g.add_weighted_edges_from(edges)
-        g = StellarGraph(g)
+        g = weighted(1, np.inf, 3, 4)
 
         biasedrw = BiasedRandomWalk(g)
 
@@ -443,13 +436,16 @@ class TestBiasedRandomWalk(object):
                 assert node == "self loner"  # all nodes should be the same node
 
     def test_walk_biases(self):
-        graph = nx.Graph()
         # a square with a triangle:
         #   0-3
         #  /| |
         # 1-2-4
-        graph.add_edges_from([(0, 1), (0, 2), (0, 3), (1, 2), (2, 4), (3, 4)])
-        graph = StellarGraph(graph)
+        nodes = pd.DataFrame(index=range(5))
+        edges = pd.DataFrame(
+            [(0, 1), (0, 2), (0, 3), (1, 2), (2, 4), (3, 4)],
+            columns=["source", "target"],
+        )
+        graph = StellarGraph(nodes, edges)
         biasedrw = BiasedRandomWalk(graph)
 
         # there's 18 total walks of length 4 starting at 0 in `graph`,

--- a/tests/data/test_breadth_first_walker.py
+++ b/tests/data/test_breadth_first_walker.py
@@ -14,11 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pandas as pd
 import pytest
-import networkx as nx
 from stellargraph.data.explorer import SampledBreadthFirstWalk
 from stellargraph.core.graph import StellarDiGraph
-from ..test_utils.graphs import create_test_graph
+from ..test_utils.graphs import create_test_graph, tree_graph
 
 
 def expected_bfw_size(n_size):
@@ -165,20 +165,7 @@ class TestBreadthFirstWalk(object):
             assert len(subgraph) == expected_bfw_size(n_size)
             assert subgraph[0] == "loner"
 
-    def test_directed_walk_generation_single_root_node(self):
-
-        g = nx.DiGraph()
-        edges = [
-            ("root", 2),
-            ("root", 1),
-            ("root", "0"),
-            (2, "c2.1"),
-            (2, "c2.2"),
-            (1, "c1.1"),
-        ]
-        g.add_edges_from(edges)
-        g = StellarDiGraph(g)
-
+    def test_directed_walk_generation_single_root_node(self, tree_graph):
         def _check_directed_walk(walk, n_size):
             if len(n_size) > 1 and n_size[0] > 0 and n_size[1] > 0:
                 for child_pos in range(n_size[0]):
@@ -201,7 +188,7 @@ class TestBreadthFirstWalk(object):
                     else:
                         assert 1 == 0
 
-        bfw = SampledBreadthFirstWalk(g)
+        bfw = SampledBreadthFirstWalk(tree_graph)
 
         nodes = ["root"]
         n = 1

--- a/tests/data/test_directed_breadth_first_sampler.py
+++ b/tests/data/test_directed_breadth_first_sampler.py
@@ -16,30 +16,9 @@
 
 import random
 import pytest
-import networkx as nx
 from stellargraph.data.explorer import DirectedBreadthFirstNeighbours
 from stellargraph.core.graph import StellarDiGraph
-from ..test_utils.graphs import create_test_graph
-
-
-def create_simple_graph():
-    """
-    Creates a simple directed graph for testing. The node ids are string or integers.
-
-    :return: A small, directed graph with 4 nodes and 6 edges in StellarDiGraph format.
-    """
-
-    g = nx.DiGraph()
-    edges = [
-        ("root", 2),
-        ("root", 1),
-        ("root", "0"),
-        (2, "c2.1"),
-        (2, "c2.2"),
-        (1, "c1.1"),
-    ]
-    g.add_edges_from(edges)
-    return StellarDiGraph(g)
+from ..test_utils.graphs import create_test_graph, tree_graph
 
 
 class TestDirectedBreadthFirstNeighbours(object):
@@ -122,9 +101,8 @@ class TestDirectedBreadthFirstNeighbours(object):
         subgraph = bfw.run(nodes=nodes, n=n, in_size=in_size, out_size=out_size)
         assert len(subgraph) == 0
 
-    def test_zero_hops(self):
-        g = create_simple_graph()
-        bfw = DirectedBreadthFirstNeighbours(g)
+    def test_zero_hops(self, tree_graph):
+        bfw = DirectedBreadthFirstNeighbours(tree_graph)
         # By consensus, a zero-length walk raises an error.
         with pytest.raises(ValueError):
             subgraph = bfw.run(nodes=["root"], n=1, in_size=[], out_size=[])
@@ -132,9 +110,8 @@ class TestDirectedBreadthFirstNeighbours(object):
         # assert len(subgraph) == 1
         # assert len(subgraph[0]) == 1
 
-    def test_one_hop(self):
-        g = create_simple_graph()
-        bfw = DirectedBreadthFirstNeighbours(g)
+    def test_one_hop(self, tree_graph):
+        bfw = DirectedBreadthFirstNeighbours(tree_graph)
         # - The following case should be [[["root"], [None], [child]]]
         subgraph = bfw.run(nodes=["root"], n=1, in_size=[1], out_size=[1])
         assert len(subgraph) == 1
@@ -166,9 +143,8 @@ class TestDirectedBreadthFirstNeighbours(object):
         for child in subgraph[0][2]:
             assert child in ["0", 1, 2]
 
-    def test_two_hops(self):
-        g = create_simple_graph()
-        bfw = DirectedBreadthFirstNeighbours(g)
+    def test_two_hops(self, tree_graph):
+        bfw = DirectedBreadthFirstNeighbours(tree_graph)
         # - The following case should be [[["root"], [None], [child*2], [None], [None*2], ["root"*2], [grandchild*4]]]
         in_size = [1, 1]
         out_size = [2, 2]
@@ -204,7 +180,7 @@ class TestDirectedBreadthFirstNeighbours(object):
                     assert grandchild in ["c2.1", "c2.2"]
         # - Check structure size for multiple start nodes
         # - For each start node, should be [[[node], [in], [out], [in.in], [in.out], [out.in], [out.out]]]
-        nodes = list(g.nodes())
+        nodes = list(tree_graph.nodes())
         in_size = [2, 3]
         out_size = [4, 5]
         subgraph = bfw.run(nodes=nodes, n=1, in_size=in_size, out_size=out_size)

--- a/tests/data/test_metapath_walker.py
+++ b/tests/data/test_metapath_walker.py
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pandas as pd
 import pytest
-import networkx as nx
 from stellargraph.data.explorer import UniformRandomMetaPathWalk
 from stellargraph.core.graph import StellarGraph
 
@@ -32,47 +32,41 @@ def create_test_graph():
         networkx format.
 
     """
-    g = nx.Graph()
-    edges = [
-        ("0", 1),
-        ("0", 2),
-        (1, 3),
-        (1, 4),
-        (3, 6),
-        (4, "7"),
-        (4, 8),
-        (2, "5"),
-        ("5", 9),
-        ("5", 10),
-        ("0", "0"),
-        (1, 1),
-        (3, 3),
-        (6, 6),
-        (4, 4),
-        ("7", "7"),
-        (8, 8),
-        (2, 2),
-        ("5", "5"),
-        (9, 9),
-        (
-            "self loner",
-            "self loner",
-        ),  # node that is not connected with any other nodes but has self loop
-    ]
+    nodes = {
+        "s": pd.DataFrame(index=["0", "5", "7", "self loner", "loner"]),
+        "n": pd.DataFrame(index=[1, 2, 3, 4, 6, 8, 9, 10]),
+    }
+    edges = pd.DataFrame(
+        [
+            ("0", 1),
+            ("0", 2),
+            (1, 3),
+            (1, 4),
+            (3, 6),
+            (4, "7"),
+            (4, 8),
+            (2, "5"),
+            ("5", 9),
+            ("5", 10),
+            ("0", "0"),
+            (1, 1),
+            (3, 3),
+            (6, 6),
+            (4, 4),
+            ("7", "7"),
+            (8, 8),
+            (2, 2),
+            ("5", "5"),
+            (9, 9),
+            (
+                "self loner",
+                "self loner",
+            ),  # node that is not connected with any other nodes but has self loop
+        ],
+        columns=["source", "target"],
+    )
 
-    g.add_edges_from(edges)
-    g.add_node(
-        "loner"
-    )  # node that is not connected to any other nodes and not having a self loop
-
-    for node in g.nodes():
-        if type(node) == str:  # make these type s for string
-            g.nodes[node]["label"] = "s"
-        else:  # make these type n for number
-            g.nodes[node]["label"] = "n"
-
-    g = StellarGraph(g)
-    return g
+    return StellarGraph(nodes, edges)
 
 
 class TestMetaPathWalk(object):

--- a/tests/test_utils/graphs.py
+++ b/tests/test_utils/graphs.py
@@ -289,3 +289,21 @@ def knowledge_graph():
     }
 
     return StellarDiGraph(nodes=pd.DataFrame(index=nodes), edges=edges)
+
+
+@pytest.fixture
+def tree_graph() -> StellarGraph:
+    nodes = pd.DataFrame(index=["root", "0", 1, 2, "c1.1", "c2.1", "c2.2"])
+    edges = pd.DataFrame(
+        [
+            ("root", 2),
+            ("root", 1),
+            ("root", "0"),
+            (2, "c2.1"),
+            (2, "c2.2"),
+            (1, "c1.1"),
+        ],
+        columns=["source", "target"],
+    )
+
+    return StellarDiGraph(nodes, edges)


### PR DESCRIPTION
This switches away from the legacy `StellarGraph` constructor, and NetworkX itself, to use the new StellarGraph in the `tests/data/...` files as much as possible. This includes some instances of switching to a shared graph from `tests/test_utils/graphs.py` rather than each file creating its own.

See: #717