### PR TITLE
Make benchmarks run for less time on CI

### DIFF
--- a/.buildkite/steps/script.sh
+++ b/.buildkite/steps/script.sh
@@ -18,7 +18,7 @@ echo "+++ running tests"
 # so there's no point spending too much time. It's good to check that the benchmark does run
 # successfully as a benchmark (that is, multiple iterations, not just once, as a test with
 # --benchmark-disable)
-small_benchmarks=("--benchmark-max-time=0.01" "--benchmark-warmup=off" "--benchmark-min-rounds=2")
+small_benchmarks=("--benchmark-disable" "--benchmark-max-time=0.01" "--benchmark-warmup=off" "--benchmark-min-rounds=2")
 
 py.test -ra --cov=stellargraph tests/ --doctest-modules --cov-report=xml -p no:cacheprovider --junitxml="./${junit_file}" "${small_benchmarks[@]}" || exitCode=$?
 

--- a/.buildkite/steps/script.sh
+++ b/.buildkite/steps/script.sh
@@ -18,7 +18,7 @@ echo "+++ running tests"
 # so there's no point spending too much time. It's good to check that the benchmark does run
 # successfully as a benchmark (that is, multiple iterations, not just once, as a test with
 # --benchmark-disable)
-small_benchmarks=("--benchmark-disable" "--benchmark-max-time=0.01" "--benchmark-warmup=off" "--benchmark-min-rounds=2")
+small_benchmarks=("--benchmark-max-time=0.01" "--benchmark-warmup=off" "--benchmark-min-rounds=2")
 
 py.test -ra --cov=stellargraph tests/ --doctest-modules --cov-report=xml -p no:cacheprovider --junitxml="./${junit_file}" "${small_benchmarks[@]}" || exitCode=$?
 

--- a/.buildkite/steps/script.sh
+++ b/.buildkite/steps/script.sh
@@ -15,12 +15,10 @@ exitCode=0
 
 echo "+++ running tests"
 # benchmarks on shared infrastructure like the CI machines are usually unreliable (high variance),
-# so there's no point spending too much time. It's good to check that the benchmark does run
-# successfully as a benchmark (that is, multiple iterations, not just once, as a test with
-# --benchmark-disable)
-small_benchmarks=("--benchmark-max-time=0.01" "--benchmark-warmup=off" "--benchmark-min-rounds=2")
+# so there's no point spending too much time, hence --benchmark-disable which just runs them
+# once (as a test)
 
