### PR TITLE
Fix mistakes in ComplEx notebook due to being out of date

### DIFF
--- a/demos/link-prediction/knowledge-graphs/complex.ipynb
+++ b/demos/link-prediction/knowledge-graphs/complex.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "This notebook reproduces the experiments done in the paper that introduced the ComplEx algorith: Complex Embeddings for Simple Link Prediction, Théo Trouillon, Johannes Welbl, Sebastian Riedel, Éric Gaussier and Guillaume Bouchard, ICML 2016. http://jmlr.org/proceedings/papers/v48/trouillon16.pdf\n",
     "\n",
-    "In table 2, the paper reports five metrics measured on the WN18 and FB15K datasets: \"raw\" MRR (mean reciprocal rank), \"filtered\" MRR and filtered Hits at {1, 3, 10}. This notebook measures only the \"raw\" metrics, because the filtered ones are currently more difficult to compute."
+    "In table 2, the paper reports five metrics measured on the WN18 and FB15K datasets: \"raw\" MRR (mean reciprocal rank), \"filtered\" MRR and filtered Hits at {1, 3, 10}. This notebook measures all of these, as well as raw Hits at {1, 3, 10}."
    ]
   },
   {
@@ -34,7 +34,7 @@
    "source": [
     "## Initialisation\n",
     "\n",
-    "We need to set up our model parameters, like the number of epochs to train for, and the dimension of the embedding vectors we compute for each node and for each edge type. We'll also define a function to do our evaluation, so we can easily apply it to both WN18 and FB15k.\n",
+    "We need to set up our model parameters, like the number of epochs to train for, and the dimension of the embedding vectors we compute for each node and for each edge type.\n",
     "\n",
     "The evaluation is performed in three steps:\n",
     "\n",
@@ -42,7 +42,10 @@
     "2. Train a model\n",
     "3. Evaluate the model\n",
     "\n",
-    "The paper describes using the AdaGrad optimiser for 1000 epochs with an early stopping criterion evaluated every 50 epochs. We've found using the Adam optimiser allows for much fewer epochs. The paper says that the best choices of embedding dimension are generally 150 or 200, with close results. The paper evaluated using 1, 2, 5 and 10 negative samples, and found that using 10 improved performance on FB15k noticably (comparing to 1), but did not make much difference on WN18."
+    "The paper says that it used:\n",
+    "- the AdaGrad optimiser for 1000 epochs with an early stopping criterion evaluated every 50 epochs, but we've found using the Adam optimiser allows for much fewer epochs\n",
+    "- an embedding dimension of 150 or 200, since they had close results\n",
+    "- 10 negative samples (corrupted edges) per positive edge, which gives noticably improved performance on FB15k compared to using 1, and but not for WN18 (the paper evaluated 1, 2, 5 and 10 negative samples)"
    ]
   },
   {


### PR DESCRIPTION
There's a few bits and pieces in the ComplEx notebook that refer to an old form of the notebook that no longer applies.

It also switches a long sentence to a list per https://developers.google.com/tech-writing/one/lists-and-tables