### PR TITLE
Add rdflib to test dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ EXTRAS_REQUIRES = {
         "nbconvert>=5.5.0",
         "treon>=0.1.2",
         "papermill>=2.0.0",
+        "rdflib",
     ],
 }
 


### PR DESCRIPTION
Encountered while trying to test the upgrade to tf 2.1 in a fresh environment for #1048 :

```
___________________________________________ test_aifb_load ____________________________________________

    def test_aifb_load() -> None:
>       g, affiliation = AIFB().load()

tests/datasets/test_datasets.py:173:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <stellargraph.datasets.datasets.AIFB object at 0x14f1fd110>

    def load(self):
        """
        Loads the dataset into a directed heterogeneous graph.

        The nodes features are the node's position after being one-hot encoded; for example, the
        first node has features ``[1, 0, 0, ...]``, the second has ``[0, 1, 0, ...]``.

        This requires the ``rdflib`` library to be installed.

        Returns:
            A tuple where the first element is a graph containing all edges except for those with
            type ``affiliation`` and ``employs`` (the inverse of ``affiliation``), and the second
            element is a DataFrame containing the one-hot encoded affiliation of the 178 nodes that
            have an affiliation.
        """
        try:
            import rdflib
        except ModuleNotFoundError as e:
            raise ModuleNotFoundError(
                f"{e.msg}. Loading the AIFB dataset requires the 'rdflib' module; please install it",
                name=e.name,
                path=e.path,
>           ) from None
E           ModuleNotFoundError: No module named 'rdflib'. Loading the AIFB dataset requires the 'rdflib' module; please install it

stellargraph/datasets/datasets.py:449: ModuleNotFoundError
```

I'm guessing this isn't caught in CI I think because we always install both test and demo dependencies together?

Note that there's currently no minimum version specified for `rdflib` in the dependencies