### PR TITLE
Store embeddings statefully in Watch Your Step

### DIFF
--- a/tests/layer/test_watch_your_step.py
+++ b/tests/layer/test_watch_your_step.py
@@ -51,9 +51,6 @@ def test_WatchYourStep_init(barbell):
     assert wys.n_nodes == len(barbell.nodes())
     assert wys.num_walks == 80
     assert wys.embedding_dimension == 64
-    assert wys.attention_initializer == "glorot_uniform"
-    assert wys.attention_constraint is None
-    assert wys.attention_regularizer is None
 
 
 def test_WatchYourStep_bad_init(barbell):

--- a/tests/layer/test_watch_your_step.py
+++ b/tests/layer/test_watch_your_step.py
@@ -89,6 +89,9 @@ def test_WatchYourStep(barbell):
 
     assert embs.shape == (len(barbell.nodes()), wys.embedding_dimension)
 
+    model2 = Model(*wys.build())
+    assert np.array_equal(get_embeddings(model2), embs)
+
 
 def test_WatchYourStep_embeddings(barbell):
     generator = AdjacencyPowerGenerator(barbell, num_powers=5)


### PR DESCRIPTION
Our models are meant to be stateful collections of layers, meaning each `build` call should give input/output tensors using the same underlying trainable weights. For `WatchYourStep`, this means storing the left and right embeddings in the model itself.

See: #1088 