### PR TITLE
Make datasets accessible in stellargraph module by default

### DIFF
--- a/stellargraph/__init__.py
+++ b/stellargraph/__init__.py
@@ -21,6 +21,7 @@ Stellar Machine Learning Library
 
 __all__ = [
     "data",
+    "datasets"
     "layer",
     "mapper",
     "utils",
@@ -35,6 +36,7 @@ from .version import __version__
 # Import modules
 from stellargraph import (
     calibration,
+    datasets,
     ensemble,
     interpretability,
     losses,

--- a/stellargraph/__init__.py
+++ b/stellargraph/__init__.py
@@ -21,7 +21,7 @@ Stellar Machine Learning Library
 
 __all__ = [
     "data",
-    "datasets"
+    "datasets",
     "layer",
     "mapper",
     "utils",


### PR DESCRIPTION
It's convenient for basic code to only need a few imports. Before this patch, a user could not write `import stellargraph` or `import stellargraph as sg` followed by `sg.datasets.Cora().load()` (or similar). They would have to have an independent `from stellargraph import datasets` or `import stellargraph.datasets`.

This does not seem to make things slower. With or without this patch, 5 runs of `python -c 'import stellargraph'` take 2.7-2.8s.

See: #1112 