### PR TITLE
Disable codecov PR comments

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,7 @@
 ---
+# the comments are too noisy to be useful
+comment: false
+
 coverage:
   precision: 1
   round: nearest


### PR DESCRIPTION
The PR comments from codecov can be noisy and aren't often aren't very useful, so in the vein of keeping things focused (e.g. #595, #954), let's turn them off.

This doesn't change anything other than the comments themselves: we still report the coverage, it is still recorded by codecov for analysis, and it's even still reported on each PR as a status check.

See: #1035