### PR TITLE
Use from_networkx instead of legacy construction in more notebooks

### DIFF
--- a/demos/calibration/calibration-pubmed-link-prediction.ipynb
+++ b/demos/calibration/calibration-pubmed-link-prediction.ipynb
@@ -987,9 +987,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "G_val = sg.StellarGraph(G_val, node_features=\"feature\")\n",
-    "G_train = sg.StellarGraph(G_train, node_features=\"feature\")\n",
-    "G_test = sg.StellarGraph(G_test, node_features=\"feature\")"
+    "G_val = sg.StellarGraph.from_networkx(G_val, node_features=\"feature\")\n",
+    "G_train = sg.StellarGraph.from_networkx(G_train, node_features=\"feature\")\n",
+    "G_test = sg.StellarGraph.from_networkx(G_test, node_features=\"feature\")"
    ]
   },
   {

--- a/demos/node-classification/node2vec/stellargraph-node2vec-weighted-random-walks.ipynb
+++ b/demos/node-classification/node2vec/stellargraph-node2vec-weighted-random-walks.ipynb
@@ -903,7 +903,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "rw = BiasedRandomWalk(StellarGraph(g_nx_wt))"
+    "rw = BiasedRandomWalk(StellarGraph.from_networkx(g_nx_wt))"
    ]
   },
   {


### PR DESCRIPTION
These were missed in #1018.

I believe this is the last ones: #1027 configures our CI to emit an error if the legacy constructor is ever called in any of the tested notebooks, but the CI there passes.

See: #717