### PR TITLE
Switch the `input_dim` argument to a real argument

### DIFF
--- a/stellargraph/layer/appnp.py
+++ b/stellargraph/layer/appnp.py
@@ -53,11 +53,20 @@ class APPNPPropagationLayer(Layer):
                             if True it returns the subset specified by the indices passed to it.
         teleport_probability: "probability" of returning to the starting node in the propogation step as desribed  in
         the paper (alpha in the paper)
+        input_dim (int, optional): the size of the input shape, if known.
+        kwargs: any additional arguments to pass to :class:`tensorflow.keras.layers.Layer`
     """
 
-    def __init__(self, units, teleport_probability=0.1, final_layer=False, **kwargs):
-        if "input_shape" not in kwargs and "input_dim" in kwargs:
-            kwargs["input_shape"] = (kwargs.get("input_dim"),)
+    def __init__(
+        self,
+        units,
+        teleport_probability=0.1,
+        final_layer=False,
+        input_dim=None,
+        **kwargs
+    ):
+        if "input_shape" not in kwargs and input_dim is not None:
+            kwargs["input_shape"] = (input_dim,)
 
         super().__init__(**kwargs)
 

--- a/stellargraph/layer/cluster_gcn.py
+++ b/stellargraph/layer/cluster_gcn.py
@@ -63,6 +63,8 @@ class ClusterGraphConvolution(Layer):
         activity_regularizer (str): not used in the current implementation
         kernel_constraint (str): constraint applied to layer's kernel
         bias_constraint (str): constraint applied to layer's bias
+        input_dim (int, optional): the size of the input shape, if known.
+        kwargs: any additional arguments to pass to :class:`tensorflow.keras.layers.Layer`
     """
 
     def __init__(
@@ -78,10 +80,11 @@ class ClusterGraphConvolution(Layer):
         activity_regularizer=None,
         kernel_constraint=None,
         bias_constraint=None,
+        input_dim=None,
         **kwargs,
     ):
-        if "input_shape" not in kwargs and "input_dim" in kwargs:
-            kwargs["input_shape"] = (kwargs.get("input_dim"),)
+        if "input_shape" not in kwargs and input_dim is not None:
+            kwargs["input_shape"] = (input_dim,)
 
         super().__init__(**kwargs)
 

--- a/stellargraph/layer/ppnp.py
+++ b/stellargraph/layer/ppnp.py
@@ -58,7 +58,7 @@ class PPNPPropagationLayer(Layer):
         kwargs: any additional arguments to pass to :class:`tensorflow.keras.layers.Layer`
     """
 
-    def __init__(self, units, final_layer=False, input_dim=None, u**kwargs):
+    def __init__(self, units, final_layer=False, input_dim=None, **kwargs):
         if "input_shape" not in kwargs and input_dim is not None:
             kwargs["input_shape"] = (input_dim,)
 

--- a/stellargraph/layer/ppnp.py
+++ b/stellargraph/layer/ppnp.py
@@ -58,7 +58,7 @@ class PPNPPropagationLayer(Layer):
         kwargs: any additional arguments to pass to :class:`tensorflow.keras.layers.Layer`
     """
 
-    def __init__(self, units, final_layer=False, **kwargs):
+    def __init__(self, units, final_layer=False, input_dim=None, u**kwargs):
         if "input_shape" not in kwargs and input_dim is not None:
             kwargs["input_shape"] = (input_dim,)
 

--- a/stellargraph/layer/ppnp.py
+++ b/stellargraph/layer/ppnp.py
@@ -54,11 +54,13 @@ class PPNPPropagationLayer(Layer):
         units (int): dimensionality of output feature vectors
         final_layer (bool): If False the layer returns output for all nodes,
                             if True it returns the subset specified by the indices passed to it.
+        input_dim (int, optional): the size of the input shape, if known.
+        kwargs: any additional arguments to pass to :class:`tensorflow.keras.layers.Layer`
     """
 
     def __init__(self, units, final_layer=False, **kwargs):
-        if "input_shape" not in kwargs and "input_dim" in kwargs:
-            kwargs["input_shape"] = (kwargs.get("input_dim"),)
+        if "input_shape" not in kwargs and input_dim is not None:
+            kwargs["input_shape"] = (input_dim,)
 
         super().__init__(**kwargs)
 

--- a/stellargraph/layer/rgcn.py
+++ b/stellargraph/layer/rgcn.py
@@ -78,6 +78,8 @@ class RelationalGraphConvolution(Layer):
                 defaults to None.
             bias_constraint (str or func): The constraint to use for the bias;
                 defaults to None.
+            input_dim (int, optional): the size of the input shape, if known.
+            kwargs: any additional arguments to pass to :class:`tensorflow.keras.layers.Layer`
         """
 
     def __init__(
@@ -88,10 +90,11 @@ class RelationalGraphConvolution(Layer):
         activation=None,
         use_bias=True,
         final_layer=False,
+        input_dim=None,
         **kwargs
     ):
-        if "input_shape" not in kwargs and "input_dim" in kwargs:
-            kwargs["input_shape"] = (kwargs.get("input_dim"),)
+        if "input_shape" not in kwargs and input_dim is not None:
+            kwargs["input_shape"] = (input_dim,)
 
         super().__init__(**kwargs)
 


### PR DESCRIPTION
If we're going to support this argument, we should include it as a real argument. This PR switches it to a real argument (and documents it) in the classes for which it is the only `kwargs` that StellarGraph uses; that is, after this patch the `kwargs` parameter is not used for anything in these classes except for passing through to `tf.keras.Layer`.

See: #801