### PR TITLE
Fix Conda package dependencies and test failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [0.11.1](https://github.com/stellargraph/stellargraph/tree/v0.11.1)
+
+### Bug fixes and other changes
+
+- The [Conda package for StellarGraph](https://anaconda.org/stellargraph/stellargraph) has been updated to require TensorFlow 2.1, as TensorFlow 2.0 is no longer supported.  This means that StellarGraph will currently install via Conda on Linux and Windows - Mac support is waiting on the [Tensorflow 2.1 release to Conda](https://github.com/tensorflow/tensorflow/issues/35754). [\#1165](https://github.com/stellargraph/stellargraph/pull/1165)
+
 ## [0.11.0](https://github.com/stellargraph/stellargraph/tree/v0.11.0)
 
 [Full Changelog](https://github.com/stellargraph/stellargraph/compare/v0.10.0...v0.11.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug fixes and other changes
 
-- The [Conda package for StellarGraph](https://anaconda.org/stellargraph/stellargraph) has been updated to require TensorFlow 2.1, as TensorFlow 2.0 is no longer supported.  This means that StellarGraph will currently install via Conda on Linux and Windows - Mac support is waiting on the [Tensorflow 2.1 release to Conda](https://github.com/tensorflow/tensorflow/issues/35754). [\#1165](https://github.com/stellargraph/stellargraph/pull/1165)
+- The [Conda package for StellarGraph](https://anaconda.org/stellargraph/stellargraph) has been updated to require TensorFlow 2.1, as TensorFlow 2.0 is no longer supported.  As a result, StellarGraph will currently install via Conda on Linux and Windows - Mac support is waiting on the [Tensorflow 2.1 release to Conda](https://github.com/tensorflow/tensorflow/issues/35754). [\#1165](https://github.com/stellargraph/stellargraph/pull/1165)
 
 ## [0.11.0](https://github.com/stellargraph/stellargraph/tree/v0.11.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## [0.11.1](https://github.com/stellargraph/stellargraph/tree/v0.11.1)
 
+[Full Changelog](https://github.com/stellargraph/stellargraph/compare/v0.11.0...v0.11.1)
+
+This bugfix release contains the same code as 0.11.0, and just fixes the metadata in the Anaconda package so that it can be installed successfully.
+
 ### Bug fixes and other changes
 
-- The [Conda package for StellarGraph](https://anaconda.org/stellargraph/stellargraph) has been updated to require TensorFlow 2.1, as TensorFlow 2.0 is no longer supported.  As a result, StellarGraph will currently install via Conda on Linux and Windows - Mac support is waiting on the [Tensorflow 2.1 release to Conda](https://github.com/tensorflow/tensorflow/issues/35754). [\#1165](https://github.com/stellargraph/stellargraph/pull/1165)
+- The [Conda package for StellarGraph](https://anaconda.org/stellargraph/stellargraph) has been updated to require TensorFlow 2.1, as TensorFlow 2.0 is no longer supported.  As a result, StellarGraph will currently install via Conda on Linux and Windows - Mac support is waiting on the [Tensorflow 2.1 osx-64 release to Conda](https://github.com/ContinuumIO/anaconda-issues/issues/11697). [\#1165](https://github.com/stellargraph/stellargraph/pull/1165)
 
 ## [0.11.0](https://github.com/stellargraph/stellargraph/tree/v0.11.0)
 

--- a/docker/stellargraph-neo4j/Dockerfile
+++ b/docker/stellargraph-neo4j/Dockerfile
@@ -2,6 +2,8 @@ FROM neo4j:3.5
 
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
+USER neo4j
+
 ENV APOC_VERSION="3.5.0.9" APOC_SHA="b4b1a8f8940ad250c17b45296459afcfff2eb1beee18b8c8a394e2b5a434183b924b34cb5b04fea1a371fbfb87a286228bd4ae814829e0ef99f9e190a764fa1d"
 RUN echo "--- downloading apoc jar" && \
     wget --no-verbose "https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/download/${APOC_VERSION}/apoc-${APOC_VERSION}-all.jar" --directory-prefix plugins/ && \

--- a/meta.yaml
+++ b/meta.yaml
@@ -47,7 +47,7 @@ test:
     - stellargraph.layer
     - stellargraph.mapper
     - stellargraph.utils
-    - stellargraph.utils.saliency_maps
+    - stellargraph.interpretability.saliency_maps
 
 about:
   home: "https://github.com/stellargraph/stellargraph"

--- a/meta.yaml
+++ b/meta.yaml
@@ -16,38 +16,38 @@ requirements:
   host:
     - gensim >=3.4.0
     - matplotlib >=2.2
-    - networkx >=2.2,<2.4
+    - networkx >=2.2
     - numpy >=1.14
     - pandas >=0.24
     - pip
     - python
-    - scikit-learn >=0.20
+    - scikit_learn >=0.20
     - scipy >=1.1.0
-    - tensorflow 1.14.*
-    - ipython
-    - ipykernel
+    - tensorflow >=2.1.0
   run:
     - gensim >=3.4.0
     - matplotlib >=2.2
-    - networkx >=2.2,<2.4
+    - networkx >=2.2
     - numpy >=1.14
     - pandas >=0.24
     - python
-    - scikit-learn >=0.20
+    - scikit_learn >=0.20
     - scipy >=1.1.0
-    - tensorflow 1.14.*
-    - ipython
-    - ipykernel
+    - tensorflow >=2.1.0
 
 test:
   imports:
     - stellargraph
+    - stellargraph.connector
+    - stellargraph.connector.neo4j
     - stellargraph.core
     - stellargraph.data
+    - stellargraph.datasets
+    - stellargraph.interpretability
+    - stellargraph.interpretability.saliency_maps
     - stellargraph.layer
     - stellargraph.mapper
     - stellargraph.utils
-    - stellargraph.interpretability.saliency_maps
 
 about:
   home: "https://github.com/stellargraph/stellargraph"

--- a/meta.yaml
+++ b/meta.yaml
@@ -16,24 +16,28 @@ requirements:
   host:
     - gensim >=3.4.0
     - matplotlib >=2.2
-    - networkx >=2.2
+    - networkx >=2.2,<2.4
     - numpy >=1.14
     - pandas >=0.24
     - pip
     - python
-    - scikit_learn >=0.20
+    - scikit-learn >=0.20
     - scipy >=1.1.0
     - tensorflow >=2.1.0
+    - ipython
+    - ipykernel
   run:
     - gensim >=3.4.0
     - matplotlib >=2.2
-    - networkx >=2.2
+    - networkx >=2.2,<2.4
     - numpy >=1.14
     - pandas >=0.24
     - python
-    - scikit_learn >=0.20
+    - scikit-learn >=0.20
     - scipy >=1.1.0
     - tensorflow >=2.1.0
+    - ipython
+    - ipykernel
 
 test:
   imports:


### PR DESCRIPTION
`conda build` fails at the test stage due to moved saliency_maps code - the test imports section needs to be updated due to API changes this release.

In addition, the requirements are very old and haven't been correct for the last few Conda releases of StellarGraph - TensorFlow needs to be updated to version 2.1.   Unfortunately, this is only possible currently for Windows and Linux - Anaconda have not yet released a Mac version of TensorFlow 2.1: https://github.com/tensorflow/tensorflow/issues/35754

A fresh attempt at `meta.yaml` was generated using `conda skeleton pypi stellargraph` (with the v0.11 already on PyPI) - suggested package changes were then made to the original `meta.yaml`.

See: #1166