### PR TITLE
Pass Generator not Sequence for GraphSAGE in hateful-twitter demo

### DIFF
--- a/demos/use-cases/hateful-twitters.ipynb
+++ b/demos/use-cases/hateful-twitters.ipynb
@@ -1722,7 +1722,7 @@
    "source": [
     "if model_type == \"graphsage\":\n",
     "    base_model = GraphSAGE(\n",
-    "        layer_sizes=[32, 32], generator=train_gen, bias=True, dropout=0.5,\n",
+    "        layer_sizes=[32, 32], generator=generator, bias=True, dropout=0.5,\n",
     "    )\n",
     "    x_inp, x_out = base_model.default_model(flatten_output=True)\n",
     "    prediction = layers.Dense(units=1, activation=\"sigmoid\")(x_out)\n",


### PR DESCRIPTION
The GraphSAGE model was changed to take a generator rather than a sequence (created with `generator.flow`) in #498, but the `demos/use-cases/hateful-twitter.ipynb` notebook was mistakenly not updated.

See: #912