### PR TITLE
Fix docs for generators

### DIFF
--- a/docs/api.txt
+++ b/docs/api.txt
@@ -5,7 +5,7 @@ Core
 ----------------
 
 .. automodule:: stellargraph.core
-  :members: StellarGraph, GraphSchema
+  :members: StellarGraph, StellarDiGraph, GraphSchema
 
 
 Data

--- a/stellargraph/mapper/full_batch_generators.py
+++ b/stellargraph/mapper/full_batch_generators.py
@@ -237,8 +237,7 @@ class FullBatchNodeGenerator(FullBatchGenerator):
         # Alternatively, use the generator itself with model.fit_generator:
         model.fit_generator(train_flow, epochs=num_epochs)
 
-    For more information, please see the GCN/GAT, PPNP/APPNP and SGC demos:
-        `<https://github.com/stellargraph/stellargraph/blob/master/demos/>`_
+    For more information, please see the GCN, GAT, PPNP/APPNP and SGC demos: `<https://github.com/stellargraph/stellargraph/blob/master/demos/>`_
 
     Args:
         G (StellarGraphBase): a machine-learning StellarGraph-type graph
@@ -323,8 +322,7 @@ class FullBatchLinkGenerator(FullBatchGenerator):
         # Alternatively, use the generator itself with model.fit_generator:
         model.fit_generator(train_flow, epochs=num_epochs)
 
-    For more information, please see the GCN, GAT, PPNP/APPNP and SGC demos:
-        `<https://github.com/stellargraph/stellargraph/blob/master/demos/>`_
+    For more information, please see the GCN, GAT, PPNP/APPNP and SGC demos: `<https://github.com/stellargraph/stellargraph/blob/master/demos/>`_
 
     Args:
         G (StellarGraphBase): a machine-learning StellarGraph-type graph

--- a/stellargraph/mapper/mini_batch_node_generators.py
+++ b/stellargraph/mapper/mini_batch_node_generators.py
@@ -46,8 +46,7 @@ class ClusterNodeGenerator:
 
     [1] `W. Chiang, X. Liu, S. Si, Y. Li, S. Bengio, C. Hsieh, 2019 <https://arxiv.org/abs/1905.07953>`_.
 
-    For more information, please see the ClusterGCN demo:
-        `<https://github.com/stellargraph/stellargraph/blob/master/demos/>`_
+    For more information, please see the ClusterGCN demo: `<https://github.com/stellargraph/stellargraph/blob/master/demos/>`_
 
     Args:
         G (StellarGraph): a machine-learning StellarGraph-type graph

--- a/stellargraph/mapper/sampled_node_generators.py
+++ b/stellargraph/mapper/sampled_node_generators.py
@@ -43,7 +43,7 @@ from ..data import (
     SampledHeterogeneousBreadthFirstWalk,
     DirectedBreadthFirstNeighbours,
 )
-from ..core.graph import StellarGraph, StellarDiGraph, GraphSchema
+from ..core.graph import StellarGraph, GraphSchema
 from ..core.utils import is_real_iterable
 from . import NodeSequence
 from ..random import SeededPerBatch

--- a/stellargraph/mapper/sampled_node_generators.py
+++ b/stellargraph/mapper/sampled_node_generators.py
@@ -43,7 +43,7 @@ from ..data import (
     SampledHeterogeneousBreadthFirstWalk,
     DirectedBreadthFirstNeighbours,
 )
-from ..core.graph import StellarGraph, GraphSchema
+from ..core.graph import StellarGraph, StellarDiGraph, GraphSchema
 from ..core.utils import is_real_iterable
 from . import NodeSequence
 from ..random import SeededPerBatch


### PR DESCRIPTION
This fixes poorly formatted docstrings for various generator classes.

`StellarDiGraph` has been added to our API docs to support links to
that class - I think we do want this class in our docs if we expect a
user to create a graph of that type to pass into various methods.

Part of #866 

Links for convenience:

* directed graphsage node generator https://stellargraph--1068.org.readthedocs.build/en/1068/api.html#stellargraph.mapper.DirectedGraphSAGENodeGenerator
* full batch node generator https://stellargraph--1068.org.readthedocs.build/en/1068/api.html#stellargraph.mapper.FullBatchNodeGenerator
* full batch link generator https://stellargraph--1068.org.readthedocs.build/en/1068/api.html#stellargraph.mapper.FullBatchLinkGenerator
* cluster node generator https://stellargraph--1068.org.readthedocs.build/en/1068/api.html#stellargraph.mapper.ClusterNodeGenerator