### PR TITLE
Use from_networkx rather than legacy construction in demos

### DIFF
--- a/demos/community_detection/attacks_clustering_analysis.ipynb
+++ b/demos/community_detection/attacks_clustering_analysis.ipynb
@@ -1315,7 +1315,7 @@
     }
    ],
    "source": [
-    "Gs = sg.StellarGraph(G, node_features=node_features)\n",
+    "Gs = sg.StellarGraph.from_networkx(G, node_features=node_features)\n",
     "print(Gs.info())"
    ]
   },

--- a/demos/embeddings/graphwave-barbell.ipynb
+++ b/demos/embeddings/graphwave-barbell.ipynb
@@ -96,7 +96,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "G = StellarGraph(gnx)\n",
+    "G = StellarGraph.from_networkx(gnx)\n",
     "sample_points = np.linspace(0, 100, 50).astype(np.float32)\n",
     "degree = 20\n",
     "scales = [5, 10]\n",

--- a/demos/ensembles/ensemble-link-prediction-example.ipynb
+++ b/demos/ensembles/ensemble-link-prediction-example.ipynb
@@ -295,9 +295,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "G_train = sg.StellarGraph(G_train, node_features=\"feature\")\n",
-    "G_test = sg.StellarGraph(G_test, node_features=\"feature\")\n",
-    "G_val = sg.StellarGraph(G_val, node_features=\"feature\")"
+    "G_train = sg.StellarGraph.from_networkx(G_train, node_features=\"feature\")\n",
+    "G_test = sg.StellarGraph.from_networkx(G_test, node_features=\"feature\")\n",
+    "G_val = sg.StellarGraph.from_networkx(G_val, node_features=\"feature\")"
    ]
   },
   {

--- a/demos/interpretability/gcn/hateful-twitters-interpretability.ipynb
+++ b/demos/interpretability/gcn/hateful-twitters-interpretability.ipynb
@@ -806,7 +806,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "G = sg.StellarGraph(g_nx, node_features=node_features)"
+    "G = sg.StellarGraph.from_networkx(g_nx, node_features=node_features)"
    ]
   },
   {

--- a/demos/link-prediction/attri2vec/stellargraph-attri2vec-DBLP.ipynb
+++ b/demos/link-prediction/attri2vec/stellargraph-attri2vec-DBLP.ipynb
@@ -195,7 +195,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "G_all = sg.StellarGraph(G_all_nx, node_features=all_node_features)"
+    "G_all = sg.StellarGraph.from_networkx(G_all_nx, node_features=all_node_features)"
    ]
   },
   {
@@ -337,7 +337,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "G_sub = sg.StellarGraph(G_sub_nx, node_features=subgraph_node_features)"
+    "G_sub = sg.StellarGraph.from_networkx(G_sub_nx, node_features=subgraph_node_features)"
    ]
   },
   {

--- a/demos/link-prediction/gcn/cora-gcn-links-example.ipynb
+++ b/demos/link-prediction/gcn/cora-gcn-links-example.ipynb
@@ -278,8 +278,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "G_train = sg.StellarGraph(G_train, node_features=\"feature\")\n",
-    "G_test = sg.StellarGraph(G_test, node_features=\"feature\")"
+    "G_train = sg.StellarGraph.from_networkx(G_train, node_features=\"feature\")\n",
+    "G_test = sg.StellarGraph.from_networkx(G_test, node_features=\"feature\")"
    ]
   },
   {

--- a/demos/link-prediction/graphsage/cora-links-example.ipynb
+++ b/demos/link-prediction/graphsage/cora-links-example.ipynb
@@ -277,8 +277,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "G_train = sg.StellarGraph(G_train, node_features=\"feature\")\n",
-    "G_test = sg.StellarGraph(G_test, node_features=\"feature\")"
+    "G_train = sg.StellarGraph.from_networkx(G_train, node_features=\"feature\")\n",
+    "G_test = sg.StellarGraph.from_networkx(G_test, node_features=\"feature\")"
    ]
   },
   {

--- a/demos/link-prediction/random-walks/main.py
+++ b/demos/link-prediction/random-walks/main.py
@@ -231,8 +231,8 @@ if __name__ == "__main__":
         metapaths = get_metapaths_from_str(args.metapaths)
 
         train_heterogeneous_graph(
-            g_train=StellarGraph(g_train),
-            g_test=StellarGraph(g_test),
+            g_train=StellarGraph.from_networkx(g_train),
+            g_test=StellarGraph.from_networkx(g_test),
             output_node_features=args.output_node_features,
             edge_data_ids_train=edge_data_ids_train,
             edge_data_labels_train=edge_data_labels_train,

--- a/demos/node-classification/hinsage/yelp-example.py
+++ b/demos/node-classification/hinsage/yelp-example.py
@@ -249,8 +249,8 @@ if __name__ == "__main__":
     features = {"user": user_features, "business": business_features}
 
     # Create stellar Graph object
-    G = StellarGraph(
-        Gnx, node_type_name="ntype", edge_type_name="etype", node_features=features
+    G = StellarGraph.from_networkx(
+        Gnx, node_type_attr="ntype", edge_type_attr="etype", node_features=features
     )
 
     train(

--- a/demos/node-classification/node2vec/stellargraph-node2vec-weighted-random-walks.ipynb
+++ b/demos/node-classification/node2vec/stellargraph-node2vec-weighted-random-walks.ipynb
@@ -293,7 +293,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "rw = BiasedRandomWalk(StellarGraph(g_nx_wt))"
+    "rw = BiasedRandomWalk(StellarGraph.from_networkx(g_nx_wt))"
    ]
   },
   {

--- a/demos/use-cases/hateful-twitters.ipynb
+++ b/demos/use-cases/hateful-twitters.ipynb
@@ -1673,7 +1673,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "G = sg.StellarGraph(g_nx, node_features=node_features)"
+    "G = sg.StellarGraph.from_networkx(g_nx, node_features=node_features)"
    ]
   },
   {


### PR DESCRIPTION
This replaces the legacy `StellarGraph(networkx_graph, ...)` constructor with an explicit `StellarGraph.from_networkx(networkx_graph, ...)` call, in notebooks where building a new StellarGraph object directly may be difficult. At the moment, this is mainly due to:

- link-prediction using `EdgeSplitter` which uses NetworkX (#174)
- datasets that aren't supported in the `stellargraph.datasets` module (#818), and so were not converted as part of #812.

See: #717