### PR TITLE
Remove chebyshev filter option

### DIFF
--- a/stellargraph/core/utils.py
+++ b/stellargraph/core/utils.py
@@ -159,7 +159,9 @@ def GCN_Aadj_feats_op(features, A, k=1, method="gcn"):
         print("Using GCN (local pooling) filters...")
         A = preprocess_adj(A)
     elif method == "chebyshev":
-        raise ValueError("method 'chebyshev' did not behave correctly and has been removed")
+        raise ValueError(
+            "method 'chebyshev' did not behave correctly and has been removed"
+        )
     elif method == "sgc":
         # Smoothing filter (Simplifying Graph Convolutional Networks)
         if isinstance(k, int) and k > 0:

--- a/stellargraph/core/utils.py
+++ b/stellargraph/core/utils.py
@@ -158,6 +158,8 @@ def GCN_Aadj_feats_op(features, A, k=1, method="gcn"):
         # Local pooling filters (see 'renormalization trick' in Kipf & Welling, arXiv 2016) """
         print("Using GCN (local pooling) filters...")
         A = preprocess_adj(A)
+    elif method == "chebyshev":
+        raise ValueError("method 'chebyshev' did not behave correctly and has been removed")
     elif method == "sgc":
         # Smoothing filter (Simplifying Graph Convolutional Networks)
         if isinstance(k, int) and k > 0:
@@ -170,7 +172,5 @@ def GCN_Aadj_feats_op(features, A, k=1, method="gcn"):
                     type(k), k
                 )
             )
-    elif method == "chebyshev":
-        raise ValueError("method 'chebyhev' did not behave correctly and has been removed")
 
     return features, A

--- a/stellargraph/core/utils.py
+++ b/stellargraph/core/utils.py
@@ -158,7 +158,6 @@ def GCN_Aadj_feats_op(features, A, k=1, method="gcn"):
         # Local pooling filters (see 'renormalization trick' in Kipf & Welling, arXiv 2016) """
         print("Using GCN (local pooling) filters...")
         A = preprocess_adj(A)
-
     elif method == "sgc":
         # Smoothing filter (Simplifying Graph Convolutional Networks)
         if isinstance(k, int) and k > 0:
@@ -171,5 +170,7 @@ def GCN_Aadj_feats_op(features, A, k=1, method="gcn"):
                     type(k), k
                 )
             )
+    elif method == "chebyshev":
+        raise ValueError("method 'chebyhev' did not behave correctly and has been removed")
 
     return features, A

--- a/stellargraph/core/utils.py
+++ b/stellargraph/core/utils.py
@@ -96,34 +96,6 @@ def rescale_laplacian(laplacian):
     return scaled_laplacian
 
 
