### PR TITLE
Move watch_your_step.get_embeddings to WatchYourStep.embeddings method

### DIFF
--- a/demos/embeddings/watch-your-step-cora-demo.ipynb
+++ b/demos/embeddings/watch-your-step-cora-demo.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "from stellargraph.core import StellarGraph\n",
     "from stellargraph.mapper import AdjacencyPowerGenerator\n",
-    "from stellargraph.layer.watch_your_step import WatchYourStep, get_embeddings\n",
+    "from stellargraph.layer import WatchYourStep\n",
     "from stellargraph.losses import graph_log_likelihood\n",
     "from stellargraph import datasets\n",
     "\n",
@@ -265,7 +265,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "embeddings = get_embeddings(model)"
+    "embeddings = wys.embeddings()"
    ]
   },
   {

--- a/stellargraph/layer/watch_your_step.py
+++ b/stellargraph/layer/watch_your_step.py
@@ -105,28 +105,6 @@ class AttentiveWalk(Layer):
         return expected_walk
 
 
-def get_embeddings(model):
-    """
-    This function returns the embeddings from a model with Watch Your Step embeddings.
-
-    Args:
-        model (keras Model): a keras model that contains Watch Your Step embeddings.
-
-    Returns:
-        embeddings (np.array): a numpy array of the model's embeddings.
-    """
-    embeddings = np.hstack(
-        [
-            model.get_layer("WATCH_YOUR_STEP_LEFT_EMBEDDINGS").embeddings.numpy(),
-            model.get_layer("WATCH_YOUR_STEP_RIGHT_EMBEDDINGS")
-            .kernel.numpy()
-            .transpose(),
-        ]
-    )
-
-    return embeddings
-
-
 class WatchYourStep:
     """
     Implementation of the node embeddings as in Watch Your Step: Learning Node Embeddings via Graph Attention
@@ -185,7 +163,6 @@ class WatchYourStep:
             self.n_nodes,
             int(self.embedding_dimension / 2),
             input_length=None,
-            name="WATCH_YOUR_STEP_LEFT_EMBEDDINGS",
             embeddings_initializer=embeddings_initializer,
             embeddings_regularizer=embeddings_regularizer,
             embeddings_constraint=embeddings_constraint,
@@ -196,7 +173,6 @@ class WatchYourStep:
             kernel_initializer=embeddings_initializer,
             kernel_regularizer=embeddings_regularizer,
             kernel_constraint=embeddings_constraint,
-            name="WATCH_YOUR_STEP_RIGHT_EMBEDDINGS",
         )
         self._attentive_walk = AttentiveWalk(
             walk_length=self.num_powers,
@@ -204,6 +180,22 @@ class WatchYourStep:
             attention_regularizer=attention_regularizer,
             attention_initializer=attention_initializer,
         )
+
+    def embeddings(self):
+        """
+        This function returns the embeddings from a model with Watch Your Step embeddings.
+
+        Returns:
+            embeddings (np.array): a numpy array of the model's embeddings.
+        """
+        embeddings = np.hstack(
+            [
+                self._left_embedding.embeddings.numpy(),
+                self._right_embedding.kernel.numpy().transpose(),
+            ]
+        )
+
+        return embeddings
 
     def build(self):
         """

--- a/tests/layer/test_watch_your_step.py
+++ b/tests/layer/test_watch_your_step.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from stellargraph.layer import AttentiveWalk, WatchYourStep, get_embeddings
+from stellargraph.layer import AttentiveWalk, WatchYourStep
 import numpy as np
 from ..test_utils.graphs import barbell
 from stellargraph.mapper import AdjacencyPowerGenerator
@@ -82,12 +82,14 @@ def test_WatchYourStep(barbell):
     model.compile(optimizer="adam", loss=graph_log_likelihood)
     model.fit(gen, epochs=1, steps_per_epoch=int(len(barbell.nodes()) // 4))
 
-    embs = get_embeddings(model)
-
+    embs = wys.embeddings()
     assert embs.shape == (len(barbell.nodes()), wys.embedding_dimension)
 
-    model2 = Model(*wys.build())
-    assert np.array_equal(get_embeddings(model2), embs)
+    # build() should always return tensors backed by the same trainable weights, and thus give the
+    # same predictions
+    preds1 = model.predict(gen, steps=8)
+    preds2 = Model(*wys.build()).predict(gen, steps=8)
+    assert np.array_equal(preds1, preds2)
 
 
 def test_WatchYourStep_embeddings(barbell):
@@ -97,6 +99,6 @@ def test_WatchYourStep_embeddings(barbell):
 
     model = Model(inputs=x_in, outputs=x_out)
     model.compile(optimizer="adam", loss=graph_log_likelihood)
-    embs = get_embeddings(model)
+    embs = wys.embeddings()
 
     assert (embs == 1).all()


### PR DESCRIPTION
This moves the `get_embeddings` function to be a method on `WatchYourStep`, similar to `ComplEx`, `DistMult` and `DeepGraphInfomax`. This method refers to the layers stored within the `WatchYourStep` model instance.

See: #1109