### PR TITLE
Allow instantiating random walk classes with pre-defined hyper-parameters

### DIFF
--- a/stellargraph/data/explorer.py
+++ b/stellargraph/data/explorer.py
@@ -42,7 +42,7 @@ def _default_if_none(value, default, name, ensure_not_none=True):
     value = value if value is not None else default
     if ensure_not_none and value is None:
         raise ValueError(
-            f"{name}: expected a value to be specified in either `__init__` or `run`, found: None."
+            f"{name}: expected a value to be specified in either `__init__` or `run`, found None in both"
         )
     return value
 
@@ -191,15 +191,14 @@ class UniformRandomWalk(GraphWalk):
 
     Args:
         graph (StellarGraph): Graph to traverse
-        graph_schema (GraphSchema, optional): Graph schema
         n (int, optional): Total number of random walks per root node
         length (int, optional): Maximum length of each random walk
         seed (int, optional): Random number generator seed
 
     """
 
-    def __init__(self, graph, graph_schema=None, n=None, length=None, seed=None):
-        super().__init__(graph, graph_schema=graph_schema, seed=seed)
+    def __init__(self, graph, n=None, length=None, seed=None):
+        super().__init__(graph, graph_schema=None, seed=seed)
         self.n = n
         self.length = length
 
@@ -284,7 +283,6 @@ class BiasedRandomWalk(GraphWalk):
 
     Args:
         graph (StellarGraph): Graph to traverse
-        graph_schema (GraphSchema, optional): Graph schema
         n (int, optional): Total number of random walks per root node
         length (int, optional): Maximum length of each random walk
         p (float, optional): Defines probability, 1/p, of returning to source node
@@ -295,17 +293,9 @@ class BiasedRandomWalk(GraphWalk):
     """
 
     def __init__(
-        self,
-        graph,
-        graph_schema=None,
-        n=None,
-        length=None,
-        p=1.0,
-        q=1.0,
-        weighted=False,
-        seed=None,
+        self, graph, n=None, length=None, p=1.0, q=1.0, weighted=False, seed=None,
     ):
-        super().__init__(graph, graph_schema=graph_schema, seed=seed)
+        super().__init__(graph, graph_schema=None, seed=seed)
         self.n = n
         self.length = length
         self.p = p
@@ -465,7 +455,6 @@ class UniformRandomMetaPathWalk(GraphWalk):
 
     Args:
         graph (StellarGraph): Graph to traverse
-        graph_schema (GraphSchema, optional): Graph schema
         n (int, optional): Total number of random walks per root node
         length (int, optional): Maximum length of each random walk
         metapaths (list of list, optional): List of lists of node labels that specify a metapath schema, e.g.,
@@ -476,9 +465,9 @@ class UniformRandomMetaPathWalk(GraphWalk):
     """
 
     def __init__(
-        self, graph, graph_schema=None, n=None, length=None, metapaths=None, seed=None,
+        self, graph, n=None, length=None, metapaths=None, seed=None,
     ):
-        super().__init__(graph, graph_schema=graph_schema, seed=seed)
+        super().__init__(graph, graph_schema=None, seed=seed)
         self.n = n
         self.length = length
         self.metapaths = metapaths
@@ -877,7 +866,6 @@ class TemporalRandomWalk(GraphWalk):
 
     Args:
         graph (StellarGraph): Graph to traverse
-        graph_schema (GraphSchema, optional): Graph schema
         cw_size (int, optional): Size of context window. Also used as the minimum walk length,
             since a walk must generate at least 1 context window for it to be useful.
         max_walk_length (int, optional): Maximum length of each random walk. Should be greater
@@ -908,7 +896,6 @@ class TemporalRandomWalk(GraphWalk):
     def __init__(
         self,
         graph,
-        graph_schema=None,
         cw_size=None,
         max_walk_length=80,
         initial_edge_bias=None,
@@ -916,7 +903,7 @@ class TemporalRandomWalk(GraphWalk):
         p_walk_success_threshold=0.01,
         seed=None,
     ):
-        super().__init__(graph, graph_schema=graph_schema, seed=seed)
+        super().__init__(graph, graph_schema=None, seed=seed)
         self.cw_size = cw_size
         self.max_walk_length = max_walk_length
         self.initial_edge_bias = initial_edge_bias

--- a/stellargraph/data/explorer.py
+++ b/stellargraph/data/explorer.py
@@ -41,7 +41,9 @@ from ..random import random_state
 def _default_if_none(value, default, name, ensure_not_none=True):
     value = value if value is not None else default
     if ensure_not_none and value is None:
-        raise ValueError(f"{name}: expected a value, found: None.")
+        raise ValueError(
+            f"{name}: expected a value to be specified in either `__init__` or `run`, found: None."
+        )
     return value
 
 

--- a/stellargraph/data/explorer.py
+++ b/stellargraph/data/explorer.py
@@ -458,7 +458,8 @@ class BiasedRandomWalk(GraphWalk):
 
 class UniformRandomMetaPathWalk(GraphWalk):
     """
