### PR TITLE
Remove legacy construction from remaining test files

### DIFF
--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -245,6 +245,8 @@ class StellarGraph:
                     "graph: expected no value when using 'nodes' and 'edges' parameters, found: {graph!r}"
                 )
 
+            raise ValueError("legacy constructor not allowed")
+
             nodes, edges = convert.from_networkx(
                 graph,
                 node_type_attr=node_type_name,

--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -245,8 +245,6 @@ class StellarGraph:
                     "graph: expected no value when using 'nodes' and 'edges' parameters, found: {graph!r}"
                 )
 
-            raise ValueError("legacy constructor not allowed")
-
             nodes, edges = convert.from_networkx(
                 graph,
                 node_type_attr=node_type_name,

--- a/tests/mapper/test_directed_node_generator.py
+++ b/tests/mapper/test_directed_node_generator.py
@@ -29,13 +29,9 @@ def create_simple_graph():
         A small, directed graph with 3 nodes and 2 edges in StellarDiGraph format.
     """
 
-    g = nx.DiGraph()
-    edges = [(1, 2), (2, 3)]
-    g.add_edges_from(edges)
-    nodes = list(g.nodes())
-    features = [(node, -1.0 * node) for node in nodes]
-    df = pd.DataFrame(features, columns=["id", "f0"]).set_index("id")
-    return StellarDiGraph(g, node_features=df)
+    nodes = pd.DataFrame([-1, -2, -3], index=[1, 2, 3])
+    edges = pd.DataFrame([(1, 2), (2, 3)], columns=["source", "target"])
+    return StellarDiGraph(nodes, edges)
 
 
 class TestDirectedNodeGenerator(object):

--- a/tests/mapper/test_node_mappers.py
+++ b/tests/mapper/test_node_mappers.py
@@ -53,58 +53,56 @@ def example_graph_2(feature_size=None):
 
 
 def example_hin_2(feature_size_by_type=None):
+    if feature_size_by_type is None:
+        feature_size_by_type = {"t1": None, "t2": None}
+
     nodes_type_1 = [0, 1, 2, 3]
     nodes_type_2 = [4, 5]
+    nodes = {
+        "t1": pd.DataFrame(
+            repeated_features(nodes_type_1, feature_size_by_type["t1"]),
+            index=nodes_type_1,
+        ),
+        "t2": pd.DataFrame(
+            repeated_features(nodes_type_2, feature_size_by_type["t2"]),
+            index=nodes_type_2,
+        ),
+    }
+    edges = {
+        "e1": pd.DataFrame(
+            [(0, 4), (1, 4), (2, 5), (3, 5)], columns=["source", "target"]
+        )
+    }
 
-    # Create isolated graphs
-    G = nx.Graph()
-    G.add_nodes_from(nodes_type_1, label="t1")
-    G.add_nodes_from(nodes_type_2, label="t2")
-    G.add_edges_from([(0, 4), (1, 4), (2, 5), (3, 5)], label="e1")
-
-    # Add example features
-    if feature_size_by_type is not None:
-        for v, vdata in G.nodes(data=True):
-            nt = vdata["label"]
-            vdata["feature"] = int(v) * np.ones(feature_size_by_type[nt], dtype="int")
-
-        G = StellarGraph(G, node_features="feature")
-
-    else:
-        G = StellarGraph(G)
-
-    return G, nodes_type_1, nodes_type_2
+    return StellarGraph(nodes, edges), nodes_type_1, nodes_type_2
 
 
 def example_hin_3(feature_size_by_type=None):
-    nodes_type_1 = [0, 1, 2]
-    nodes_type_2 = [4, 5, 6]
+    if feature_size_by_type is None:
+        feature_size_by_type = {"t1": None, "t2": None}
 
-    # Create isolated graphs
-    G = nx.Graph()
-    G.add_nodes_from(nodes_type_1, label="t1")
-    G.add_nodes_from(nodes_type_2, label="t2")
-    G.add_edges_from([(0, 4), (1, 5)], label="e1")
-    G.add_edges_from([(0, 2)], label="e2")
+    nodes_type_1 = np.array([0, 1, 2])
+    nodes_type_2 = np.array([4, 5, 6])
+    nodes = {
+        "t1": pd.DataFrame(
+            repeated_features(10 + nodes_type_1, feature_size_by_type["t1"]),
+            index=nodes_type_1,
+        ),
+        "t2": pd.DataFrame(
+            repeated_features(10 + nodes_type_2, feature_size_by_type["t2"]),
+            index=nodes_type_2,
+        ),
+    }
+    edges = {
+        "e1": pd.DataFrame([(0, 4), (1, 5)], columns=["source", "target"]),
+        "e2": pd.DataFrame([(0, 2)], columns=["source", "target"], index=[2]),
+    }
 
     # Node 2 has no edges of type 1
     # Node 1 has no edges of type 2
     # Node 6 has no edges
 
-    # Add example features
-    if feature_size_by_type is not None:
-        for v, vdata in G.nodes(data=True):
-            nt = vdata["label"]
-            vdata["feature"] = (int(v) + 10) * np.ones(
-                feature_size_by_type[nt], dtype="int"
-            )
-
-        G = StellarGraph(G, node_features="feature")
-
-    else:
-        G = StellarGraph(G)
-
-    return G, nodes_type_1, nodes_type_2
+    return StellarGraph(nodes, edges), nodes_type_1, nodes_type_2
 
 
 def test_nodemapper_constructor_nx():

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 import pytest
-import networkx as nx
 import numpy as np
 import tensorflow as tf
 from stellargraph import StellarGraph
@@ -43,19 +42,18 @@ from tensorflow.keras.losses import categorical_crossentropy, binary_crossentrop
 
 # FIXME (#535): Consider using graph fixtures
 def example_graph_1(feature_size=None):
-    G = nx.Graph()
-    elist = [(1, 2), (2, 3), (1, 4), (3, 2), (5, 6), (1, 5)]
-    G.add_nodes_from([1, 2, 3, 4, 5, 6], label="default")
-    G.add_edges_from(elist, label="default")
-
-    # Add example features
+    nlist = [1, 2, 3, 4, 5, 6]
     if feature_size is not None:
-        for v in G.nodes():
-            G.nodes[v]["feature"] = np.ones(feature_size)
-        return StellarGraph(G, node_features="feature")
-
+        features = np.ones((len(nlist), feature_size))
     else:
-        return StellarGraph(G)
+        features = []
+
+    elist = [(1, 2), (2, 3), (1, 4), (3, 2), (5, 6), (1, 5)]
+
+    return StellarGraph(
+        pd.DataFrame(features, index=nlist),
+        pd.DataFrame(elist, columns=["source", "target"]),
+    )
 
 
 def create_graphSAGE_model(graph, link_prediction=False):

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pandas as pd
 import pytest
 import numpy as np
 import tensorflow as tf


### PR DESCRIPTION
Three test files still had some legacy constructor invocations:

- `tests/test_ensemble.py`
- `tests/mapper/test_directed_node_generator.py`
- `tests/mapper/test_node_mappers.py`

The latter two were apparently missed in #1000.

This is verified as the last legacy constructor calls in tests by adding a `throw ValueError()` to the legacy constructor, and running it on CI at https://buildkite.com/stellar/stellargraph-public/builds/1987: the tests all pass, meaning that code path isn't taken (something that the coverage report on codecov is picking up on: that line is no longer covered). Some notebooks still fail, meaning they still need to be updated. That work is still tracked at #717.

See: #717