### PR TITLE
Add enron employees dataset

### DIFF
--- a/stellargraph/datasets/dataset_loader.py
+++ b/stellargraph/datasets/dataset_loader.py
@@ -45,24 +45,25 @@ class DatasetLoader:
     directory_name = ""
     url = ""
     url_archive_format: Optional[str] = None
+    url_archive_contains_directory: bool = True
     expected_files: List[str] = []
     description = ""
     source = ""
     data_subdirectory_name: Optional[str] = None
-    url_archive_contains_directory: bool = True
 
     @classmethod
     def __init_subclass__(
         cls,
+        *,
         name: str,
         directory_name: str,
         url: str,
         url_archive_format: Optional[str],
+        url_archive_contains_directory: bool = True,
         expected_files: List[str],
         description: str,
         source: str,
         data_subdirectory_name: Optional[str] = None,
-        url_archive_contains_directory: bool = True,
         **kwargs: Any,
     ) -> None:
         """Used to set class variables during the class definition of derived classes and generate customised docs.
@@ -71,11 +72,11 @@ class DatasetLoader:
         cls.directory_name = directory_name
         cls.url = url
         cls.url_archive_format = url_archive_format
+        cls.url_archive_contains_directory = url_archive_contains_directory
         cls.expected_files = expected_files
         cls.description = description
         cls.source = source
         cls.data_subdirectory_name = data_subdirectory_name
-        cls.url_archive_contains_directory = url_archive_contains_directory
 
         if url_archive_format is None and len(expected_files) != 1:
             raise ValueError(

--- a/stellargraph/datasets/dataset_loader.py
+++ b/stellargraph/datasets/dataset_loader.py
@@ -49,6 +49,7 @@ class DatasetLoader:
     description = ""
     source = ""
     data_subdirectory_name: Optional[str] = None
+    create_directory: bool = False
 
     @classmethod
     def __init_subclass__(
@@ -61,6 +62,7 @@ class DatasetLoader:
         description: str,
         source: str,
         data_subdirectory_name: Optional[str] = None,
+        create_directory: bool = False,
         **kwargs: Any,
     ) -> None:
         """Used to set class variables during the class definition of derived classes and generate customised docs.
@@ -73,6 +75,7 @@ class DatasetLoader:
         cls.description = description
         cls.source = source
         cls.data_subdirectory_name = data_subdirectory_name
