### PR TITLE
Deprecate and replace *_generator with * in ensemble.py

### DIFF
--- a/stellargraph/ensemble.py
+++ b/stellargraph/ensemble.py
@@ -188,7 +188,7 @@ class Ensemble(object):
 
         self.metrics_names = self.models[0].metrics_names  # assumes all models are same
 
-    def fit_generator(
+    def fit(
         self,
         generator,
         steps_per_epoch=None,
@@ -277,8 +277,8 @@ class Ensemble(object):
 
         for model in self.models:
             self.history.append(
-                model.fit_generator(
-                    generator=generator,
+                model.fit(
+                    generator,
                     steps_per_epoch=steps_per_epoch,
                     epochs=epochs,
                     verbose=verbose,
@@ -296,7 +296,17 @@ class Ensemble(object):
 
         return self.history
 
-    def evaluate_generator(
+    def fit_generator(self, *args, **kwargs):
+        """
+        Deprecated: use :meth:`fit`.
+        """
+        warnings.warn(
+            "'fit_generator' has been replaced by 'fit', to match tensorflow.keras.Model",
+            DeprecationWarning,
+        )
+        return self.fit(*args, **kwargs)
+
+    def evaluate(
         self,
         generator,
         test_data=None,
@@ -376,8 +386,8 @@ class Ensemble(object):
             tm = []
             for _ in range(self.n_predictions):
                 tm.append(
-                    model.evaluate_generator(
-                        generator=data_generator,
+                    model.evaluate(
+                        data_generator,
                         max_queue_size=max_queue_size,
                         workers=workers,
                         use_multiprocessing=use_multiprocessing,
@@ -389,7 +399,17 @@ class Ensemble(object):
         # Return the mean and standard deviation of the metrics
         return np.mean(test_metrics, axis=0), np.std(test_metrics, axis=0)
 
-    def predict_generator(
+    def evaluate_generator(self, *args, **kwargs):
+        """
+        Deprecated: use :meth:`evaluate`.
+        """
+        warnings.warn(
+            "'evaluate_generator' has been replaced by 'evaluate', to match tensorflow.keras.Model",
+            DeprecationWarning,
+        )
+        return self.evaluate(*args, **kwargs)
+
+    def predict(
         self,
         generator,
         predict_data=None,
@@ -480,8 +500,8 @@ class Ensemble(object):
             model_predictions = []
             for _ in range(self.n_predictions):
                 model_predictions.append(
-                    model.predict_generator(
-                        generator=data_generator,
+                    model.predict(
+                        data_generator,
                         max_queue_size=max_queue_size,
                         workers=workers,
                         use_multiprocessing=use_multiprocessing,
@@ -501,6 +521,16 @@ class Ensemble(object):
         #     predictions = predictions.reshape(predictions.shape[0:3] + (-1,))
 
         return predictions
+
+    def predict_generator(self, *args, **kwargs):
+        """
+        Deprecated: use :meth:`predict`.
+        """
+        warnings.warn(
+            "'predict_generator' has been replaced by 'predict', to match tensorflow.keras.Model",
+            DeprecationWarning,
+        )
+        return self.predict(*args, **kwargs)
 
 
 #
@@ -532,7 +562,7 @@ class BaggingEnsemble(Ensemble):
             model=model, n_estimators=n_estimators, n_predictions=n_predictions
         )
 
-    def fit_generator(
+    def fit(
         self,
         generator,
         train_data,
@@ -662,8 +692,8 @@ class BaggingEnsemble(Ensemble):
                 ]
 
             self.history.append(
-                model.fit_generator(
-                    generator=di_gen,
+                model.fit(
+                    di_gen,
                     steps_per_epoch=steps_per_epoch,
                     epochs=epochs,
                     verbose=verbose,
@@ -680,3 +710,13 @@ class BaggingEnsemble(Ensemble):
             )
 
         return self.history
+
+    def fit_generator(self, *args, **kwargs):
+        """
+        Deprecated: use :meth:`fit`.
+        """
+        warnings.warn(
+            "'fit_generator' has been replaced by 'fit', to match tensorflow.keras.Model",
+            DeprecationWarning,
+        )
+        return self.fit(*args, **kwargs)

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -317,7 +317,7 @@ def test_compile():
             )
 
 
-def test_Ensemble_fit_generator():
+def test_Ensemble_fit():
     tf.keras.backend.clear_session()
 
     graph = example_graph_1(feature_size=10)
@@ -341,10 +341,10 @@ def test_Ensemble_fit_generator():
             optimizer=Adam(), loss=categorical_crossentropy, weighted_metrics=["acc"]
         )
 
-        ens.fit_generator(train_gen, epochs=1, verbose=0, shuffle=False)
+        ens.fit(train_gen, epochs=1, verbose=0, shuffle=False)
 
         with pytest.raises(ValueError):
-            ens.fit_generator(
+            ens.fit(
                 generator=generator,  # wrong type
                 epochs=10,
                 validation_data=train_gen,
@@ -353,7 +353,7 @@ def test_Ensemble_fit_generator():
             )
 
 
-def test_BaggingEnsemble_fit_generator():
+def test_BaggingEnsemble_fit():
     tf.keras.backend.clear_session()
 
     train_data = np.array([1, 2])
@@ -380,7 +380,7 @@ def test_BaggingEnsemble_fit_generator():
             optimizer=Adam(), loss=categorical_crossentropy, weighted_metrics=["acc"]
         )
 
-        ens.fit_generator(
+        ens.fit(
             generator=generator,
             train_data=train_data,
             train_targets=train_targets,
@@ -392,7 +392,7 @@ def test_BaggingEnsemble_fit_generator():
 
         # This is a BaggingEnsemble so the generator in the below call is of the wrong type.
         with pytest.raises(ValueError):
-            ens.fit_generator(
+            ens.fit(
                 train_gen,
                 train_data=train_data,
                 train_targets=train_targets,
@@ -402,7 +402,7 @@ def test_BaggingEnsemble_fit_generator():
             )
 
         with pytest.raises(ValueError):
-            ens.fit_generator(
+            ens.fit(
                 generator=generator,
                 train_data=train_data,
                 train_targets=None,  # Should not be None
@@ -413,7 +413,7 @@ def test_BaggingEnsemble_fit_generator():
             )
 
         with pytest.raises(ValueError):
-            ens.fit_generator(
+            ens.fit(
                 generator=generator,
                 train_data=None,
                 train_targets=None,
@@ -424,7 +424,7 @@ def test_BaggingEnsemble_fit_generator():
             )
 
         with pytest.raises(ValueError):
-            ens.fit_generator(
+            ens.fit(
                 generator=generator,
                 train_data=train_data,
                 train_targets=train_targets,
@@ -436,7 +436,7 @@ def test_BaggingEnsemble_fit_generator():
             )
 
         with pytest.raises(ValueError):
-            ens.fit_generator(
+            ens.fit(
                 generator=generator,
                 train_data=train_data,
                 train_targets=train_targets,
@@ -448,7 +448,7 @@ def test_BaggingEnsemble_fit_generator():
             )
 
 
-def test_evaluate_generator():
+def test_evaluate():
     tf.keras.backend.clear_session()
 
     test_data = np.array([3, 4, 5])
@@ -477,27 +477,27 @@ def test_evaluate_generator():
         # Check that passing invalid parameters is handled correctly. We will not check error handling for those
         # parameters that Keras will be responsible for.
         with pytest.raises(ValueError):
-            ens.evaluate_generator(
+            ens.evaluate(
                 generator=generator, test_data=test_data, test_targets=test_targets
             )
 
         with pytest.raises(ValueError):
-            ens.evaluate_generator(
+            ens.evaluate(
                 generator=generator,
                 test_data=test_data,
                 test_targets=None,  # must give test_targets
             )
 
         with pytest.raises(ValueError):
-            ens.evaluate_generator(
+            ens.evaluate(
                 generator=generator.flow(test_data, test_targets),
                 test_data=test_data,
                 test_targets=test_targets,
             )
 
         # We won't train the model instead use the initial random weights to test
-        # the evaluate_generator method.
-        test_metrics_mean, test_metrics_std = ens.evaluate_generator(
+        # the evaluate method.
+        test_metrics_mean, test_metrics_std = ens.evaluate(
             generator.flow(test_data, test_targets)
         )
 
@@ -517,27 +517,27 @@ def test_evaluate_generator():
         # Check that passing invalid parameters is handled correctly. We will not check error handling for those
         # parameters that Keras will be responsible for.
         with pytest.raises(ValueError):
-            ens.evaluate_generator(
+            ens.evaluate(
                 generator=generator, test_data=test_data, test_targets=test_targets
             )
 
         with pytest.raises(ValueError):
-            ens.evaluate_generator(
+            ens.evaluate(
                 generator=generator,
                 test_data=test_data,
                 test_targets=None,  # must give test_targets
             )
 
         with pytest.raises(ValueError):
-            ens.evaluate_generator(
+            ens.evaluate(
                 generator=generator.flow(test_data, test_targets),
                 test_data=test_data,
                 test_targets=test_targets,
             )
 
         # We won't train the model instead use the initial random weights to test
-        # the evaluate_generator method.
-        test_metrics_mean, test_metrics_std = ens.evaluate_generator(
+        # the evaluate method.
+        test_metrics_mean, test_metrics_std = ens.evaluate(
             generator.flow(test_data, test_targets)
         )
 
@@ -546,7 +546,7 @@ def test_evaluate_generator():
         assert len(test_metrics_std.shape) == 1
 
 
-def test_predict_generator():
+def test_predict():
 
     tf.keras.backend.clear_session()
 
@@ -578,11 +578,11 @@ def test_predict_generator():
         # Check that passing invalid parameters is handled correctly. We will not check error handling for those
         # parameters that Keras will be responsible for.
         with pytest.raises(ValueError):
-            ens.predict_generator(generator=test_gen, predict_data=test_data)
+            ens.predict(generator=test_gen, predict_data=test_data)
 
         # We won't train the model instead use the initial random weights to test
-        # the evaluate_generator method.
-        test_predictions = ens.predict_generator(test_gen, summarise=True)
+        # the evaluate method.
+        test_predictions = ens.predict(test_gen, summarise=True)
 
         print("test_predictions shape {}".format(test_predictions.shape))
         if i > 1:
@@ -593,7 +593,7 @@ def test_predict_generator():
             assert len(test_predictions) == len(test_data)
         assert test_predictions.shape[-1] == test_targets.shape[-1]
 
-        test_predictions = ens.predict_generator(test_gen, summarise=False)
+        test_predictions = ens.predict(test_gen, summarise=False)
 
         assert test_predictions.shape[0] == ens.n_estimators
         assert test_predictions.shape[1] == ens.n_predictions
@@ -615,11 +615,11 @@ def test_predict_generator():
         # Check that passing invalid parameters is handled correctly. We will not check error handling for those
         # parameters that Keras will be responsible for.
         with pytest.raises(ValueError):
-            ens.predict_generator(generator=test_gen, predict_data=test_data)
+            ens.predict(generator=test_gen, predict_data=test_data)
 
         # We won't train the model instead use the initial random weights to test
-        # the evaluate_generator method.
-        test_predictions = ens.predict_generator(test_gen, summarise=True)
+        # the evaluate method.
+        test_predictions = ens.predict(test_gen, summarise=True)
 
         print("test_predictions shape {}".format(test_predictions.shape))
         if i > 1:
@@ -630,7 +630,7 @@ def test_predict_generator():
             assert len(test_predictions) == len(test_data)
         assert test_predictions.shape[-1] == test_targets.shape[-1]
 
-        test_predictions = ens.predict_generator(test_gen, summarise=False)
+        test_predictions = ens.predict(test_gen, summarise=False)
 
         assert test_predictions.shape[0] == ens.n_estimators
         assert test_predictions.shape[1] == ens.n_predictions
@@ -644,7 +644,7 @@ def test_predict_generator():
 #
 # Tests for link prediction that can't be combined easily with the node attribute inference workflow above.
 #
-def test_evaluate_generator_link_prediction():
+def test_evaluate_link_prediction():
     tf.keras.backend.clear_session()
     edge_ids_test = np.array([[1, 2], [2, 3], [1, 3]])
     edge_labels_test = np.array([1, 1, 0])
@@ -670,29 +670,29 @@ def test_evaluate_generator_link_prediction():
         # Check that passing invalid parameters is handled correctly. We will not check error handling for those
         # parameters that Keras will be responsible for.
         with pytest.raises(ValueError):
-            ens.evaluate_generator(
+            ens.evaluate(
                 generator=generator,
                 test_data=edge_ids_test,
                 test_targets=edge_labels_test,
             )
 
         with pytest.raises(ValueError):
-            ens.evaluate_generator(
+            ens.evaluate(
                 generator=generator,
                 test_data=edge_labels_test,
                 test_targets=None,  # must give test_targets
             )
 
         with pytest.raises(ValueError):
-            ens.evaluate_generator(
+            ens.evaluate(
                 generator=generator.flow(edge_ids_test, edge_labels_test),
                 test_data=edge_ids_test,
                 test_targets=edge_labels_test,
             )
 
         # We won't train the model instead use the initial random weights to test
-        # the evaluate_generator method.
-        test_metrics_mean, test_metrics_std = ens.evaluate_generator(
+        # the evaluate method.
+        test_metrics_mean, test_metrics_std = ens.evaluate(
             generator.flow(edge_ids_test, edge_labels_test)
         )
 
@@ -712,29 +712,29 @@ def test_evaluate_generator_link_prediction():
         # Check that passing invalid parameters is handled correctly. We will not check error handling for those
         # parameters that Keras will be responsible for.
         with pytest.raises(ValueError):
-            ens.evaluate_generator(
+            ens.evaluate(
                 generator=generator,
                 test_data=edge_ids_test,
                 test_targets=edge_labels_test,
             )
 
         with pytest.raises(ValueError):
-            ens.evaluate_generator(
+            ens.evaluate(
                 generator=generator,
                 test_data=edge_labels_test,
                 test_targets=None,  # must give test_targets
             )
 
         with pytest.raises(ValueError):
-            ens.evaluate_generator(
+            ens.evaluate(
                 generator=generator.flow(edge_ids_test, edge_labels_test),
                 test_data=edge_ids_test,
                 test_targets=edge_labels_test,
             )
 
         # We won't train the model instead use the initial random weights to test
-        # the evaluate_generator method.
-        test_metrics_mean, test_metrics_std = ens.evaluate_generator(
+        # the evaluate method.
+        test_metrics_mean, test_metrics_std = ens.evaluate(
             generator.flow(edge_ids_test, edge_labels_test)
         )
 
@@ -743,7 +743,7 @@ def test_evaluate_generator_link_prediction():
         assert len(test_metrics_std.shape) == 1
 
 
-def test_predict_generator_link_prediction():
+def test_predict_link_prediction():
     tf.keras.backend.clear_session()
     edge_ids_test = np.array([[1, 2], [2, 3], [1, 3]])
 
@@ -769,18 +769,18 @@ def test_predict_generator_link_prediction():
         # Check that passing invalid parameters is handled correctly. We will not check error handling for those
         # parameters that Keras will be responsible for.
         with pytest.raises(ValueError):
-            ens.predict_generator(generator=test_gen, predict_data=edge_ids_test)
+            ens.predict(generator=test_gen, predict_data=edge_ids_test)
 
         # We won't train the model instead use the initial random weights to test
-        # the evaluate_generator method.
-        test_predictions = ens.predict_generator(test_gen, summarise=True)
+        # the evaluate method.
+        test_predictions = ens.predict(test_gen, summarise=True)
 
         print("test_predictions shape {}".format(test_predictions.shape))
         assert len(test_predictions) == len(edge_ids_test)
 
         assert test_predictions.shape[1] == 1
 
-        test_predictions = ens.predict_generator(test_gen, summarise=False)
+        test_predictions = ens.predict(test_gen, summarise=False)
 
         assert test_predictions.shape[0] == ens.n_estimators
         assert test_predictions.shape[1] == ens.n_predictions
@@ -799,20 +799,62 @@ def test_predict_generator_link_prediction():
         # Check that passing invalid parameters is handled correctly. We will not check error handling for those
         # parameters that Keras will be responsible for.
         with pytest.raises(ValueError):
-            ens.predict_generator(generator=test_gen, predict_data=edge_ids_test)
+            ens.predict(generator=test_gen, predict_data=edge_ids_test)
 
         # We won't train the model instead use the initial random weights to test
-        # the evaluate_generator method.
-        test_predictions = ens.predict_generator(test_gen, summarise=True)
+        # the evaluate method.
+        test_predictions = ens.predict(test_gen, summarise=True)
 
         print("test_predictions shape {}".format(test_predictions.shape))
         assert len(test_predictions) == len(edge_ids_test)
 
         assert test_predictions.shape[1] == 1
 
-        test_predictions = ens.predict_generator(test_gen, summarise=False)
+        test_predictions = ens.predict(test_gen, summarise=False)
 
         assert test_predictions.shape[0] == ens.n_estimators
         assert test_predictions.shape[1] == ens.n_predictions
         assert test_predictions.shape[2] == len(edge_ids_test)
         assert test_predictions.shape[3] == 1
+
+
+def test_deprecated_methods():
+    tf.keras.backend.clear_session()
+
+    train_data = np.array([1, 2])
+    train_targets = np.array([[1, 0], [0, 1]])
+
+    graph = example_graph_1(feature_size=2)
+
+    _, keras_model, gen, train_gen = create_GAT_model(graph)
+
+    ensemble = Ensemble(keras_model, n_estimators=1, n_predictions=1)
+    bagging = BaggingEnsemble(keras_model, n_estimators=1, n_predictions=1)
+    models = [ensemble, bagging]
+    for model in models:
+        model.compile(optimizer=Adam(), loss=binary_crossentropy)
+
+    # check that each of the generator methods gives a warning, and also seems to behave like the
+    # non-deprecated method
+    with pytest.warns(DeprecationWarning, match="'fit_generator' .* 'fit'"):
+        ens_history = ensemble.fit_generator(train_gen, epochs=2, verbose=0)
+    assert len(ens_history) == 1
+    assert len(ens_history[0].history["loss"]) == 2
+
+    with pytest.warns(DeprecationWarning, match="'fit_generator' .* 'fit'"):
+        bag_history = bagging.fit_generator(
+            gen, train_data, train_targets, epochs=2, verbose=0
+        )
+    assert len(bag_history) == 1
+    assert len(bag_history[0].history["loss"]) == 2
+
+    for model in models:
+        with pytest.warns(
+            DeprecationWarning, match="'evaluate_generator' .* 'evaluate'"
+        ):
+            eval_result = model.evaluate_generator(train_gen, verbose=0)
+        np.testing.assert_array_equal(eval_result, model.evaluate(train_gen, verbose=0))
+
+        with pytest.warns(DeprecationWarning, match="'predict_generator' .* 'predict'"):
+            pred_result = model.predict_generator(train_gen, verbose=0)
+        np.testing.assert_array_equal(pred_result, model.predict(train_gen, verbose=0))


### PR DESCRIPTION
Tensorflow Keras's Model type has deprecated its `..._generator` methods in Tensorflow 2.1.0.

https://www.tensorflow.org/api_docs/python/tf/keras/Model#fit_generator:

> Warning: THIS FUNCTION IS DEPRECATED. It will be removed in a future version. Instructions for updating: Please use Model.fit, which supports generators. 

https://github.com/tensorflow/tensorflow/releases/tag/v2.1.0-rc1:

> `Model.fit_generator`, `Model.evaluate_generator`, and `Model.predict_generator` are deprecated endpoints. They are subsumed by `Model.fit`, `Model.evaluate`, and `Model.predict` which now support generators and Sequences.

This deprecates the following methods we define on `Ensemble` that match Keras `Model` methods and replaces them with the corresponding Keras replacement:

- `fit_generator` → `fit`
- `predict_generator` → `predict`
- `evaluate_generator` → `evaluate`

The existing methods still work with a warning, to avoid breaking users and help them to migrate. It doesn't do any replacements in the notebooks, because, once this lands, all notebooks can have the replacement done automatically (#1066).

See: #803