### PR TITLE
Fix AttributeError, not warning, from DeepGraphInfomax(link_model)

### DIFF
--- a/stellargraph/layer/deep_graph_infomax.py
+++ b/stellargraph/layer/deep_graph_infomax.py
@@ -82,8 +82,7 @@ class DeepGraphInfomax:
 
         if base_model.multiplicity != 1:
             warnings.warn(
-                f"multiplicity: expected the base_model to have a multiplicity of 1, found"
-                f" ({self.base_model.multiplicity}). A multiplicity of 1 will be used to construct the base model."
+                f"base_model: expected a node model (multiplicity = 1), found a link model (multiplicity = {base_model.multiplicity}). Base model tensors will be constructed as for a node model.",
             )
 
         self.base_model = base_model


### PR DESCRIPTION
The warning message wasn't tested and so had a typo in the code (`self.base_model` instead of just `base_model`) that triggers an `AttributeError` exception: 

```
AttributeError: 'DeepGraphInfomax' object has no attribute 'base_model'
```

This also rephrases the warning message to focus on what a user will be thinking about (node vs. link) instead of the implementation detail of the `multiplicity` property on the models.