### PR TITLE
Replace kwargs with real args in rgcn

### DIFF
--- a/stellargraph/layer/rgcn.py
+++ b/stellargraph/layer/rgcn.py
@@ -54,30 +54,18 @@ class RelationalGraphConvolution(Layer):
             use_bias (bool): toggles an optional bias
             final_layer (bool): If False the layer returns output for all nodes,
                                 if True it returns the subset specified by the indices passed to it.
-            kernel_initializer (str or func): The initialiser to use for the self kernel and also relational kernels if num_bases=0;
-                defaults to 'glorot_uniform'.
-            kernel_regularizer (str or func): The regulariser to use for the self kernel and also relational kernels if num_bases=0;
-                defaults to None.
-            kernel_constraint (str or func): The constraint to use for the self kernel and also relational kernels if num_bases=0;
-                defaults to None.
-            basis_initializer (str or func): The initialiser to use for the basis matrices;
-                defaults to 'glorot_uniform'.
-            basis_regularizer (str or func): The regulariser to use for the basis matrices;
-                defaults to None.
-            basis_constraint (str or func): The constraint to use for the basis matrices;
-                defaults to None.
-            coefficient_initializer (str or func): The initialiser to use for the coefficients;
-                defaults to 'glorot_uniform'.
-            coefficient_regularizer (str or func): The regulariser to use for the coefficients;
-                defaults to None.
-            coefficient_constraint (str or func): The constraint to use for the coefficients;
-                defaults to None.
-            bias_initializer (str or func): The initialiser to use for the bias;
-                defaults to 'zeros'.
-            bias_regularizer (str or func): The regulariser to use for the bias;
-                defaults to None.
-            bias_constraint (str or func): The constraint to use for the bias;
-                defaults to None.
+            kernel_initializer (str or func): The initialiser to use for the self kernel and also relational kernels if num_bases=0.
+            kernel_regularizer (str or func): The regulariser to use for the self kernel and also relational kernels if num_bases=0.
+            kernel_constraint (str or func): The constraint to use for the self kernel and also relational kernels if num_bases=0.
+            basis_initializer (str or func): The initialiser to use for the basis matrices.
+            basis_regularizer (str or func): The regulariser to use for the basis matrices.
+            basis_constraint (str or func): The constraint to use for the basis matrices.
+            coefficient_initializer (str or func): The initialiser to use for the coefficients.
+            coefficient_regularizer (str or func): The regulariser to use for the coefficients.
+            coefficient_constraint (str or func): The constraint to use for the coefficients.
+            bias_initializer (str or func): The initialiser to use for the bias.
+            bias_regularizer (str or func): The regulariser to use for the bias.
+            bias_constraint (str or func): The constraint to use for the bias.
             input_dim (int, optional): the size of the input shape, if known.
             kwargs: any additional arguments to pass to :class:`tensorflow.keras.layers.Layer`
         """
@@ -91,6 +79,18 @@ class RelationalGraphConvolution(Layer):
         use_bias=True,
         final_layer=False,
         input_dim=None,
+        kernel_initializer="glorot_uniform",
+        kernel_regularizer=None,
+        kernel_constraint=None,
+        bias_initializer="zeros",
+        bias_regularizer=None,
+        bias_constraint=None,
+        basis_initializer="glorot_uniform",
+        basis_regularizer=None,
+        basis_constraint=None,
+        coefficient_initializer="glorot_uniform",
+        coefficient_regularizer=None,
+        coefficient_constraint=None,
         **kwargs
     ):
         if "input_shape" not in kwargs and input_dim is not None:
@@ -118,40 +118,22 @@ class RelationalGraphConvolution(Layer):
         self.num_bases = num_bases
         self.activation = activations.get(activation)
         self.use_bias = use_bias
-        self._get_regularisers_from_keywords(kwargs)
+
+        self.kernel_initializer = initializers.get(kernel_initializer)
+        self.kernel_regularizer = regularizers.get(kernel_regularizer)
+        self.kernel_constraint = constraints.get(kernel_constraint)
+        self.bias_initializer = initializers.get(bias_initializer)
+        self.bias_regularizer = regularizers.get(bias_regularizer)
+        self.bias_constraint = constraints.get(bias_constraint)
+        self.basis_initializer = initializers.get(basis_initializer)
+        self.basis_regularizer = regularizers.get(basis_regularizer)
+        self.basis_constraint = constraints.get(basis_constraint)
+        self.coefficient_initializer = initializers.get(coefficient_initializer)
+        self.coefficient_regularizer = regularizers.get(coefficient_regularizer)
+        self.coefficient_constraint = constraints.get(coefficient_constraint)
+
         self.final_layer = final_layer
         super().__init__(**kwargs)
-
-    def _get_regularisers_from_keywords(self, kwargs):
-        self.kernel_initializer = initializers.get(
-            kwargs.pop("kernel_initializer", "glorot_uniform")
-        )
-        self.kernel_regularizer = regularizers.get(
-            kwargs.pop("kernel_regularizer", None)
-        )
-        self.kernel_constraint = constraints.get(kwargs.pop("kernel_constraint", None))
-
-        self.basis_initializer = initializers.get(
-            kwargs.pop("basis_initializer", "glorot_uniform")
-        )
-        self.basis_regularizer = regularizers.get(kwargs.pop("basis_regularizer", None))
-        self.basis_constraint = constraints.get(kwargs.pop("basis_constraint", None))
-
-        self.coefficient_initializer = initializers.get(
-            kwargs.pop("coefficient_initializer", "glorot_uniform")
-        )
-        self.coefficient_regularizer = regularizers.get(
-            kwargs.pop("coefficient_regularizer", None)
-        )
-        self.coefficient_constraint = constraints.get(
-            kwargs.pop("coefficient_constraint", None)
-        )
-
-        self.bias_initializer = initializers.get(
-            kwargs.pop("bias_initializer", "zeros")
-        )
-        self.bias_regularizer = regularizers.get(kwargs.pop("bias_regularizer", None))
-        self.bias_constraint = constraints.get(kwargs.pop("bias_constraint", None))
 
     def get_config(self):
         """
