### PR TITLE
Mark Neo4j notebooks passed in demo notebook testing, not soft-fail

### DIFF
--- a/.buildkite/steps/test-demo-notebooks.sh
+++ b/.buildkite/steps/test-demo-notebooks.sh
@@ -34,7 +34,6 @@ f=${NOTEBOOKS[$INDEX]}
 case $(basename "$f") in
   'attacks_clustering_analysis.ipynb' | 'hateful-twitters-interpretability.ipynb' | 'hateful-twitters.ipynb' | 'stellargraph-attri2vec-DBLP.ipynb' | \
     'node-link-importance-demo-gat.ipynb' | 'node-link-importance-demo-gcn.ipynb' | 'node-link-importance-demo-gcn-sparse.ipynb' | 'rgcn-aifb-node-classification-example.ipynb' | \
-    'directed-graphsage-on-cora-neo4j-example.ipynb' | 'undirected-graphsage-on-cora-neo4j-example.ipynb' | 'load-cora-into-neo4j.ipynb' | \
     'stellargraph-metapath2vec.ipynb')
     # These notebooks do not yet work on CI:
     # FIXME #818: datasets can't be downloaded
@@ -43,6 +42,12 @@ case $(basename "$f") in
     # FIXME #907: socialcomputing.asu.edu is down
     echo "+++ :python: :skull_and_crossbones: skipping $f"
     exit 2 # this will be a soft-fail for buildkite
+    ;;
+
+  'directed-graphsage-on-cora-neo4j-example.ipynb' | 'undirected-graphsage-on-cora-neo4j-example.ipynb' | 'load-cora-into-neo4j.ipynb')
+    # these are tested separately (see test-neo4j-notebooks.sh)
+    echo "+++ :python: skipping Neo4j notebook $f"
+    exit 0
     ;;
 esac
 


### PR DESCRIPTION
We're now testing the Neo4j notebooks on CI (#1046), as a separate step to the main demo notebook testing one. The notebooks cannot be run in main step because they have dependencies (the GraphSAGE notebooks need to run the Cora ingestion notebook first, and all of them need to have py2neo installed), and so its correct to filter them out of that step, however filtering them out as "soft failures" is misleading: these notebooks aren't temporarily broken, they're permanently being tested elsewhere.

We can thus make our build summary convey exactly how many notebooks we're not testing (9 out of 36), by marking the parallel jobs that "run" (i.e. skip) the neo4j notebooks as passed, since they've successfully done what they're meant to do.