+        cls.create_directory = create_directory
 
         if url_archive_format is None and len(expected_files) != 1:
             raise ValueError(
@@ -125,6 +128,12 @@ class DatasetLoader:
         """Convert dataset relative file names to their full path on filesystem"""
         return os.path.join(self.base_directory, filename)
 
+    def _resolve_unpack_path(self):
+        if self.create_directory:
+            return self.base_directory
+        else:
+            return self._all_datasets_directory()
+
     def _missing_files(self) -> List[str]:
         """Returns a list of files that are missing"""
         return [
@@ -175,7 +184,7 @@ class DatasetLoader:
                 # directory_name for this dataset must match the directory name inside the archive file
                 unpack_archive(
                     temporary_filename,
-                    self._all_datasets_directory(),
+                    self._resolve_unpack_path(),
                     self.url_archive_format,
                 )
             # verify the download

--- a/stellargraph/datasets/dataset_loader.py
+++ b/stellargraph/datasets/dataset_loader.py
@@ -49,7 +49,7 @@ class DatasetLoader:
     description = ""
     source = ""
     data_subdirectory_name: Optional[str] = None
-    url_contains_directory: bool = True
+    url_archive_contains_directory: bool = True
 
     @classmethod
     def __init_subclass__(
@@ -62,7 +62,7 @@ class DatasetLoader:
         description: str,
         source: str,
         data_subdirectory_name: Optional[str] = None,
-        url_contains_directory: bool = True,
+        url_archive_contains_directory: bool = True,
         **kwargs: Any,
     ) -> None:
         """Used to set class variables during the class definition of derived classes and generate customised docs.
@@ -75,7 +75,7 @@ class DatasetLoader:
         cls.description = description
         cls.source = source
         cls.data_subdirectory_name = data_subdirectory_name
-        cls.url_contains_directory = url_contains_directory
+        cls.url_archive_contains_directory = url_archive_contains_directory
 
         if url_archive_format is None and len(expected_files) != 1:
             raise ValueError(
@@ -129,7 +129,7 @@ class DatasetLoader:
         return os.path.join(self.base_directory, filename)
 
     def _resolve_unpack_path(self):
-        if self.url_contains_directory:
+        if self.url_archive_contains_directory:
             return self._all_datasets_directory()
         else:
             return self.base_directory

--- a/stellargraph/datasets/dataset_loader.py
+++ b/stellargraph/datasets/dataset_loader.py
@@ -49,7 +49,7 @@ class DatasetLoader:
     description = ""
     source = ""
     data_subdirectory_name: Optional[str] = None
-    create_directory: bool = False
+    url_contains_directory: bool = True
 
     @classmethod
     def __init_subclass__(
@@ -62,7 +62,7 @@ class DatasetLoader:
         description: str,
         source: str,
         data_subdirectory_name: Optional[str] = None,
-        create_directory: bool = False,
+        url_contains_directory: bool = True,
         **kwargs: Any,
     ) -> None:
         """Used to set class variables during the class definition of derived classes and generate customised docs.
@@ -75,7 +75,7 @@ class DatasetLoader:
         cls.description = description
         cls.source = source
         cls.data_subdirectory_name = data_subdirectory_name
-        cls.create_directory = create_directory
+        cls.url_contains_directory = url_contains_directory
 
         if url_archive_format is None and len(expected_files) != 1:
             raise ValueError(
@@ -129,10 +129,10 @@ class DatasetLoader:
         return os.path.join(self.base_directory, filename)
 
     def _resolve_unpack_path(self):
-        if self.create_directory:
-            return self.base_directory
-        else:
+        if self.url_contains_directory:
             return self._all_datasets_directory()
+        else:
+            return self.base_directory
 
     def _missing_files(self) -> List[str]:
         """Returns a list of files that are missing"""

--- a/stellargraph/datasets/datasets.py
+++ b/stellargraph/datasets/datasets.py
@@ -720,7 +720,7 @@ class IAEnronEmployees(
     "There are 50572 edges, and each of them contains timestamp information. "
     "Edges refer to 151 unique node IDs in total.",
     source="http://networkrepository.com/ia-enron-employees.php",
-    create_directory=True,
+    url_contains_directory=False,
 ):
     def load(self):
         """

--- a/stellargraph/datasets/datasets.py
+++ b/stellargraph/datasets/datasets.py
@@ -711,16 +711,17 @@ class FB15k_237(
 
 class IAEnronEmployees(
     DatasetLoader,
-    name="IAEnronEmployees",
+    name="ia-enron-employees",
     directory_name="ia-enron-employees",
     url="http://nrvis.com/download/data/dynamic/ia-enron-employees.zip",
     url_archive_format="zip",
+    url_archive_contains_directory=False,
     expected_files=["ia-enron-employees.edges", "readme.html"],
     description="A dataset of edges that represent emails sent from one employee to another."
     "There are 50572 edges, and each of them contains timestamp information. "
-    "Edges refer to 151 unique node IDs in total.",
+    "Edges refer to 151 unique node IDs in total."
+    "Ryan A. Rossi and Nesreen K. Ahmed “The Network Data Repository with Interactive Graph Analytics and Visualization” (2015)",
     source="http://networkrepository.com/ia-enron-employees.php",
-    url_contains_directory=False,
 ):
     def load(self):
         """
@@ -733,16 +734,19 @@ class IAEnronEmployees(
         self.download()
 
         edges_path = self._resolve_path("ia-enron-employees.edges")
-        edges = pd.read_csv(edges_path, sep=" ", header=None)
-
-        # clean up columns
-        edges.columns = ["source", "target", "x", "time"]
+        edges = pd.read_csv(
+            edges_path,
+            sep=" ",
+            header=None,
+            names=["source", "target", "x", "time"],
+            usecols=["source", "target", "time"],
+        )
         edges[["source", "target"]] = edges[["source", "target"]].astype(str)
-        edges = edges.drop(columns=["x"])  # unused column
 
         nodes = pd.DataFrame(
-            np.unique(pd.concat([edges["source"], edges["target"]], ignore_index=True)),
-            columns=["id"],
-        ).set_index("id")
+            index=np.unique(
+                pd.concat([edges["source"], edges["target"]], ignore_index=True)
+            )
+        )
 
         return nodes, edges

--- a/stellargraph/datasets/datasets.py
+++ b/stellargraph/datasets/datasets.py
@@ -740,8 +740,6 @@ class IAEnronEmployees(
         edges[["source", "target"]] = edges[["source", "target"]].astype(str)
         edges = edges.drop(columns=["x"])  # unused column
 
-        # time in seconds
-        edges["time"] = edges["time"]
         nodes = pd.DataFrame(
             np.unique(pd.concat([edges["source"], edges["target"]], ignore_index=True)),
             columns=["id"],

--- a/stellargraph/datasets/datasets.py
+++ b/stellargraph/datasets/datasets.py
@@ -728,8 +728,16 @@ class IAEnronEmployees(
         Load this data into a set of nodes and edges
 
         Returns:
-            A tuple ``(nodes, edges)`` where each element is a Pandas DataFrame. Edges are kept
-            sorted in ascending order of time as per the original dataset.
+            A tuple ``(graph, edges)``
+
+            ``graph`` is a :class:`StellarGraph` containing all the data. Timestamp information on
+            edges are encoded as edge weights.
+
+            ``edges`` are the original edges from the dataset which are sorted in ascending
+            order of time - these can be used to create train/test splits based on time values.
+
+            Node IDs in the returned data structures are all converted to strings to allow for
+            compatibility with with ``gensim``'s ``Word2Vec`` model.
         """
         self.download()
 
@@ -749,4 +757,4 @@ class IAEnronEmployees(
             )
         )
 
-        return nodes, edges
+        return StellarGraph(nodes=nodes, edges=edges, edge_weight_column="time"), edges

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -257,11 +257,12 @@ def test_pubmeddiabetes_load() -> None:
 
 
 def test_ia_enron_employees_load() -> None:
-    nodes, edges = IAEnronEmployees().load()
+    graph, edges = IAEnronEmployees().load()
 
     n_nodes = 151
     n_edges = 50572
 
-    assert len(nodes) == n_nodes
+    assert graph.number_of_nodes() == n_nodes
+    assert graph.number_of_edges() == n_edges
     assert len(edges) == n_edges
     assert set(edges.columns) == {"source", "target", "time"}

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -254,3 +254,14 @@ def test_pubmeddiabetes_load() -> None:
 
     assert len(labels) == n_nodes
     assert set(labels.index) == set(g.nodes())
+
+
+def test_ia_enron_employees_load() -> None:
+    nodes, edges = IAEnronEmployees().load()
+
+    n_nodes = 151
+    n_edges = 50572
+
+    assert len(nodes) == n_nodes
+    assert len(edges) == n_edges
+    assert set(edges.columns) == {"source", "target", "time"}


### PR DESCRIPTION
I've had to introduce a `url_contains_directory` parameter to `DatasetLoader` slightly to allow for datasets that are zipped without the directory - not sure what the best name for it is though.

The dataset comes from http://networkrepository.com/ia-enron-employees.php and is supposed to be cited with:
```
@inproceedings{nr,
     title={The Network Data Repository with Interactive Graph Analytics and Visualization},
     author={Ryan A. Rossi and Nesreen K. Ahmed},
     booktitle={AAAI},
     url={http://networkrepository.com},
     year={2015}
}
```

Maybe we could add some mechanism in `DatasetLoader` to hold onto the citation information? Otherwise any notebook that uses this dataset would have to paste something like that