@@ -403,8 +385,12 @@ class RGCN:
         dropout (float): Dropout rate applied to input features of each RGCN layer.
         activations (list of str or func): Activations applied to each layer's output;
             defaults to ['relu', ..., 'relu'].
-        kernel_regularizer (str or func): The regulariser to use for the weights of each layer;
-            defaults to None.
+        kernel_initializer (str or func, optional): The initialiser to use for the weights of each layer.
+        kernel_regularizer (str or func, optional): The regulariser to use for the weights of each layer.
+        kernel_constraint (str or func, optional): The constraint to use for the weights of each layer.
+        bias_initializer (str or func, optional): The initialiser to use for the bias of each layer.
+        bias_regularizer (str or func, optional): The regulariser to use for the bias of each layer.
+        bias_constraint (str or func, optional): The constraint to use for the bias of each layer.
     """
 
     def __init__(
@@ -415,7 +401,12 @@ class RGCN:
         num_bases=0,
         dropout=0.0,
         activations=None,
-        **kwargs
+        kernel_initializer="glorot_uniform",
+        kernel_regularizer=None,
+        kernel_constraint=None,
+        bias_initializer="zeros",
+        bias_regularizer=None,
+        bias_constraint=None,
     ):
         if not isinstance(generator, RelationalFullBatchNodeGenerator):
             raise TypeError(
@@ -450,9 +441,6 @@ class RGCN:
         self.activations = activations
         self.num_bases = num_bases
 
-        # Optional regulariser, etc. for weights and biases
-        self._get_regularisers_from_keywords(kwargs)
-
         # Initialize a stack of RGCN layers
         self._layers = []
         for ii in range(n_layers):
@@ -465,24 +453,14 @@ class RGCN:
                     activation=self.activations[ii],
                     use_bias=self.bias,
                     final_layer=ii == (n_layers - 1),
-                    **self._regularisers
+                    kernel_initializer=kernel_initializer,
+                    kernel_regularizer=kernel_regularizer,
+                    kernel_constraint=kernel_constraint,
+                    bias_initializer=bias_initializer,
+                    bias_regularizer=bias_regularizer,
+                    bias_constraint=bias_constraint,
                 )
             )
-
-    def _get_regularisers_from_keywords(self, kwargs):
-        regularisers = {}
-        for param_name in [
-            "kernel_initializer",
-            "kernel_regularizer",
-            "kernel_constraint",
-            "bias_initializer",
-            "bias_regularizer",
-            "bias_constraint",
-        ]:
-            param_value = kwargs.pop(param_name, None)
-            if param_value is not None:
-                regularisers[param_name] = param_value
-        self._regularisers = regularisers
 
     def __call__(self, x):
         """

--- a/tests/layer/test_rgcn.py
+++ b/tests/layer/test_rgcn.py
@@ -20,6 +20,7 @@ from stellargraph.mapper.full_batch_generators import RelationalFullBatchNodeGen
 import pytest
 from scipy import sparse as sps
 from stellargraph.core.utils import normalize_adj
+import tensorflow as tf
 from tensorflow import keras
 from tensorflow.keras import backend as K
 from tensorflow.keras.layers import Input, Lambda
@@ -382,3 +383,17 @@ def get_As(G):
         As.append(A)
 
     return As
+
+
+def test_kernel_and_bias_defaults():
+    graph, _ = create_graph_features()
+    generator = RelationalFullBatchNodeGenerator(graph, sparse=False)
+    rgcn = RGCN([2, 2], generator, num_bases=10)
+    for layer in rgcn._layers:
+        if isinstance(layer, RelationalGraphConvolution):
+            assert isinstance(layer.kernel_initializer, tf.initializers.GlorotUniform)
+            assert isinstance(layer.bias_initializer, tf.initializers.Zeros)
+            assert layer.kernel_regularizer is None
+            assert layer.bias_regularizer is None
+            assert layer.kernel_constraint is None
+            assert layer.bias_constraint is None


### PR DESCRIPTION
See #801 

I noticed that the `basis` and `coefficient` related kwargs weren't exposed via the `RGCN` class - should we also add them? (Edit: I've filed https://github.com/stellargraph/stellargraph/issues/1155 for now)