### PR TITLE
Switch PendingDeprecationWarnings to real DeprecationWarnings

### DIFF
--- a/stellargraph/layer/attri2vec.py
+++ b/stellargraph/layer/attri2vec.py
@@ -232,9 +232,8 @@ class Attri2Vec:
 
     def default_model(self, flatten_output=True):
         warnings.warn(
-            "The .default_model() method will be deprecated in future versions. "
-            "Please use .build() method instead.",
-            PendingDeprecationWarning,
+            "The .default_model() method is deprecated. Please use .build() method instead.",
+            DeprecationWarning,
             stacklevel=2,
         )
         return self.build()

--- a/stellargraph/layer/graphsage.py
+++ b/stellargraph/layer/graphsage.py
@@ -1078,9 +1078,8 @@ class GraphSAGE:
 
     def default_model(self, flatten_output=True):
         warnings.warn(
-            "The .default_model() method will be deprecated in future versions. "
-            "Please use .build() method instead.",
-            PendingDeprecationWarning,
+            "The .default_model() method is deprecated. Please use .build() method instead.",
+            DeprecationWarning,
             stacklevel=2,
         )
         return self.build()

--- a/stellargraph/layer/hinsage.py
+++ b/stellargraph/layer/hinsage.py
@@ -590,9 +590,8 @@ class HinSAGE:
 
     def default_model(self, flatten_output=True):
         warnings.warn(
-            "The .default_model() method will be deprecated in future versions. "
-            "Please use .build() method instead.",
-            PendingDeprecationWarning,
+            "The .default_model() method is deprecated. Please use .build() method instead.",
+            DeprecationWarning,
             stacklevel=2,
         )
         return self.build()


### PR DESCRIPTION
The `default_model` methods are really truly deprecated in favour of `build` (at the moment: #1140, #1089).