### PR TITLE
Mechanically replace Model.*_generator with Model.* in Python files

### DIFF
--- a/demos/node-classification/hinsage/yelp-example.py
+++ b/demos/node-classification/hinsage/yelp-example.py
@@ -124,12 +124,12 @@ def train(
     )
 
     # Train model
-    history = model.fit_generator(
+    history = model.fit(
         train_gen, epochs=num_epochs, verbose=2, shuffle=False
     )
 
     # Evaluate on test set and print metrics
-    predictions = model.predict_generator(test_gen)
+    predictions = model.predict(test_gen)
     binary_predictions = predictions[:, 1] > 0.5
     print("\nTest Set Metrics (on {} nodes)".format(len(predictions)))
 

--- a/demos/node-classification/hinsage/yelp-example.py
+++ b/demos/node-classification/hinsage/yelp-example.py
@@ -124,9 +124,7 @@ def train(
     )
 
     # Train model
-    history = model.fit(
-        train_gen, epochs=num_epochs, verbose=2, shuffle=False
-    )
+    history = model.fit(train_gen, epochs=num_epochs, verbose=2, shuffle=False)
 
     # Evaluate on test set and print metrics
     predictions = model.predict(test_gen)

--- a/stellargraph/mapper/full_batch_generators.py
+++ b/stellargraph/mapper/full_batch_generators.py
@@ -167,8 +167,8 @@ class FullBatchGenerator(ABC):
 
         Returns:
             A NodeSequence object to use with GCN or GAT models
-            in Keras methods :meth:`fit_generator`, :meth:`evaluate_generator`,
-            and :meth:`predict_generator`
+            in Keras methods :meth:`fit`, :meth:`evaluate`,
+            and :meth:`predict`
 
         """
         if targets is not None:
@@ -234,8 +234,8 @@ class FullBatchNodeGenerator(FullBatchGenerator):
         x_inputs, y_train = train_flow[0]
         model.fit(x=x_inputs, y=y_train)
 
-        # Alternatively, use the generator itself with model.fit_generator:
-        model.fit_generator(train_flow, epochs=num_epochs)
+        # Alternatively, use the generator itself with model.fit:
+        model.fit(train_flow, epochs=num_epochs)
 
     For more information, please see the GCN/GAT, PPNP/APPNP and SGC demos:
         `<https://github.com/stellargraph/stellargraph/blob/master/demos/>`_
@@ -270,8 +270,8 @@ class FullBatchNodeGenerator(FullBatchGenerator):
 
         Returns:
             A NodeSequence object to use with GCN or GAT models
-            in Keras methods :meth:`fit_generator`, :meth:`evaluate_generator`,
-            and :meth:`predict_generator`
+            in Keras methods :meth:`fit`, :meth:`evaluate`,
+            and :meth:`predict`
 
         """
         return super().flow(node_ids, targets)
@@ -320,8 +320,8 @@ class FullBatchLinkGenerator(FullBatchGenerator):
         x_inputs, y_train = train_flow[0]
         model.fit(x=x_inputs, y=y_train)
 
-        # Alternatively, use the generator itself with model.fit_generator:
-        model.fit_generator(train_flow, epochs=num_epochs)
+        # Alternatively, use the generator itself with model.fit:
+        model.fit(train_flow, epochs=num_epochs)
 
     For more information, please see the GCN, GAT, PPNP/APPNP and SGC demos:
         `<https://github.com/stellargraph/stellargraph/blob/master/demos/>`_
@@ -356,8 +356,8 @@ class FullBatchLinkGenerator(FullBatchGenerator):
 
         Returns:
             A NodeSequence object to use with GCN or GAT models
-            in Keras methods :meth:`fit_generator`, :meth:`evaluate_generator`,
-            and :meth:`predict_generator`
+            in Keras methods :meth:`fit`, :meth:`evaluate`,
+            and :meth:`predict`
 
         """
         return super().flow(link_ids, targets)
@@ -389,8 +389,8 @@ class RelationalFullBatchNodeGenerator:
         train_data_gen = G_generator.flow(node_ids, node_targets)
 
         # Fetch the data from train_data_gen, and feed into a Keras model:
-        # Alternatively, use the generator itself with model.fit_generator:
-        model.fit_generator(train_gen, epochs=num_epochs, ...)
+        # Alternatively, use the generator itself with model.fit:
+        model.fit(train_gen, epochs=num_epochs, ...)
 
     Args:
         G (StellarGraph): a machine-learning StellarGraph-type graph
@@ -477,8 +477,8 @@ class RelationalFullBatchNodeGenerator:
 
         Returns:
             A NodeSequence object to use with RGCN models
-            in Keras methods :meth:`fit_generator`, :meth:`evaluate_generator`,
-            and :meth:`predict_generator`
+            in Keras methods :meth:`fit`, :meth:`evaluate`,
+            and :meth:`predict`
         """
 
         if targets is not None:

--- a/stellargraph/mapper/mini_batch_node_generators.py
+++ b/stellargraph/mapper/mini_batch_node_generators.py
@@ -161,7 +161,7 @@ class ClusterNodeGenerator:
 
         Returns:
             A ClusterNodeSequence object to use with ClusterGCN in Keras
-            methods :meth:`fit_generator`, :meth:`evaluate_generator`, and :meth:`predict_generator`
+            methods :meth:`fit`, :meth:`evaluate`, and :meth:`predict`
 
         """
         if targets is not None:
@@ -195,9 +195,9 @@ class ClusterNodeGenerator:
 class ClusterNodeSequence(Sequence):
     """
     A Keras-compatible data generator for node inference using ClusterGCN model.
-    Use this class with the Keras methods :meth:`keras.Model.fit_generator`,
-        :meth:`keras.Model.evaluate_generator`, and
-        :meth:`keras.Model.predict_generator`,
+    Use this class with the Keras methods :meth:`keras.Model.fit`,
+        :meth:`keras.Model.evaluate`, and
+        :meth:`keras.Model.predict`,
 
     This class should be created using the `.flow(...)` method of
     :class:`ClusterNodeGenerator`.

--- a/stellargraph/mapper/sampled_link_generators.py
+++ b/stellargraph/mapper/sampled_link_generators.py
@@ -109,8 +109,8 @@ class BatchedLinkGenerator(abc.ABC):
 
         Returns:
             A NodeSequence object to use with with StellarGraph models
-            in Keras methods ``fit_generator``, ``evaluate_generator``,
-            and ``predict_generator``
+            in Keras methods ``fit``, ``evaluate``,
+            and ``predict``
 
         """
         if self.head_node_types is not None:
@@ -179,8 +179,8 @@ class BatchedLinkGenerator(abc.ABC):
 
         Returns:
             A NodeSequence object to use with StellarGraph models
-            in Keras methods ``fit_generator``, ``evaluate_generator``,
-            and ``predict_generator``
+            in Keras methods ``fit``, ``evaluate``,
+            and ``predict``
 
         """
         return self.flow(

--- a/stellargraph/mapper/sampled_node_generators.py
+++ b/stellargraph/mapper/sampled_node_generators.py
@@ -123,8 +123,8 @@ class BatchedNodeGenerator(abc.ABC):
 
         Returns:
             A NodeSequence object to use with with StellarGraph models
-            in Keras methods ``fit_generator``, ``evaluate_generator``,
-            and ``predict_generator``
+            in Keras methods ``fit``, ``evaluate``,
+            and ``predict``
 
         """
         if self.head_node_types is not None:
@@ -166,8 +166,8 @@ class BatchedNodeGenerator(abc.ABC):
 
         Returns:
             A NodeSequence object to use with with StellarGraph models
-            in Keras methods ``fit_generator``, ``evaluate_generator``,
-            and ``predict_generator``
+            in Keras methods ``fit``, ``evaluate``,
+            and ``predict``
 
         """
         return self.flow(node_targets.index, node_targets.values, shuffle=shuffle)
@@ -540,7 +540,7 @@ class Attri2VecNodeGenerator(BatchedNodeGenerator):
 
         Returns:
             A NodeSequence object to use with the Attri2Vec model
-            in the Keras method ``predict_generator``.
+            in the Keras method ``predict``.
 
         """
         return NodeSequence(
@@ -557,7 +557,7 @@ class Attri2VecNodeGenerator(BatchedNodeGenerator):
 
         Returns:
             A NodeSequence object to use with the Attri2Vec model
-            in the Keras method ``predict_generator``.
+            in the Keras method ``predict``.
 
         """
         return NodeSequence(self.sample_features, self.batch_size, node_ids.index)

--- a/stellargraph/mapper/sequences.py
+++ b/stellargraph/mapper/sequences.py
@@ -45,8 +45,8 @@ from ..random import random_state
 
 class NodeSequence(Sequence):
     """Keras-compatible data generator to use with the Keras
-    methods :meth:`keras.Model.fit_generator`, :meth:`keras.Model.evaluate_generator`,
-    and :meth:`keras.Model.predict_generator`.
+    methods :meth:`keras.Model.fit`, :meth:`keras.Model.evaluate`,
+    and :meth:`keras.Model.predict`.
 
     This class generated data samples for node inference models
     and should be created using the `.flow(...)` method of
@@ -149,8 +149,8 @@ class NodeSequence(Sequence):
 
 class LinkSequence(Sequence):
     """
-    Keras-compatible data generator to use with Keras methods :meth:`keras.Model.fit_generator`,
-    :meth:`keras.Model.evaluate_generator`, and :meth:`keras.Model.predict_generator`
+    Keras-compatible data generator to use with Keras methods :meth:`keras.Model.fit`,
+    :meth:`keras.Model.evaluate`, and :meth:`keras.Model.predict`
     This class generates data samples for link inference models
     and should be created using the :meth:`flow` method of
     :class:`GraphSAGELinkGenerator` or :class:`HinSAGELinkGenerator` or :class:`Attri2VecLinkGenerator`.
@@ -251,8 +251,8 @@ class LinkSequence(Sequence):
 
 class OnDemandLinkSequence(Sequence):
     """
-    Keras-compatible data generator to use with Keras methods :meth:`keras.Model.fit_generator`,
-    :meth:`keras.Model.evaluate_generator`, and :meth:`keras.Model.predict_generator`
+    Keras-compatible data generator to use with Keras methods :meth:`keras.Model.fit`,
+    :meth:`keras.Model.evaluate`, and :meth:`keras.Model.predict`
 
     This class generates data samples for link inference models
     and should be created using the :meth:`flow` method of
@@ -351,9 +351,9 @@ class FullBatchSequence(Sequence):
     """
     Keras-compatible data generator for for node inference models
     that require full-batch training (e.g., GCN, GAT).
-    Use this class with the Keras methods :meth:`keras.Model.fit_generator`,
-        :meth:`keras.Model.evaluate_generator`, and
-        :meth:`keras.Model.predict_generator`,
+    Use this class with the Keras methods :meth:`keras.Model.fit`,
+        :meth:`keras.Model.evaluate`, and
+        :meth:`keras.Model.predict`,
 
     This class should be created using the `.flow(...)` method of
     :class:`FullBatchNodeGenerator`.
@@ -409,9 +409,9 @@ class SparseFullBatchSequence(Sequence):
     """
     Keras-compatible data generator for for node inference models
     that require full-batch training (e.g., GCN, GAT).
-    Use this class with the Keras methods :meth:`keras.Model.fit_generator`,
-        :meth:`keras.Model.evaluate_generator`, and
-        :meth:`keras.Model.predict_generator`,
+    Use this class with the Keras methods :meth:`keras.Model.fit`,
+        :meth:`keras.Model.evaluate`, and
+        :meth:`keras.Model.predict`,
 
     This class uses sparse matrix representations to send data to the models,
     and only works with the Keras tensorflow backend. For any other backends,
@@ -475,9 +475,9 @@ class RelationalFullBatchNodeSequence(Sequence):
     """
     Keras-compatible data generator for for node inference models on relational graphs
     that require full-batch training (e.g., RGCN).
-    Use this class with the Keras methods :meth:`keras.Model.fit_generator`,
-        :meth:`keras.Model.evaluate_generator`, and
-        :meth:`keras.Model.predict_generator`,
+    Use this class with the Keras methods :meth:`keras.Model.fit`,
+        :meth:`keras.Model.evaluate`, and
+        :meth:`keras.Model.predict`,
 
     This class uses either dense or sparse representations to send data to the models.
 

--- a/tests/layer/test_appnp.py
+++ b/tests/layer/test_appnp.py
@@ -107,8 +107,8 @@ def test_APPNP_apply_dense():
     preds_1 = model.predict([features[None, :, :], out_indices, adj])
     assert preds_1.shape == (1, 2, 2)
 
-    # Check fit_generator method
-    preds_2 = model.predict_generator(generator.flow(["a", "b"]))
+    # Check fit method
+    preds_2 = model.predict(generator.flow(["a", "b"]))
     assert preds_2.shape == (1, 2, 2)
 
     assert preds_1 == pytest.approx(preds_2)
@@ -134,8 +134,8 @@ def test_APPNP_apply_sparse():
     preds_1 = model.predict([features[None, :, :], out_indices, A_indices, A_values])
     assert preds_1.shape == (1, 2, 2)
 
-    # Check fit_generator method
-    preds_2 = model.predict_generator(generator.flow(["a", "b"]))
+    # Check fit method
+    preds_2 = model.predict(generator.flow(["a", "b"]))
     assert preds_2.shape == (1, 2, 2)
 
     assert preds_1 == pytest.approx(preds_2)
@@ -157,8 +157,8 @@ def test_APPNP_linkmodel_apply_dense():
     preds_1 = model.predict([features[None, :, :], out_indices, adj])
     assert preds_1.shape == (1, 2, 2, 3)
 
-    # Check fit_generator method
-    preds_2 = model.predict_generator(generator.flow([("a", "b"), ("b", "c")]))
+    # Check fit method
+    preds_2 = model.predict(generator.flow([("a", "b"), ("b", "c")]))
     assert preds_2.shape == (1, 2, 2, 3)
 
     assert preds_1 == pytest.approx(preds_2)
@@ -186,8 +186,8 @@ def test_APPNP_linkmodel_apply_sparse():
     preds_1 = model.predict([features[None, :, :], out_indices, A_indices, A_values])
     assert preds_1.shape == (1, 2, 2, 3)
 
-    # Check fit_generator method
-    preds_2 = model.predict_generator(generator.flow([("a", "b"), ("b", "c")]))
+    # Check fit method
+    preds_2 = model.predict(generator.flow([("a", "b"), ("b", "c")]))
     assert preds_2.shape == (1, 2, 2, 3)
 
     assert preds_1 == pytest.approx(preds_2)
@@ -213,8 +213,8 @@ def test_APPNP_apply_propagate_model_dense():
     preds_1 = model.predict([features[None, :, :], out_indices, adj])
     assert preds_1.shape == (1, 2, 2)
 
-    # Check fit_generator method
-    preds_2 = model.predict_generator(generator.flow(["a", "b"]))
+    # Check fit method
+    preds_2 = model.predict(generator.flow(["a", "b"]))
     assert preds_2.shape == (1, 2, 2)
 
     assert preds_1 == pytest.approx(preds_2)
@@ -243,8 +243,8 @@ def test_APPNP_apply_propagate_model_sparse():
     preds_1 = model.predict([features[None, :, :], out_indices, A_indices, A_values])
     assert preds_1.shape == (1, 2, 2)
 
-    # Check fit_generator method
-    preds_2 = model.predict_generator(generator.flow(["a", "b"]))
+    # Check fit method
+    preds_2 = model.predict(generator.flow(["a", "b"]))
     assert preds_2.shape == (1, 2, 2)
 
     assert preds_1 == pytest.approx(preds_2)

--- a/tests/layer/test_cluster_gcn.py
+++ b/tests/layer/test_cluster_gcn.py
@@ -122,8 +122,8 @@ def test_ClusterGCN_apply():
     x_in, x_out = cluster_gcn_model.build()
     model = keras.Model(inputs=x_in, outputs=x_out)
 
-    # Check fit_generator method
-    preds_2 = model.predict_generator(generator.flow(["a", "b", "c"]))
+    # Check fit method
+    preds_2 = model.predict(generator.flow(["a", "b", "c"]))
     assert preds_2.shape == (1, 3, 2)
 
 

--- a/tests/layer/test_gcn.py
+++ b/tests/layer/test_gcn.py
@@ -153,8 +153,8 @@ def test_GCN_apply_dense():
     preds_1 = model.predict([features[None, :, :], out_indices, adj])
     assert preds_1.shape == (1, 2, 2)
 
-    # Check fit_generator method
-    preds_2 = model.predict_generator(generator.flow(["a", "b"]))
+    # Check fit method
+    preds_2 = model.predict(generator.flow(["a", "b"]))
     assert preds_2.shape == (1, 2, 2)
 
     assert preds_1 == pytest.approx(preds_2)
@@ -182,8 +182,8 @@ def test_GCN_apply_sparse():
     preds_1 = model.predict([features[None, :, :], out_indices, A_indices, A_values])
     assert preds_1.shape == (1, 2, 2)
 
-    # Check fit_generator method
-    preds_2 = model.predict_generator(generator.flow(["a", "b"]))
+    # Check fit method
+    preds_2 = model.predict(generator.flow(["a", "b"]))
     assert preds_2.shape == (1, 2, 2)
 
     assert preds_1 == pytest.approx(preds_2)
@@ -205,8 +205,8 @@ def test_GCN_linkmodel_apply_dense():
     preds_1 = model.predict([features[None, :, :], out_indices, adj])
     assert preds_1.shape == (1, 2, 2, 3)
 
-    # Check fit_generator method
-    preds_2 = model.predict_generator(generator.flow([("a", "b"), ("b", "c")]))
+    # Check fit method
+    preds_2 = model.predict(generator.flow([("a", "b"), ("b", "c")]))
     assert preds_2.shape == (1, 2, 2, 3)
 
     assert preds_1 == pytest.approx(preds_2)
@@ -234,8 +234,8 @@ def test_GCN_linkmodel_apply_sparse():
     preds_1 = model.predict([features[None, :, :], out_indices, A_indices, A_values])
     assert preds_1.shape == (1, 2, 2, 3)
 
-    # Check fit_generator method
-    preds_2 = model.predict_generator(generator.flow([("a", "b"), ("b", "c")]))
+    # Check fit method
+    preds_2 = model.predict(generator.flow([("a", "b"), ("b", "c")]))
     assert preds_2.shape == (1, 2, 2, 3)
 
     assert preds_1 == pytest.approx(preds_2)

--- a/tests/layer/test_graph_attention.py
+++ b/tests/layer/test_graph_attention.py
@@ -507,7 +507,7 @@ class Test_GAT:
         model = keras.Model(inputs=x_in, outputs=x_out)
 
         ng = gen.flow(G.nodes())
-        actual = model.predict_generator(ng)
+        actual = model.predict(ng)
         expected = np.ones((G.number_of_nodes(), self.layer_sizes[-1])) * (
             1.0 / G.number_of_nodes()
         )
@@ -533,7 +533,7 @@ class Test_GAT:
         model = keras.Model(inputs=x_in, outputs=x_out)
 
         ng = gen.flow(G.nodes())
-        actual = model.predict_generator(ng)
+        actual = model.predict(ng)
 
         expected = np.ones((G.number_of_nodes(), self.layer_sizes[-1])) * (
             self.F_in
@@ -586,7 +586,7 @@ class Test_GAT:
         model2.set_weights(model_weights)
 
         # Test deserialized model
-        actual = model2.predict_generator(ng)
+        actual = model2.predict(ng)
         expected = np.ones((G.number_of_nodes(), self.layer_sizes[-1])) * (
             1.0 / G.number_of_nodes()
         )

--- a/tests/layer/test_ppnp.py
+++ b/tests/layer/test_ppnp.py
@@ -71,8 +71,8 @@ def test_PPNP_apply_dense():
     preds_1 = model.predict([features[None, :, :], out_indices, adj])
     assert preds_1.shape == (1, 2, 2)
 
-    # Check fit_generator method
-    preds_2 = model.predict_generator(generator.flow(["a", "b"]))
+    # Check fit method
+    preds_2 = model.predict(generator.flow(["a", "b"]))
     assert preds_2.shape == (1, 2, 2)
 
     assert preds_1 == pytest.approx(preds_2)

--- a/tests/layer/test_rgcn.py
+++ b/tests/layer/test_rgcn.py
@@ -217,8 +217,8 @@ def test_RGCN_apply_sparse():
     preds_1 = model.predict([features[None, :, :], out_indices] + A_indices + A_values)
     assert preds_1.shape == (1, 2, 2)
 
-    # Check fit_generator method
-    preds_2 = model.predict_generator(generator.flow(["a", "b"]))
+    # Check fit method
+    preds_2 = model.predict(generator.flow(["a", "b"]))
     assert preds_2.shape == (1, 2, 2)
 
     assert preds_1 == pytest.approx(preds_2)
@@ -241,8 +241,8 @@ def test_RGCN_apply_dense():
     preds_1 = model.predict([features[None, :, :], out_indices] + As)
     assert preds_1.shape == (1, 2, 2)
 
-    # Check fit_generator method
-    preds_2 = model.predict_generator(generator.flow(["a", "b"]))
+    # Check fit method
+    preds_2 = model.predict(generator.flow(["a", "b"]))
     assert preds_2.shape == (1, 2, 2)
 
     assert preds_1 == pytest.approx(preds_2)
@@ -270,8 +270,8 @@ def test_RGCN_apply_sparse_directed():
     preds_1 = model.predict([features[None, :, :], out_indices] + A_indices + A_values)
     assert preds_1.shape == (1, 2, 2)
 
-    # Check fit_generator method
-    preds_2 = model.predict_generator(generator.flow(["a", "b"]))
+    # Check fit method
+    preds_2 = model.predict(generator.flow(["a", "b"]))
     assert preds_2.shape == (1, 2, 2)
 
     assert preds_1 == pytest.approx(preds_2)
@@ -293,8 +293,8 @@ def test_RGCN_apply_dense_directed():
     preds_1 = model.predict([features[None, :, :], out_indices] + As)
     assert preds_1.shape == (1, 2, 2)
 
-    # Check fit_generator method
-    preds_2 = model.predict_generator(generator.flow(["a", "b"]))
+    # Check fit method
+    preds_2 = model.predict(generator.flow(["a", "b"]))
     assert preds_2.shape == (1, 2, 2)
 
     assert preds_1 == pytest.approx(preds_2)

--- a/tests/reproducibility/test_graphsage.py
+++ b/tests/reproducibility/test_graphsage.py
@@ -78,7 +78,7 @@ def unsup_gs(
 
     model = unsup_gs_model(num_samples, generator, optimizer, bias, dropout, normalize)
 
-    model.fit_generator(
+    model.fit(
         train_gen,
         epochs=epochs,
         verbose=1,
@@ -134,7 +134,7 @@ def gs_nai(
         num_samples, generator, targets, optimizer, bias, dropout, normalize
     )
 
-    model.fit_generator(
+    model.fit(
         train_gen,
         epochs=epochs,
         verbose=1,
@@ -195,7 +195,7 @@ def gs_link_prediction(
         num_samples, generator, optimizer, bias, dropout, normalize
     )
 
-    model.fit_generator(
+    model.fit(
         train_gen,
         epochs=epochs,
         verbose=1,


### PR DESCRIPTION
Tensorflow Keras's Model type has deprecated its `..._generator` methods in Tensorflow 2.1.0.

https://www.tensorflow.org/api_docs/python/tf/keras/Model#fit_generator:

> Warning: THIS FUNCTION IS DEPRECATED. It will be removed in a future version. Instructions for updating: Please use Model.fit, which supports generators. 

https://github.com/tensorflow/tensorflow/releases/tag/v2.1.0-rc1:

> `Model.fit_generator`, `Model.evaluate_generator`, and `Model.predict_generator` are deprecated endpoints. They are subsumed by `Model.fit`, `Model.evaluate`, and `Model.predict` which now support generators and Sequences.

This patch does an automatic replacement of the following, in `*.py` files:

- `fit_generator` → `fit`
- `predict_generator` → `predict`
- `evaluate_generator` → `evaluate`

It does not make any changes to `ensemble.py`/`test_ensemble.py` (#1065), because we define our own `fit_generator` (etc.) methods there, and thus manual work is required. Nor does it do any of the notebooks (#1066), in order to break the work up and reduce merge conflicts (notebooks are more likely to have merge conflicts, and they're more annoying to resolve).

There's a few places where manual changes might be good (e.g. mistakes in comments), but I'd prefer not to do them here: keeping this fully automated makes it easy to resolve any merge conflicts (revert the file to the other form, and then redo the automated replacement). As you review, feel free to do some manual changes as your own separate branch/PR.

See: #803