-py.test -ra --cov=stellargraph tests/ --doctest-modules --cov-report=xml -p no:cacheprovider --junitxml="./${junit_file}" "${small_benchmarks[@]}" || exitCode=$?
+py.test -ra --cov=stellargraph tests/ --doctest-modules --cov-report=xml -p no:cacheprovider --junitxml="./${junit_file}" --benchmark-disable || exitCode=$?
 
 echo "--- :coverage::codecov::arrow_up: uploading coverage to codecov.io"
 bash <(curl https://codecov.io/bash)

--- a/.buildkite/steps/script.sh
+++ b/.buildkite/steps/script.sh
@@ -14,7 +14,13 @@ pip freeze
 exitCode=0
 
 echo "+++ running tests"
-py.test -ra --cov=stellargraph tests/ --doctest-modules --cov-report=xml -p no:cacheprovider --junitxml="./${junit_file}" || exitCode=$?
+# benchmarks on shared infrastructure like the CI machines are usually unreliable (high variance),
+# so there's no point spending too much time. It's good to check that the benchmark does run
+# successfully as a benchmark (that is, multiple iterations, not just once, as a test with
+# --benchmark-disable)
+small_benchmarks=(--benchmark-max-time=0.01 --benchmark-warmup=off --benchmark-min-rounds=2)
+
+py.test -ra --cov=stellargraph tests/ --doctest-modules --cov-report=xml -p no:cacheprovider --junitxml="./${junit_file}" "${small_benchmarks[@]}" || exitCode=$?
 
 echo "--- :coverage::codecov::arrow_up: uploading coverage to codecov.io"
 bash <(curl https://codecov.io/bash)

--- a/.buildkite/steps/script.sh
+++ b/.buildkite/steps/script.sh
@@ -18,7 +18,7 @@ echo "+++ running tests"
 # so there's no point spending too much time. It's good to check that the benchmark does run
 # successfully as a benchmark (that is, multiple iterations, not just once, as a test with
 # --benchmark-disable)
-small_benchmarks=(--benchmark-max-time=0.01 --benchmark-warmup=off --benchmark-min-rounds=2)
+small_benchmarks=("--benchmark-max-time=0.01" "--benchmark-warmup=off" "--benchmark-min-rounds=2")
 
 py.test -ra --cov=stellargraph tests/ --doctest-modules --cov-report=xml -p no:cacheprovider --junitxml="./${junit_file}" "${small_benchmarks[@]}" || exitCode=$?
 


### PR DESCRIPTION
Benchmarking on shared machines is usually somewhat useless, because of high variance (see #1114 for an example of a benchmark varying from 278 to 580 milliseconds, more than 2&times;).

`pytest-benchmark` will, by default, run tests for at least a second, which ends up adding up across our ~34 benchmarks. As such, we can cut up to 40s off our critical path, by reducing the benchmarks run during our testing step (which is currently 8-9 minutes). This can be done by running the benchmark code once, as a test, using `--benchmark-disable`. The total time spent running benchmarks falls to ~5s (from 43s as reported in #1114).

The `--benchmark-disable` flag is potentially problematic, if a benchmark does some mutation that causes a second run to fail. Specifically, if `f` is being benchmarked, `--benchmark-disable` results in a call sequence approximately like `setup(); f(); clean_up()`, while a real benchmark run looks like `setup(); f(); f(); ...; f(); clean_up();`, if `f` does a mutation that causes a second call to fail, running with `--benchmark-disable` won't catch it. I decided that this risk was ok, because even reducing the time with `--benchmark-max-time=0.01 --benchmark-min-rounds=2` still took 18+ seconds. (https://pytest-benchmark.readthedocs.io/en/latest/usage.html#commandline-options discusses all the command line options.)

See: #1114 

After this patch, this is an example set of reported times (from https://buildkite.com/stellar/stellargraph-public/builds/2391) to compare to #1114. Notice how almost all of the benchmarks now take significantly less than 1 second to run.

|name|time|
|----|---:|
|test_benchmark_biasedrandomwalk|0.016|
|test_benchmark_bfs_walk|0.017|
|test_benchmark_biasedweightedrandomwalk|0.019|
|test_benchmark_get_features[specify-1]|0.020|
|test_benchmark_get_features[infer-1]|0.021|
|test_benchmark_creation[None-0-0]|0.022|
|test_benchmark_creation[None-100-200]|0.022|
|test_benchmark_setup_generator_small|0.022|
|test_benchmark_get_neighbours|0.024|
|test_benchmark_uniformrandomwalk|0.027|
|test_benchmark_creation[100-0-0]|0.028|
|test_benchmark_creation[100-100-200]|0.029|
|test_benchmark_bfs_walk|0.031|
|test_benchmark_get_features[specify-4]|0.033|
|test_benchmark_get_features[infer-4]|0.035|
|test_benchmark_graph_schema[1]|0.039|
|test_benchmark_creation[None-1000-5000]|0.043|
|test_benchmark_to_adjacency_matrix[True]|0.043|
|test_benchmark_to_adjacency_matrix[False]|0.045|
|test_benchmark_graph_schema[4]|0.049|
|test_benchmark_creation[100-1000-5000]|0.049|
|test_benchmark_sampledheterogeneousbreadthfirstwalk|0.053|
|test_benchmark_uniformrandommetapathwalk|0.056|
|test_allocation_benchmark_creation[None-0-0]|0.178|
|test_allocation_benchmark_creation[None-100-200]|0.179|
|test_allocation_benchmark_creation[100-0-0]|0.181|
|test_allocation_benchmark_creation[100-100-200]|0.185|
|test_allocation_benchmark_creation[None-1000-5000]|0.234|
|test_allocation_benchmark_creation[100-1000-5000]|0.244|
|test_benchmark_node_generator_small|0.357|
|test_benchmark_link_generator_small|0.358|
|test_benchmark_setup_generator_large|0.813|
|test_benchmark_link_generator_large|0.890|
|test_benchmark_node_generator_large|0.896|