### PR TITLE
Fix formatting in explorer classes

### DIFF
--- a/stellargraph/data/explorer.py
+++ b/stellargraph/data/explorer.py
@@ -507,12 +507,13 @@ class SampledBreadthFirstWalk(GraphWalk):
         Performs a sampled breadth-first walk starting from the root nodes.
 
         Args:
-            nodes (list): A list of root node ids such that from each node n BFWs will be generated up to the
+            nodes (list): A list of root node ids such that from each node a BFWs will be generated up to the
                 given depth d.
-            n_size (int): The number of neighbouring nodes to expand at each depth of the walk. Sampling of
-            n (int, default 1): Number of walks per node id. Neighbours with replacement is always used
-                regardless of the node degree and number of neighbours requested.
-            seed (int, optional): Random number generator seed; default is None
+            n_size (list of int): The number of neighbouring nodes to expand at each depth of the walk.
+                Sampling of neighbours is always done with replacement regardless of the node degree and
+                number of neighbours requested.
+            n (int): Number of walks per node id.
+            seed (int, optional): Random number generator seed; Default is None.
 
         Returns:
             A list of lists such that each list element is a sequence of ids corresponding to a BFW.
@@ -815,17 +816,17 @@ class TemporalRandomWalk(GraphWalk):
                 since a walk must generate at least 1 context window for it to be useful.
             max_walk_length (int): Maximum length of each random walk. Should be greater
                 than or equal to the context window size.
-            initial_edge_bias (str, optional): distribution to use when choosing a random
+            initial_edge_bias (str, optional): Distribution to use when choosing a random
                 initial temporal edge to start from. Available options are:
 
-                * None (default) - the initial edge is picked from a uniform distribution
-                * "exponential" - heavily biased towards more recent edges.
+                * None (default) - The initial edge is picked from a uniform distribution.
+                * "exponential" - Heavily biased towards more recent edges.
 
-            walk_bias (str, optional): distribution to use when choosing a random
+            walk_bias (str, optional): Distribution to use when choosing a random
                 neighbour to walk through. Available options are:
 
-                * None (default) - neighbours are picked from a uniform distribution
-                * "exponential" - exponentially decaying probability, resulting in a bias towards shorter time gaps
+                * None (default) - Neighbours are picked from a uniform distribution.
+                * "exponential" - Exponentially decaying probability, resulting in a bias towards shorter time gaps.
 
             p_walk_success_threshold (float): Lower bound for the proportion of successful
                 (i.e. longer than minimum length) walks. If the 95% percentile of the
@@ -834,10 +835,10 @@ class TemporalRandomWalk(GraphWalk):
                 of the attempted random walks are successful. This parameter exists to catch any
                 potential situation where too many unsuccessful walks can cause an infinite or very
                 slow loop.
-            seed (int, optional): Random number generator seed; default is None
+            seed (int, optional): Random number generator seed; default is None.
 
         Returns:
-            List of lists of node ids for each of the random walks
+            List of lists of node ids for each of the random walks.
 
         """
         if cw_size < 2:

--- a/stellargraph/data/explorer.py
+++ b/stellargraph/data/explorer.py
@@ -818,13 +818,17 @@ class TemporalRandomWalk(GraphWalk):
                 than or equal to the context window size.
             initial_edge_bias (str, optional): distribution to use when choosing a random
                 initial temporal edge to start from. Available options are:
+
                 * None (default) - the initial edge is picked from a uniform distribution
                 * "exponential" - heavily biased towards more recent edges.
+
             walk_bias (str, optional): distribution to use when choosing a random
                 neighbour to walk through. Available options are:
+
                 * None (default) - neighbours are picked from a uniform distribution
                 * "exponential" - exponentially decaying probability, resulting in a bias
                     towards shorter time gaps
+
             p_walk_success_threshold (float): Lower bound for the proportion of successful
                 (i.e. longer than minimum length) walks. If the 95% percentile of the
                 estimated proportion is less than the provided threshold, a RuntimeError

--- a/stellargraph/data/explorer.py
+++ b/stellargraph/data/explorer.py
@@ -826,8 +826,7 @@ class TemporalRandomWalk(GraphWalk):
                 neighbour to walk through. Available options are:
 
                 * None (default) - neighbours are picked from a uniform distribution
-                * "exponential" - exponentially decaying probability, resulting in a bias
-                    towards shorter time gaps
+                * "exponential" - exponentially decaying probability, resulting in a bias towards shorter time gaps
 
             p_walk_success_threshold (float): Lower bound for the proportion of successful
                 (i.e. longer than minimum length) walks. If the 95% percentile of the

--- a/stellargraph/data/explorer.py
+++ b/stellargraph/data/explorer.py
@@ -807,7 +807,7 @@ class TemporalRandomWalk(GraphWalk):
         seed=None,
     ):
         """
-        Perform a time respecting random walk starting from the root nodes.
+        Perform a time respecting random walk starting from randomly selected temporal edges.
 
         Args:
             num_cw (int): Total number of context windows to generate. For comparable

--- a/stellargraph/data/explorer.py
+++ b/stellargraph/data/explorer.py
@@ -510,9 +510,8 @@ class SampledBreadthFirstWalk(GraphWalk):
             nodes (list): A list of root node ids such that from each node n BFWs will be generated up to the
                 given depth d.
             n_size (int): The number of neighbouring nodes to expand at each depth of the walk. Sampling of
-            n (int, default 1): Number of walks per node id.
-            neighbours with replacement is always used regardless of the node degree and number of neighbours
-            requested.
+            n (int, default 1): Number of walks per node id. Neighbours with replacement is always used
+                regardless of the node degree and number of neighbours requested.
             seed (int, optional): Random number generator seed; default is None
 
         Returns:

--- a/stellargraph/data/explorer.py
+++ b/stellargraph/data/explorer.py
@@ -508,7 +508,8 @@ class SampledBreadthFirstWalk(GraphWalk):
 
         Args:
             nodes (list): A list of root node ids such that from each node a BFWs will be generated up to the
-                given depth d.
+                given depth. The depth of each of the walks is inferred from the length of the ``n_size``
+                list parameter.
             n_size (list of int): The number of neighbouring nodes to expand at each depth of the walk.
                 Sampling of neighbours is always done with replacement regardless of the node degree and
                 number of neighbours requested.


### PR DESCRIPTION
This fixes poorly formatted bullet points in two explorer classes.

Now it looks like
## sampled breadth first walk
![image](https://user-images.githubusercontent.com/33508488/76475512-36a3f780-6453-11ea-972e-ca98f24959ce.png)

## temporal walk
![image](https://user-images.githubusercontent.com/33508488/76475530-49b6c780-6453-11ea-9c7a-95025e105203.png)


Compared to before - see #866 