-    For heterogeneous graphs, it performs uniform random walks based on given metapaths.
+    For heterogeneous graphs, it performs uniform random walks based on given metapaths. Optional
+    parameters default to using the values passed in during construction.
 
     Args:
         graph (StellarGraph): Graph to traverse
@@ -932,6 +933,7 @@ class TemporalRandomWalk(GraphWalk):
     ):
         """
         Perform a time respecting random walk starting from randomly selected temporal edges.
+        Optional parameters default to using the values passed in during construction.
 
         Args:
             num_cw (int): Total number of context windows to generate. For comparable

--- a/tests/data/test_biased_random_walker.py
+++ b/tests/data/test_biased_random_walker.py
@@ -90,6 +90,21 @@ class TestBiasedWeightedRandomWalk(object):
                 nodes=nodes, n=n, p=p, q=q, length=length, seed=seed, weighted="unknown"
             )
 
+    def test_init_parameters(self):
+        g = weighted(1, 2, 3, 4)
+        nodes = list(g.nodes())
+        n = 4
+        length = 4
+        seed = 42
+        p = 1.0
+        q = 1.0
+
+        rw = BiasedRandomWalk(g, n=n, p=p, q=q, length=length, seed=seed, weighted=True)
+        rw_no_params = BiasedRandomWalk(g)
+        assert rw.run(nodes=nodes) == rw_no_params.run(
+            nodes=nodes, n=n, p=p, q=q, length=length, seed=seed, weighted=True
+        )
+
     def test_identity_unweighted_weighted_1_walks(self):
 
         # graph with all edge weights = 1

--- a/tests/data/test_metapath_walker.py
+++ b/tests/data/test_metapath_walker.py
@@ -294,6 +294,23 @@ class TestMetaPathWalk(object):
         for walk in walks:
             assert len(walk) <= length  # test against maximum walk length
 
+    def test_init_parameters(self):
+        g = create_test_graph()
+        n = 2
+        length = 15
+        metapaths = [["s", "n", "n", "s"]]
+        seed = 42
+        nodes = ["0", "5"]
+
+        mrw = UniformRandomMetaPathWalk(
+            g, n=n, length=length, metapaths=metapaths, seed=seed
+        )
+        mrw_no_params = UniformRandomMetaPathWalk(g)
+
+        assert mrw.run(nodes=nodes) == mrw_no_params.run(
+            nodes=nodes, n=n, length=length, metapaths=metapaths, seed=seed
+        )
+
     def test_benchmark_uniformrandommetapathwalk(self, benchmark):
 
         g = create_test_graph()

--- a/tests/data/test_temporal_random_walker.py
+++ b/tests/data/test_temporal_random_walker.py
@@ -103,3 +103,20 @@ def test_cw_size_and_walk_length(temporal_graph, cw_size):
         num_cw_obtained = sum([len(walk) - cw_size + 1 for walk in walks])
         assert num_cw == num_cw_obtained
         assert max(map(len, walks)) <= max_walk_length
+
+
+def test_init_parameters(temporal_graph):
+
+    num_cw = 5
+    cw_size = 3
+    max_walk_length = 3
+    seed = 0
+
+    rw = TemporalRandomWalk(
+        temporal_graph, cw_size=cw_size, max_walk_length=max_walk_length, seed=seed
+    )
+    rw_no_params = TemporalRandomWalk(temporal_graph)
+
+    assert rw.run(num_cw=num_cw) == rw_no_params.run(
+        num_cw=num_cw, cw_size=cw_size, max_walk_length=max_walk_length, seed=seed
+    )

--- a/tests/data/test_uniform_random_walker.py
+++ b/tests/data/test_uniform_random_walker.py
@@ -222,6 +222,21 @@ class TestUniformRandomWalk(object):
             for node in subgraph:
                 assert node == "self loner"  # all nodes should be the same node
 
+    def test_init_parameters(self):
+        g = create_test_graph()
+
+        nodes = ["0", 2]
+        n = 1
+        length = 2
+        seed = 0
+
+        urw = UniformRandomWalk(g, n=n, length=length, seed=seed)
+        urw_no_params = UniformRandomWalk(g)
+
+        assert urw.run(nodes=nodes) == urw_no_params.run(
+            nodes=nodes, n=n, length=length, seed=seed
+        )
+
     def test_benchmark_uniformrandomwalk(self, benchmark):
 
         g = create_test_graph()


### PR DESCRIPTION
This updates the `__init__` and `run` methods for the random walker classes:
* `UniformRandomWalk`
* `BiasedRandomWalk`
* `UniformRandomMetaPathWalk`
* `TemporalRandomWalk`

which are all supposed to be suitable for obtaining context pairs for unsupervised learning. This refactoring would allow users to instantiate a walker object with its hyperparameters pre-defined.

If this seems reasonable, I was hoping to do a bit more follow-up to make #919 and #536 possible:
* define a separate class for random walkers instead of `GraphWalk` (which currently also contains BFS-type walkers for the SAGE algorithms) - maybe just `RandomWalk`?
* update `UnsupervisedSampler` to optionally take a `RandomWalk` object as a parameter.

Thoughts?

See #1178 
