### PR TITLE
Update Neo4j generators for new batch_num argument

### DIFF
--- a/stellargraph/connector/neo4j/mapper.py
+++ b/stellargraph/connector/neo4j/mapper.py
@@ -121,7 +121,7 @@ class Neo4JGraphSAGENodeGenerator(Neo4JBatchedNodeGenerator):
             G, graph_schema=self.schema, seed=seed
         )
 
-    def sample_features(self, head_nodes):
+    def sample_features(self, head_nodes, batch_num):
         """
         Collect the features of the nodes sampled from Neo4J,
         and return these as a list of feature arrays for the GraphSAGE
@@ -129,6 +129,7 @@ class Neo4JGraphSAGENodeGenerator(Neo4JBatchedNodeGenerator):
 
         Args:
             head_nodes: An iterable of head nodes to perform sampling on.
+            batch_num: Ignored, because this is not reproducible.
 
         Returns:
             A list of the same length as ``num_samples`` of collected features from
@@ -218,13 +219,14 @@ class Neo4JDirectedGraphSAGENodeGenerator(Neo4JBatchedNodeGenerator):
             G, graph_schema=self.schema, seed=seed
         )
 
-    def sample_features(self, head_nodes):
+    def sample_features(self, head_nodes, batch_num):
         """
         Collect the features of the sampled nodes from Neo4J,
         and return these as a list of feature arrays for the GraphSAGE algorithm.
 
         Args:
             head_nodes: An iterable of head nodes to perform sampling on.
+            batch_num: Ignored, because this is not reproducible.
 
         Returns:
             A list of feature tensors from the sampled nodes at each layer, each of shape:


### PR DESCRIPTION
In 4070ccf24d67802a08a9f70ca3e7567a0a53a7fc (#844), a second argument (`batch_num`) was added to the `sample_features` function in the `BatchedNodeGenerator` class, and most subclasses were updated, but not the Neo4j ones. This PR adds that argument.

This code is untested on CI (even the notebooks #849), but that's being worked on (#1046), and I've manually verified the notebooks run for now.

See: #1016