### PR TITLE
Document top-level reexports instead of core module

### DIFF
--- a/docs/api.txt
+++ b/docs/api.txt
@@ -4,7 +4,7 @@ StellarGraph API
 Core
 ----------------
 
-.. automodule:: stellargraph.core
+.. automodule:: stellargraph
   :members: StellarGraph, StellarDiGraph, GraphSchema
 
 

--- a/stellargraph/__init__.py
+++ b/stellargraph/__init__.py
@@ -14,10 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Stellar Machine Learning Library
-
-"""
 
 __all__ = [
     "data",


### PR DESCRIPTION
This replaces `stellargraph.core.*` with `stellargraph.*` in our documentation. I thought this was a reasonable way to go about tackling #713 since we now only reexport classes in `core` (see #1107 ) and we don't actually have `core` included in `__all__`, so users should be encouraged to use these top-level exports.

This approach does mean that documenting anything else we might reexport at top-level that's outside of `core` is still awkward in the future, but doesn't seem too likely that we'd want to do that?

See: https://stellargraph--1127.org.readthedocs.build/en/1127/api.html#module-stellargraph

See #713 