### PR TITLE
Use correct kernel and bias defaults

### DIFF
--- a/stellargraph/layer/gcn.py
+++ b/stellargraph/layer/gcn.py
@@ -293,10 +293,10 @@ class GCN:
         bias=True,
         dropout=0.0,
         activations=None,
-        kernel_initializer=None,
+        kernel_initializer="glorot_uniform",
         kernel_regularizer=None,
         kernel_constraint=None,
-        bias_initializer=None,
+        bias_initializer="zeros",
         bias_regularizer=None,
         bias_constraint=None,
     ):

--- a/tests/layer/test_gcn.py
+++ b/tests/layer/test_gcn.py
@@ -29,6 +29,7 @@ import networkx as nx
 import pandas as pd
 import numpy as np
 from tensorflow import keras
+import tensorflow as tf
 import pytest
 from ..test_utils.graphs import create_graph_features
 
@@ -292,3 +293,18 @@ def test_GCN_regularisers():
 
     with pytest.raises(ValueError):
         gcn = GCN([2], generator, bias_initializer="barney")
+
+
+def test_kernel_and_bias_defaults():
+    graph, _ = create_graph_features()
+    generator = FullBatchNodeGenerator(graph, sparse=False, method="none")
+    gcn = GCN([2, 2], generator)
+
+    for layer in gcn._layers:
+        if isinstance(layer, GraphConvolution):
+            assert isinstance(layer.kernel_initializer, tf.initializers.GlorotUniform)
+            assert isinstance(layer.bias_initializer, tf.initializers.Zeros)
+            assert layer.kernel_regularizer is None
+            assert layer.bias_regularizer is None
+            assert layer.kernel_constraint is None
+            assert layer.bias_constraint is None


### PR DESCRIPTION
Prior to #802 it seems like `GCN` was creating `GraphConvolution` layers with its default values for `kernel_initializer` and `bias_initializer` (`self._regularizers` was only populated with non-none values: https://github.com/stellargraph/stellargraph/blob/bcf6d0a188ee9ba868c1de01c347f813e3aaa35c/stellargraph/layer/gcn.py#L337-L350) but now that we are passing these values all the way through without using kwargs, we need to make sure the defaults for `GCN` match those for `GraphConvolution`