### PR TITLE
Store weights statefully in Attri2vec

### DIFF
--- a/tests/layer/test_attri2vec.py
+++ b/tests/layer/test_attri2vec.py
@@ -98,22 +98,23 @@ def test_attri2vec_apply():
         normalize=None,
     )
 
+    # the rest of the test assumes the weights are 1, to get the predictions to be easily computed,
+    # so let's build a basic model to set those weights (which are stored statefully in Attri2vec)
+    model = keras.Model(*attri2vec.build())
+    model.set_weights([np.ones_like(w) for w in model.get_weights()])
+
     x = np.array([[1, 2]])
     expected = np.array([[12, 12]])
 
     inp = keras.Input(shape=(2,))
     out = attri2vec(inp)
     model1 = keras.Model(inputs=inp, outputs=out)
-    model_weights1 = [np.ones_like(w) for w in model1.get_weights()]
-    model1.set_weights(model_weights1)
     actual = model1.predict(x)
     assert expected == pytest.approx(actual)
 
     # Use the node model:
     xinp, xout = attri2vec.node_model()
     model2 = keras.Model(inputs=xinp, outputs=xout)
-    model_weights2 = [np.ones_like(w) for w in model2.get_weights()]
-    model2.set_weights(model_weights2)
     assert pytest.approx(expected) == model2.predict(x)
 
     x1 = np.array([[3, 1]])
@@ -124,8 +125,6 @@ def test_attri2vec_apply():
     # Test the build function:
     xinp, xout = attri2vec.build()
     model3 = keras.Model(inputs=xinp, outputs=xout)
-    model_weights3 = [np.ones_like(w) for w in model3.get_weights()]
-    model3.set_weights(model_weights3)
     actual = model3.predict([x1, x2])
     assert pytest.approx(y1) == actual[0]
     assert pytest.approx(y2) == actual[1]
@@ -133,8 +132,6 @@ def test_attri2vec_apply():
     # Use the link model:
     xinp, xout = attri2vec.link_model()
     model4 = keras.Model(inputs=xinp, outputs=xout)
-    model_weights4 = [np.ones_like(w) for w in model4.get_weights()]
-    model4.set_weights(model_weights4)
     actual = model4.predict([x1, x2])
     assert pytest.approx(y1) == actual[0]
     assert pytest.approx(y2) == actual[1]


### PR DESCRIPTION
Our models are meant to be stateful collections of layers, meaning each `build` call should give input/output tensors using the same underlying trainable weights. For `Attri2vec`, this means storing the dense layers and the link-prediction embeddings in the model itself.

See: #1088