### PR TITLE
Omit model argument in DeepGraphInfomax.embedding_model via statefulness

### DIFF
--- a/demos/node-classification/deep-graph-infomax/gcn-deep-graph-infomax-cora-example.ipynb
+++ b/demos/node-classification/deep-graph-infomax/gcn-deep-graph-infomax-cora-example.ipynb
@@ -176,7 +176,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "x_emb_in, x_emb_out = infomax.embedding_model(model)\n",
+    "x_emb_in, x_emb_out = infomax.embedding_model()\n",
     "emb_model = Model(inputs=x_emb_in, outputs=x_emb_out)"
    ]
   },

--- a/stellargraph/layer/deep_graph_infomax.py
+++ b/stellargraph/layer/deep_graph_infomax.py
@@ -93,8 +93,6 @@ class DeepGraphInfomax:
         self._corruptible_inputs_idxs = [0]
 
         self._discriminator = DGIDiscriminator()
-        self._base_input = None
-        self._base_output = None
 
     def build(self):
         """

--- a/stellargraph/layer/deep_graph_infomax.py
+++ b/stellargraph/layer/deep_graph_infomax.py
@@ -89,11 +89,12 @@ class DeepGraphInfomax:
         self.base_model = base_model
 
         self._node_feats = None
-        self._unique_id = f"DEEP_GRAPH_INFOMAX_{id(self)}"
         # specific to full batch models
         self._corruptible_inputs_idxs = [0]
 
         self._discriminator = DGIDiscriminator()
+        self._base_input = None
+        self._base_output = None
 
     def build(self):
         """
@@ -113,8 +114,7 @@ class DeepGraphInfomax:
         """
 
         x_inp, node_feats = self.base_model.build(multiplicity=1)
-        # identity layer so we can attach a name to the tensor
-        node_feats = Lambda(lambda x: x, name=self._unique_id)(node_feats)
+
         x_corr = [
             Input(batch_shape=x_inp[i].shape) for i in self._corruptible_inputs_idxs
         ]
@@ -135,26 +135,16 @@ class DeepGraphInfomax:
 
         return x_corr + x_inp, x_out
 
-    def embedding_model(self, model):
+    def embedding_model(self):
         """
         A function to create the the inputs and outputs for an embedding model.
 
-        Args:
-            model (keras.Model): the base Deep Graph Infomax model with inputs and outputs created from
-                DeepGraphInfoMax.build()
         Returns:
             input and output layers for use with a keras model
         """
 
-        try:
-            x_emb_out = model.get_layer(self._unique_id).output
-        except ValueError:
-            raise ValueError(
-                f"model: model must be a keras model with inputs and outputs created "
-                f"by the build() method of this instance of DeepGraphInfoMax"
-            )
-
-        x_emb_in = model.inputs[len(self._corruptible_inputs_idxs) :]
+        # these tensors should link into the weights that get trained by `build`
+        x_emb_in, x_emb_out = self.base_model.build(multiplicity=1)
 
         squeeze_layer = Lambda(lambda x: K.squeeze(x, axis=0), name="squeeze")
         x_emb_out = squeeze_layer(x_emb_out)

--- a/tests/layer/test_deep_graph_infomax.py
+++ b/tests/layer/test_deep_graph_infomax.py
@@ -45,38 +45,10 @@ def test_dgi(model_type, sparse):
     model.compile(loss=tf.nn.sigmoid_cross_entropy_with_logits, optimizer="Adam")
     model.fit(gen)
 
-    emb_model = tf.keras.Model(*infomax.embedding_model(model))
+    emb_model = tf.keras.Model(*infomax.embedding_model())
     embeddings = emb_model.predict(generator.flow(G.nodes()))
 
     assert embeddings.shape == (len(G.nodes()), emb_dim)
-
-
-def test_dgi_embedding_wrong_model():
-    G = example_graph_random()
-    emb_dim = 16
-
-    generator = FullBatchNodeGenerator(G)
-
-    infomax_1 = DeepGraphInfomax(
-        GCN(generator=generator, activations=["relu"], layer_sizes=[emb_dim])
-    )
-    infomax_2 = DeepGraphInfomax(
-        GCN(generator=generator, activations=["relu"], layer_sizes=[emb_dim])
-    )
-
-    model_1 = tf.keras.Model(*infomax_1.build())
-
-    # check case when infomax_2.build() has not been called
-    with pytest.raises(ValueError, match="model: *."):
-        infomax_2.embedding_model(model_1)
-
-    # check case when infomax_2.build() has been called
-    model_2 = tf.keras.Model(*infomax_2.build())
-    with pytest.raises(ValueError, match="model: *."):
-        infomax_2.embedding_model(model_1)
-
-    with pytest.raises(ValueError, match="model: *."):
-        infomax_1.embedding_model(model_2)
 
 
 def test_dgi_stateful():
@@ -95,10 +67,10 @@ def test_dgi_stateful():
     model_2 = tf.keras.Model(*infomax.build())
 
     # check embeddings are equal before training
-    embeddings_1 = tf.keras.Model(*infomax.embedding_model(model_1)).predict(
+    embeddings_1 = tf.keras.Model(*infomax.embedding_model()).predict(
         generator.flow(G.nodes())
     )
-    embeddings_2 = tf.keras.Model(*infomax.embedding_model(model_2)).predict(
+    embeddings_2 = tf.keras.Model(*infomax.embedding_model()).predict(
         generator.flow(G.nodes())
     )
 
@@ -108,10 +80,10 @@ def test_dgi_stateful():
     model_1.fit(gen)
 
     # check embeddings are still equal after training one model
-    embeddings_1 = tf.keras.Model(*infomax.embedding_model(model_1)).predict(
+    embeddings_1 = tf.keras.Model(*infomax.embedding_model()).predict(
         generator.flow(G.nodes())
     )
-    embeddings_2 = tf.keras.Model(*infomax.embedding_model(model_2)).predict(
+    embeddings_2 = tf.keras.Model(*infomax.embedding_model()).predict(
         generator.flow(G.nodes())
     )
 
@@ -121,10 +93,10 @@ def test_dgi_stateful():
     model_2.fit(gen)
 
     # check embeddings are still equal after training both models
-    embeddings_1 = tf.keras.Model(*infomax.embedding_model(model_1)).predict(
+    embeddings_1 = tf.keras.Model(*infomax.embedding_model()).predict(
         generator.flow(G.nodes())
     )
-    embeddings_2 = tf.keras.Model(*infomax.embedding_model(model_2)).predict(
+    embeddings_2 = tf.keras.Model(*infomax.embedding_model()).predict(
         generator.flow(G.nodes())
     )
 


### PR DESCRIPTION
We can use the statefulness of models (#1088) to simplify how to construct the `DeepGraphInfomax`'s embedding model. In particular, the base model should be stateful, so multiple calls to `build` will give input/output tensors that all tie into the same trainable weights, so the embedding model can be built by creating a new set of base-model input/output tensors instead of picking a layer out of a pre-build Keras model.

See: #1109 (at least, this is along the same lines as #1104 and #1106)