### PR TITLE
Allow `from_networkx(node_features=...)` without listing all node types

### DIFF
--- a/stellargraph/core/convert.py
+++ b/stellargraph/core/convert.py
@@ -206,15 +206,16 @@ def _features_from_node_data(nodes, data, dtype):
 
         def single(node_type):
             node_info = nodes[node_type]
-            this_data = data.get(node_type)
-
-            if this_data is None:
+            try:
+                this_data = data[node_type]
+            except KeyError:
                 # no data specified for this type, so len(feature vector) = 0 for each node (this
                 # uses a range index for columns, to match the behaviour of the other feature
                 # converters here, that build DataFrames from NumPy arrays even when there's no
                 # data, i.e. array.shape = (num nodes, 0))
-                df = pd.DataFrame(columns=range(0), index=node_info.ids)
-            elif isinstance(this_data, pd.DataFrame):
+                this_data = pd.DataFrame(columns=range(0), index=node_info.ids)
+
+            if isinstance(this_data, pd.DataFrame):
                 df = this_data.astype(dtype, copy=False)
             elif isinstance(this_data, (Iterable, list)):
                 # this functionality is a bit peculiar (Pandas is generally nicer), and is

--- a/stellargraph/core/convert.py
+++ b/stellargraph/core/convert.py
@@ -206,9 +206,15 @@ def _features_from_node_data(nodes, data, dtype):
 
         def single(node_type):
             node_info = nodes[node_type]
-            this_data = data[node_type]
+            this_data = data.get(node_type)
 
-            if isinstance(this_data, pd.DataFrame):
+            if this_data is None:
+                # no data specified for this type, so len(feature vector) = 0 for each node (this
+                # uses a range index for columns, to match the behaviour of the other feature
+                # converters here, that build DataFrames from NumPy arrays even when there's no
+                # data, i.e. array.shape = (num nodes, 0))
+                df = pd.DataFrame(columns=range(0), index=node_info.ids)
+            elif isinstance(this_data, pd.DataFrame):
                 df = this_data.astype(dtype, copy=False)
             elif isinstance(this_data, (Iterable, list)):
                 # this functionality is a bit peculiar (Pandas is generally nicer), and is

--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -328,6 +328,9 @@ class StellarGraph:
             }
             Gs = StellarGraph.from_networkx(nx_graph, node_features=node_data)
 
+        The dictionary only needs to include node types with features. If a node type isn't
+        mentioned in the dictionary (for example, if `nx_graph` above has a 3rd node type), each
+        node of that type will have a feature vector of length zero.
 
         You can also supply the node feature vectors as an iterator of `node_id`
         and feature vector pairs, for graphs with single and multiple node types::

--- a/tests/core/test_convert.py
+++ b/tests/core/test_convert.py
@@ -316,7 +316,7 @@ def test_from_networkx_heterogeneous_features(feature_type, dtype):
         node_features = {
             "a": pd.DataFrame(a_features, index=[0, 2]),
             "b": pd.DataFrame(b_features, index=[1]),
-            "c": pd.DataFrame(columns=range(0), index=[3]),
+            # c is implied
         }
     elif feature_type == "iterable no types":
         node_features = zip([0, 2, 1, 3], a_features + b_features + [[]])


### PR DESCRIPTION
This makes `from_networkx` more user-friendly and intuitive, by only requiring callers to list the node types that have at least one feature per node, since it's easy to infer the features for nodes with zero.

That is, suppose a graph has node types `a` and `b`, and `a` has length 3 feature vectors, and `b` has no features (length 0 feature vectors). With this PR, this might work like:

```python
import networkx as nx
import pandas as pd
import stellargraph as sg

g = nx.Graph()
g.add_node(1, label="a")
g.add_node(2, label="b")

a_features = pd.DataFrame([(1, -2, 0.3)], index=[1])

sg.StellarGraph.from_networkx(g, node_features={"a": a_features})
```

Previously, the `from_networkx`, call above would fail with `KeyError: 'b'`, and `from_networkx` would instead have to be invoked with `node_features={"a": a_features, "b": b_features}`, where `b_features = pd.DataFrame(index=[2])`. This PR likely simplifies real-world uses even more, because there may be many node types without features (the example in #1059) and even when there's only a few, computing the appropriate nodes to use in the `index` can be difficult.


See: #1059 