-def chebyshev_polynomial(X, k):
-    """
-    Calculate Chebyshev polynomials up to order k. For more info, see https://en.wikipedia.org/wiki/Chebyshev_filter
-
-    Args:
-        X: adjacency matrix
-        k: maximum polynomial degree
-
-    Returns:
-        Return a list of sparse matrices.
-    """
-
-    print("Calculating Chebyshev polynomials up to order {}...".format(k))
-
-    T_k = list()
-    T_k.append(sp.eye(X.shape[0]).tocsr())
-    T_k.append(X)
-
-    def chebyshev_recurrence(T_k_minus_one, T_k_minus_two, X):
-        X_ = sp.csr_matrix(X, copy=True)
-        return 2 * X_.dot(T_k_minus_one) - T_k_minus_two
-
-    for i in range(2, k + 1):
-        T_k.append(chebyshev_recurrence(T_k[-1], T_k[-2], X))
-
-    return T_k
-
-
 def PPNP_Aadj_feats_op(features, A, teleport_probability=0.1):
     """
     This function calculates the personalized page rank matrix of Eq 2 in [1].

--- a/stellargraph/mapper/full_batch_generators.py
+++ b/stellargraph/mapper/full_batch_generators.py
@@ -123,7 +123,7 @@ class FullBatchGenerator(ABC):
             else:
                 raise ValueError("argument 'transform' must be a callable.")
 
-        elif self.method in ["gcn", "chebyshev", "sgc"]:
+        elif self.method in ["gcn", "sgc"]:
             self.features, self.Aadj = GCN_Aadj_feats_op(
                 features=self.features, A=self.Aadj, k=self.k, method=self.method
             )
@@ -151,7 +151,7 @@ class FullBatchGenerator(ABC):
         else:
             raise ValueError(
                 "Undefined method for adjacency matrix transformation. "
-                "Accepted: 'gcn' (default), 'chebyshev','sgc', and 'self_loops'."
+                "Accepted: 'gcn' (default), 'sgc', and 'self_loops'."
             )
 
     def flow(self, node_ids, targets=None):
@@ -213,8 +213,6 @@ class FullBatchNodeGenerator(FullBatchGenerator):
 
     *   ``method='gcn'`` Normalizes the adjacency matrix for the GCN algorithm.
         This implements the linearized convolution of Eq. 8 in [1].
-    *   ``method='chebyshev'``: Implements the approximate spectral convolution
-        operator by implementing the k-th order Chebyshev expansion of Eq. 5 in [1].
     *   ``method='sgc'``: This replicates the k-th order smoothed adjacency matrix
         to implement the Simplified Graph Convolutions of Eq. 8 in [2].
     *   ``method='self_loops'`` or ``method='gat'``: Simply sets the diagonal elements
@@ -246,10 +244,9 @@ class FullBatchNodeGenerator(FullBatchGenerator):
         G (StellarGraphBase): a machine-learning StellarGraph-type graph
         name (str): an optional name of the generator
         method (str): Method to pre-process adjacency matrix. One of 'gcn' (default),
-            'chebyshev','sgc', 'self_loops', or 'none'.
-        k (None or int): This is the smoothing order for the 'sgc' method or the
-            Chebyshev series order for the 'chebyshev' method. In both cases this
-            should be positive integer.
+            'sgc', 'self_loops', or 'none'.
+        k (None or int): This is the smoothing order for the 'sgc' method. This should be positive
+            integer.
         transform (callable): an optional function to apply on features and adjacency matrix
             the function takes (features, Aadj) as arguments.
         sparse (bool): If True (default) a sparse adjacency matrix is used,
@@ -302,8 +299,6 @@ class FullBatchLinkGenerator(FullBatchGenerator):
 
     *   ``method='gcn'`` Normalizes the adjacency matrix for the GCN algorithm.
         This implements the linearized convolution of Eq. 8 in [1].
-    *   ``method='chebyshev'``: Implements the approximate spectral convolution
-        operator by implementing the k-th order Chebyshev expansion of Eq. 5 in [1].
     *   ``method='sgc'``: This replicates the k-th order smoothed adjacency matrix
         to implement the Simplified Graph Convolutions of Eq. 8 in [2].
     *   ``method='self_loops'`` or ``method='gat'``: Simply sets the diagonal elements
@@ -335,10 +330,9 @@ class FullBatchLinkGenerator(FullBatchGenerator):
         G (StellarGraphBase): a machine-learning StellarGraph-type graph
         name (str): an optional name of the generator
         method (str): Method to pre-process adjacency matrix. One of 'gcn' (default),
-            'chebyshev','sgc', 'self_loops', or 'none'.
-        k (None or int): This is the smoothing order for the 'sgc' method or the
-            Chebyshev series order for the 'chebyshev' method. In both cases this
-            should be positive integer.
+            'sgc', 'self_loops', or 'none'.
+        k (None or int): This is the smoothing order for the 'sgc' method. This should be positive
+            integer.
         transform (callable): an optional function to apply on features and adjacency matrix
             the function takes (features, Aadj) as arguments.
         sparse (bool): If True (default) a sparse adjacency matrix is used,

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -91,24 +91,6 @@ def test_GCN_Aadj_feats_op(example_graph):
     assert np.array_equal(features, features_)
     assert 6 == pytest.approx(Aadj_.todense().sum(), 0.1)
 
-    features_, Aadj_ = GCN_Aadj_feats_op(
-        features=features, A=Aadj, method="chebyshev", k=2
-    )
-    assert len(features_) == 4
-    assert np.array_equal(features_[0], features_[0])
-    assert np.array_equal(features_[1].todense(), sp.eye(Aadj.shape[0]).todense())
-    assert features_[2].max() < 1
-    assert 5 == pytest.approx(features_[3].todense()[:5, :5].sum(), 0.1)
-    assert Aadj.get_shape() == Aadj_.get_shape()
-
-    # k must an integer greater than or equal to 2
-    with pytest.raises(ValueError):
-        GCN_Aadj_feats_op(features=features, A=Aadj, method="chebyshev", k=1)
-    with pytest.raises(ValueError):
-        GCN_Aadj_feats_op(features=features, A=Aadj, method="chebyshev", k=2.0)
-    with pytest.raises(ValueError):
-        GCN_Aadj_feats_op(features=features, A=Aadj, method="chebyshev", k=None)
-
     # k must be positive integer
     with pytest.raises(ValueError):
         GCN_Aadj_feats_op(features=features, A=Aadj, method="sgc", k=None)

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -20,7 +20,6 @@ Utils tests:
 
 """
 import pytest
-import scipy as sp
 
 from stellargraph.core.utils import *
 from ..test_utils.graphs import example_graph_random
@@ -68,18 +67,6 @@ def test_rescale_laplacian(example_graph):
     rl = rescale_laplacian(normalized_laplacian(Aadj))
     assert rl.max() < 1
     assert rl.get_shape() == Aadj.get_shape()
-
-
-def test_chebyshev_polynomial(example_graph):
-    node_list = list(example_graph.nodes())
-    Aadj = example_graph.to_adjacency_matrix()
-
-    k = 2
-    cp = chebyshev_polynomial(rescale_laplacian(normalized_laplacian(Aadj)), k)
-    assert len(cp) == k + 1
-    assert np.array_equal(cp[0].todense(), sp.eye(Aadj.shape[0]).todense())
-    assert cp[1].max() < 1
-    assert 5 == pytest.approx(cp[2].todense()[:5, :5].sum(), 0.1)
 
 
 def test_GCN_Aadj_feats_op(example_graph):


### PR DESCRIPTION
This is currently not implemented correctly and is causing problems
due to tests being flaky #1012 #1013 

The existing code is probably not going to be very useful for
eventually making the option available again, so it is being
removed. Instead, it'll largely depend on refactoring GCN and RGCN,
covered by #621.