### PR TITLE
Document datasets module reexports

### DIFF
--- a/docs/api.txt
+++ b/docs/api.txt
@@ -143,7 +143,7 @@ Utilities
 Datasets
 ----------------
 
-.. automodule:: stellargraph.datasets.datasets
+.. automodule:: stellargraph.datasets
   :members:
   :inherited-members:
 

--- a/stellargraph/datasets/__init__.py
+++ b/stellargraph/datasets/__init__.py
@@ -19,4 +19,19 @@ The datasets package contains classes to download sample datasets
 
 """
 
+__all__ = [
+    "Cora",
+    "CiteSeer",
+    "PubMedDiabetes",
+    "BlogCatalog3",
+    "MovieLens",
+    "AIFB",
+    "MUTAG",
+    "WN18",
+    "WN18RR",
+    "FB15k",
+    "FB15k_237",
+    "IAEnronEmployees",
+]
+
 from .datasets import *

--- a/stellargraph/datasets/__init__.py
+++ b/stellargraph/datasets/__init__.py
@@ -19,6 +19,7 @@ The datasets package contains classes to download sample datasets
 
 """
 
+# these are defined explicitly for autodoc to pick them up via :members:
 __all__ = [
     "Cora",
     "CiteSeer",


### PR DESCRIPTION
This replaces `stellargraph.datasets.datasets.*` with `stellargraph.datasets.*` in our API docs

Part of #713 

See docs: https://stellargraph--1157.org.readthedocs.build/en/1157/api.html#module-stellargraph.datasets