### PR TITLE
Allow flexible walker for unsupervised sampler using new base class RandomWalk

### DIFF
--- a/stellargraph/data/explorer.py
+++ b/stellargraph/data/explorer.py
@@ -56,6 +56,12 @@ def _ensure_int(value, name, min_value):
 
 
 class RandomWalk(ABC):
+    """
+    Abstract base class for Random Walk classes. A Random Walk class must implement a ``run`` method
+    which takes an iterable of node IDs and returns a list of walks. Each walk is a list of node IDs
+    that contains the starting node as its first element.
+    """
+
     def __init__(self, graph, seed=None):
         if not isinstance(graph, StellarGraph):
             raise TypeError("Graph must be a StellarGraph or StellarDiGraph.")

--- a/stellargraph/data/explorer.py
+++ b/stellargraph/data/explorer.py
@@ -34,7 +34,7 @@ from scipy.special import softmax
 from ..core.schema import GraphSchema
 from ..core.graph import StellarGraph
 from ..core.utils import is_real_iterable
-from ..core.experimental import experimental
+from ..core.validation import require_integer_in_range
 from ..random import random_state
 from abc import ABC, abstractmethod
 
@@ -46,13 +46,6 @@ def _default_if_none(value, default, name, ensure_not_none=True):
             f"{name}: expected a value to be specified in either `__init__` or `run`, found None in both"
         )
     return value
-
-
-def _ensure_int(value, name, min_value):
-    if not isinstance(value, int) or value < min_value:
-        raise ValueError(
-            f"{name}: expected an integer greater than or equal to {min_value}, found: {value}"
-        )
 
 
 class RandomWalk(ABC):
@@ -81,7 +74,7 @@ class RandomWalk(ABC):
             # Restore the random state
             return self._random_state
         # seed the random number generator
-        _ensure_int(seed, "seed", min_value=0)
+        require_integer_in_range(seed, "seed", min_val=0)
         rs, _ = random_state(seed)
         return rs
 
@@ -96,8 +89,8 @@ class RandomWalk(ABC):
                 stacklevel=3,
             )
 
-        _ensure_int(n, "n", min_value=1)
-        _ensure_int(length, "length", min_value=1)
+        require_integer_in_range(n, "n", min_val=1)
+        require_integer_in_range(length, "length", min_val=1)
 
     @abstractmethod
     def run(self, nodes, **kwargs):
@@ -159,7 +152,7 @@ class GraphWalk(object):
             The random state as determined by the seed.
         """
         if seed is None:
-            # Restore the random state
+            # Use the class's random state
             return self._random_state
         # seed the random number generator
         rs, _ = random_state(seed)
@@ -259,7 +252,7 @@ class UniformRandomWalk(RandomWalk):
         self.n = n
         self.length = length
 
-    def run(self, nodes, n=None, length=None, seed=None):
+    def run(self, nodes, *, n=None, length=None, seed=None):
         """
         Perform a random walk starting from the root nodes. Optional parameters default to using the
         values passed in during construction.
@@ -359,7 +352,9 @@ class BiasedRandomWalk(RandomWalk):
         self.q = q
         self.weighted = weighted
 
-    def run(self, nodes, n=None, length=None, p=None, q=None, seed=None, weighted=None):
+    def run(
+        self, nodes, *, n=None, length=None, p=None, q=None, seed=None, weighted=None
+    ):
 
         """
         Perform a random walk starting from the root nodes. Optional parameters default to using the
@@ -517,7 +512,7 @@ class UniformRandomMetaPathWalk(RandomWalk):
         self.length = length
         self.metapaths = metapaths
 
-    def run(self, nodes, n=None, length=None, metapaths=None, seed=None):
+    def run(self, nodes, *, n=None, length=None, metapaths=None, seed=None):
         """
         Performs metapath-driven uniform random walks on heterogeneous graphs.
 

--- a/stellargraph/data/explorer.py
+++ b/stellargraph/data/explorer.py
@@ -388,13 +388,13 @@ class BiasedRandomWalk(RandomWalk):
         rs = self._get_random_state(seed)
 
         if weighted:
-
             # Check that all edge weights are greater than or equal to 0.
             # Also, if the given graph is a MultiGraph, then check that there are no two edges between
             # the same two nodes with different weights.
             for node in self.graph.nodes():
                 # TODO Encapsulate edge weights
                 for neighbor in self.graph.neighbors(node):
+
                     wts = set()
                     name = f"Edge weight between ({node}) and ({neighbor})"
                     for weight in self.graph._edge_weights(node, neighbor):

--- a/stellargraph/data/explorer.py
+++ b/stellargraph/data/explorer.py
@@ -36,6 +36,7 @@ from ..core.graph import StellarGraph
 from ..core.utils import is_real_iterable
 from ..core.experimental import experimental
 from ..random import random_state
+from abc import ABC, abstractmethod
 
 
 def _default_if_none(value, default, name, ensure_not_none=True):
@@ -45,6 +46,56 @@ def _default_if_none(value, default, name, ensure_not_none=True):
             f"{name}: expected a value to be specified in either `__init__` or `run`, found None in both"
         )
     return value
+
+
+def _ensure_int(value, name, min_value):
+    if not isinstance(value, int) or value < min_value:
+        raise ValueError(
+            f"{name}: expected an integer greater than or equal to {min_value}, found: {value}"
+        )
+
+
+class RandomWalk(ABC):
+    def __init__(self, graph, seed=None):
+        if not isinstance(graph, StellarGraph):
+            raise TypeError("Graph must be a StellarGraph or StellarDiGraph.")
+
+        self.graph = graph
+        self._random_state, self._np_random_state = random_state(seed)
+
+    def _get_random_state(self, seed):
+        """
+        Args:
+            seed: The optional seed value for a given run.
+
+        Returns:
+            The random state as determined by the seed.
+        """
+        if seed is None:
+            # Restore the random state
+            return self._random_state
+        # seed the random number generator
+        _ensure_int(seed, "seed", min_value=0)
+        rs, _ = random_state(seed)
+        return rs
+
+    @staticmethod
+    def _validate_walk_params(nodes, n, length):
+        if not is_real_iterable(nodes):
+            raise ValueError(f"nodes: expected an iterable, found: {nodes}")
+        if len(nodes) == 0:
+            warnings.warn(
+                "No root node IDs given. An empty list will be returned as a result.",
+                RuntimeWarning,
+                stacklevel=3,
+            )
+
+        _ensure_int(n, "n", min_value=1)
+        _ensure_int(length, "length", min_value=1)
+
+    @abstractmethod
+    def run(self, nodes, **kwargs):
+        pass
 
 
 class GraphWalk(object):
@@ -185,7 +236,7 @@ class GraphWalk(object):
                 self._raise_error(err_msg)
 
 
-class UniformRandomWalk(GraphWalk):
+class UniformRandomWalk(RandomWalk):
     """
     Performs uniform random walks on the given graph
 
@@ -198,7 +249,7 @@ class UniformRandomWalk(GraphWalk):
     """
 
     def __init__(self, graph, n=None, length=None, seed=None):
-        super().__init__(graph, graph_schema=None, seed=seed)
+        super().__init__(graph, seed=seed)
         self.n = n
         self.length = length
 
@@ -219,7 +270,7 @@ class UniformRandomWalk(GraphWalk):
         """
         n = _default_if_none(n, self.n, "n")
         length = _default_if_none(length, self.length, "length")
-        self._check_common_parameters(nodes, n, length, seed)
+        self._validate_walk_params(nodes, n, length)
         rs = self._get_random_state(seed)
 
         # for each root node, do n walks
@@ -229,7 +280,7 @@ class UniformRandomWalk(GraphWalk):
         walk = [start_node]
         current_node = start_node
         for _ in range(length - 1):
-            neighbours = self.neighbors(current_node)
+            neighbours = self.graph.neighbors(current_node)
             if not neighbours:
                 # dead end, so stop
                 break
@@ -276,7 +327,7 @@ def naive_weighted_choices(rs, weights):
     return idx
 
 
-class BiasedRandomWalk(GraphWalk):
+class BiasedRandomWalk(RandomWalk):
     """
     Performs biased second order random walks (like those used in Node2Vec algorithm
     https://snap.stanford.edu/node2vec/) controlled by the values of two parameters p and q.
@@ -295,7 +346,7 @@ class BiasedRandomWalk(GraphWalk):
     def __init__(
         self, graph, n=None, length=None, p=1.0, q=1.0, weighted=False, seed=None,
     ):
-        super().__init__(graph, graph_schema=None, seed=seed)
+        super().__init__(graph, seed=seed)
         self.n = n
         self.length = length
         self.p = p
@@ -326,46 +377,36 @@ class BiasedRandomWalk(GraphWalk):
         p = _default_if_none(p, self.p, "p")
         q = _default_if_none(q, self.q, "q")
         weighted = _default_if_none(weighted, self.weighted, "weighted")
-        self._check_common_parameters(nodes, n, length, seed)
+        self._validate_walk_params(nodes, n, length)
         self._check_weights(p, q, weighted)
         rs = self._get_random_state(seed)
 
         if weighted:
+
             # Check that all edge weights are greater than or equal to 0.
             # Also, if the given graph is a MultiGraph, then check that there are no two edges between
             # the same two nodes with different weights.
             for node in self.graph.nodes():
                 # TODO Encapsulate edge weights
                 for neighbor in self.graph.neighbors(node):
-
                     wts = set()
+                    name = f"Edge weight between ({node}) and ({neighbor})"
                     for weight in self.graph._edge_weights(node, neighbor):
-                        if weight is None or np.isnan(weight) or weight == np.inf:
-                            self._raise_error(
-                                "Missing or invalid edge weight ({}) between ({}) and ({}).".format(
-                                    weight, node, neighbor
-                                )
+                        weight_is_valid = (
+                            isinstance(weight, (float, int))
+                            and np.isfinite(weight)
+                            and weight >= 0
+                        )
+                        if not weight_is_valid:
+                            raise ValueError(
+                                f"{name}: expected numeric value greater than or equal to 0, found {weight}"
                             )
-                        if not isinstance(weight, (int, float)):
-                            self._raise_error(
-                                "Edge weight between nodes ({}) and ({}) is not numeric ({}).".format(
-                                    node, neighbor, weight
-                                )
-                            )
-                        if weight < 0:  # check if edge has a negative weight
-                            self._raise_error(
-                                "An edge weight between nodes ({}) and ({}) is negative ({}).".format(
-                                    node, neighbor, weight
-                                )
-                            )
-
                         wts.add(weight)
                     if len(wts) > 1:
                         # multigraph with different weights on edges between same pair of nodes
-                        self._raise_error(
-                            "({}) and ({}) have multiple edges with weights ({}). Ambiguous to choose an edge for the random walk.".format(
-                                node, neighbor, list(wts)
-                            )
+                        raise ValueError(
+                            f"{name}: expected all edges between two particular nodes to have the "
+                            f"same weight value, found {list(wts)}"
                         )
 
         ip = 1.0 / p
@@ -377,7 +418,7 @@ class BiasedRandomWalk(GraphWalk):
                 # the walk starts at the root
                 walk = [node]
 
-                neighbours = self.neighbors(node)
+                neighbours = self.graph.neighbors(node)
 
                 previous_node = node
                 previous_node_neighbours = neighbours
@@ -403,7 +444,7 @@ class BiasedRandomWalk(GraphWalk):
                     current_node = rs.choice(neighbours)
                     for _ in range(length - 1):
                         walk.append(current_node)
-                        neighbours = self.neighbors(current_node)
+                        neighbours = self.graph.neighbors(current_node)
 
                         if not neighbours:
                             break
@@ -437,18 +478,16 @@ class BiasedRandomWalk(GraphWalk):
             weighted: <False or True> Indicates whether the walk is unweighted or weighted.
        """
         if p <= 0.0:
-            self._raise_error("Parameter p should be greater than 0.")
+            raise ValueError(f"p: expected positive numeric value, found {p}")
 
         if q <= 0.0:
-            self._raise_error("Parameter q should be greater than 0.")
+            raise ValueError(f"q: expected positive numeric value, found {q}")
 
         if type(weighted) != bool:
-            self._raise_error(
-                "Parameter weighted has to be either False (unweighted random walks) or True (weighted random walks)."
-            )
+            raise ValueError(f"weighted: expected boolean value, found {weighted}")
 
 
-class UniformRandomMetaPathWalk(GraphWalk):
+class UniformRandomMetaPathWalk(RandomWalk):
     """
     For heterogeneous graphs, it performs uniform random walks based on given metapaths. Optional
     parameters default to using the values passed in during construction.
@@ -467,7 +506,7 @@ class UniformRandomMetaPathWalk(GraphWalk):
     def __init__(
         self, graph, n=None, length=None, metapaths=None, seed=None,
     ):
-        super().__init__(graph, graph_schema=None, seed=seed)
+        super().__init__(graph, seed=seed)
         self.n = n
         self.length = length
         self.metapaths = metapaths
@@ -491,7 +530,7 @@ class UniformRandomMetaPathWalk(GraphWalk):
         n = _default_if_none(n, self.n, "n")
         length = _default_if_none(length, self.length, "length")
         metapaths = _default_if_none(metapaths, self.metapaths, "metapaths")
-        self._check_common_parameters(nodes, n, length, seed)
+        self._validate_walk_params(nodes, n, length)
         self._check_metapath_values(metapaths)
         rs = self._get_random_state(seed)
 
@@ -522,7 +561,7 @@ class UniformRandomMetaPathWalk(GraphWalk):
                     for d in range(length):
                         walk.append(current_node)
                         # d+1 can also be used to index metapath to retrieve the node type for the next step in the walk
-                        neighbours = self.neighbors(current_node)
+                        neighbours = self.graph.neighbors(current_node)
                         # filter these by node type
                         neighbours = [
                             n_node
@@ -551,20 +590,24 @@ class UniformRandomMetaPathWalk(GraphWalk):
                 [['Author', 'Paper', 'Author'], ['Author, 'Paper', 'Venue', 'Paper', 'Author']] specifies two metapath
                 schemas of length 3 and 5 respectively.
         """
+
+        def raise_error(msg):
+            raise ValueError(f"metapaths: {msg}, found {metapaths}")
+
         if type(metapaths) != list:
-            self._raise_error("The metapaths parameter must be a list of lists.")
+            raise_error("expected list of lists.")
         for metapath in metapaths:
             if type(metapath) != list:
-                self._raise_error("Each metapath must be list type of node labels")
+                raise_error("expected each metapath to be a list of node labels")
             if len(metapath) < 2:
-                self._raise_error("Each metapath must specify at least two node types")
+                raise_error("expected each metapath to specify at least two node types")
 
             for node_label in metapath:
                 if type(node_label) != str:
-                    self._raise_error("Node labels in metapaths must be string type.")
+                    raise_error("expected each node type in metapaths to be a string")
             if metapath[0] != metapath[-1]:
-                self._raise_error(
-                    "The first and last node type in a metapath should be the same."
+                raise_error(
+                    "expected the first and last node type in a metapath to be the same"
                 )
 
 

--- a/stellargraph/data/unsupervised_sampler.py
+++ b/stellargraph/data/unsupervised_sampler.py
@@ -24,6 +24,15 @@ from stellargraph.core.utils import is_real_iterable
 from stellargraph.core.graph import StellarGraph
 from stellargraph.data.explorer import UniformRandomWalk
 from stellargraph.random import random_state
+import warnings
+
+
+def _warn_if_ignored(value, default, name):
+    if value != default:
+        warnings.warn(
+            f"walker, {name}: 'walker' was provided so '{name}' parameter will be ignored",
+            stacklevel=3,
+        )
 
 
 class UnsupervisedSampler:
@@ -64,6 +73,9 @@ class UnsupervisedSampler:
 
         # Instantiate the walker class used to generate random walks in the graph
         if walker is not None:
+            _warn_if_ignored(length, 2, "length")
+            _warn_if_ignored(number_of_walks, 1, "number_of_walks")
+            _warn_if_ignored(seed, None, "seed")
             self.walker = walker
         else:
             self.walker = UniformRandomWalk(

--- a/stellargraph/data/unsupervised_sampler.py
+++ b/stellargraph/data/unsupervised_sampler.py
@@ -39,13 +39,19 @@ class UnsupervisedSampler:
 
         Args:
             G (StellarGraph): A stellargraph with features.
-            nodes (optional, iterable) The root nodes from which individual walks start.
+            nodes (iterable, optional) The root nodes from which individual walks start.
                 If not provided, all nodes in the graph are used.
             length (int): An integer giving the length of the walks. Length must be at least 2.
             number_of_walks (int): Number of walks from each root node.
+            seed (int, optional): Random seed
+            walker (RandomWalk, optional): The unsupervised sampler uses the other parameters to
+                instantiate a UniformRandomWalk by default. Using this parameter will override this,
+                and use the RandomWalk object provided by the user.
     """
 
-    def __init__(self, G, nodes=None, length=2, number_of_walks=1, seed=None):
+    def __init__(
+        self, G, nodes=None, length=2, number_of_walks=1, seed=None, walker=None,
+    ):
         if not isinstance(G, StellarGraph):
             raise ValueError(
                 "({}) Graph must be a StellarGraph or StellarDigraph object.".format(
@@ -56,23 +62,12 @@ class UnsupervisedSampler:
             self.graph = G
 
         # Instantiate the walker class used to generate random walks in the graph
-        self.walker = UniformRandomWalk(G, seed=seed)
-
-        # This code will enable alternative walker classes
-        # TODO: Enable this code, but figure out how to pass required options to run
-        # if walker is not None:
-        #     if not isinstance(
-        #         walker, UniformRandomWalk
-        #     ):  # only work with Uniform Random Walker at the moment
-        #         raise TypeError(
-        #             "({}) Only Uniform Random Walks are possible".format(
-        #                 type(self).__name__
-        #             )
-        #         )
-        #     else:
-        #         self.walker = walker(G, seed=seed)
-        # else:
-        #         self.walker = UniformRandomWalk(G, seed=seed)
+        if walker is not None:
+            self.walker = walker
+        else:
+            self.walker = UniformRandomWalk(
+                G, n=number_of_walks, length=length, seed=seed
+            )
 
         # Define the root nodes for the walks
         # if no root nodes are provided for sampling defaulting to using all nodes as root nodes.
@@ -134,9 +129,7 @@ class UnsupervisedSampler:
             sampling_distribution
         )
 
-        walks = self.walker.run(
-            nodes=self.nodes, length=self.length, n=self.number_of_walks
-        )
+        walks = self.walker.run(nodes=self.nodes)
 
         # first item in each walk is the target/head node
         targets = [walk[0] for walk in walks]

--- a/stellargraph/data/unsupervised_sampler.py
+++ b/stellargraph/data/unsupervised_sampler.py
@@ -24,14 +24,12 @@ from stellargraph.core.utils import is_real_iterable
 from stellargraph.core.graph import StellarGraph
 from stellargraph.data.explorer import UniformRandomWalk
 from stellargraph.random import random_state
-import warnings
 
 
 def _warn_if_ignored(value, default, name):
     if value != default:
-        warnings.warn(
-            f"walker, {name}: 'walker' was provided so '{name}' parameter will be ignored",
-            stacklevel=3,
+        raise ValueError(
+            f"walker, {name}: cannot specify both 'walker' and '{name}'. Please use one or the other."
         )
 
 
@@ -43,20 +41,20 @@ class UnsupervisedSampler:
         The positive samples are all the (target, context) pairs from the walks and the negative
         samples are contexts generated for each target based on a sampling distribtution.
 
-        Currently only uniform random walks are performed, other walk strategies (such as
-        second order walks) will be enabled in the future.
+        By default, a UniformRandomWalk is used, but a custom `walker` can be specified instead. An
+        error will be raised if other parameters are specified along with a custom `walker`.
 
         Args:
             G (StellarGraph): A stellargraph with features.
             nodes (iterable, optional) The root nodes from which individual walks start.
                 If not provided, all nodes in the graph are used.
-            length (int): An integer giving the length of the walks. Length must be at least 2.
-            number_of_walks (int): Number of walks from each root node.
-            seed (int, optional): Random seed
-            walker (RandomWalk, optional): By default, the unsupervised sampler instantiates a
-                UniformRandomWalk using the other provided parameters. However, if `walker` is
-                specified, this will override the default behaviour and use the RandomWalk object
-                provided by the user instead.
+            length (int): Length of the walks for the default UniformRandomWalk walker. Length must
+                be at least 2.
+            number_of_walks (int): Number of walks from each root node for the default
+                UniformRandomWalk walker.
+            seed (int, optional): Random seed for the default UniformRandomWalk walker.
+            walker (RandomWalk, optional): A RandomWalk object to use instead of the default
+                UniformRandomWalk walker.
     """
 
     def __init__(

--- a/stellargraph/data/unsupervised_sampler.py
+++ b/stellargraph/data/unsupervised_sampler.py
@@ -44,9 +44,10 @@ class UnsupervisedSampler:
             length (int): An integer giving the length of the walks. Length must be at least 2.
             number_of_walks (int): Number of walks from each root node.
             seed (int, optional): Random seed
-            walker (RandomWalk, optional): The unsupervised sampler uses the other parameters to
-                instantiate a UniformRandomWalk by default. Using this parameter will override this,
-                and use the RandomWalk object provided by the user.
+            walker (RandomWalk, optional): By default, the unsupervised sampler instantiates a
+                UniformRandomWalk using the other provided parameters. However, if `walker` is
+                specified, this will override the default behaviour and use the RandomWalk object
+                provided by the user instead.
     """
 
     def __init__(

--- a/tests/data/test_biased_random_walker.py
+++ b/tests/data/test_biased_random_walker.py
@@ -245,13 +245,13 @@ class TestBiasedRandomWalk(object):
             biasedrw.run(nodes=nodes, n=0, p=p, q=q, length=length, seed=seed)
         with pytest.raises(ValueError):
             biasedrw.run(nodes=nodes, n=-121, p=p, q=q, length=length, seed=seed)
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             biasedrw.run(nodes=nodes, n=21.4, p=p, q=q, length=length, seed=seed)
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             biasedrw.run(nodes=nodes, n=-0.5, p=p, q=q, length=length, seed=seed)
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             biasedrw.run(nodes=nodes, n=0.0001, p=p, q=q, length=length, seed=seed)
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             biasedrw.run(nodes=nodes, n="2", p=p, q=q, length=length, seed=seed)
 
         # p has to be > 0.
@@ -275,17 +275,17 @@ class TestBiasedRandomWalk(object):
             biasedrw.run(nodes=nodes, n=n, p=p, q=q, length=0, seed=seed)
         with pytest.raises(ValueError):
             biasedrw.run(nodes=nodes, n=n, p=p, q=q, length=-5, seed=seed)
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             biasedrw.run(nodes=nodes, n=n, p=p, q=q, length=11.9, seed=seed)
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             biasedrw.run(nodes=nodes, n=n, p=p, q=q, length=-9.9, seed=seed)
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             biasedrw.run(nodes=nodes, n=n, p=p, q=q, length="10", seed=seed)
 
         # seed has to be None, 0,  or positive integer
         with pytest.raises(ValueError):
             biasedrw.run(nodes=nodes, n=n, p=p, q=q, length=length, seed=-1)
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             biasedrw.run(nodes=nodes, n=n, p=p, q=q, length=length, seed=1010.8)
 
         # If no root nodes are given, an empty list is returned which is not an error but I thought this method

--- a/tests/data/test_metapath_walker.py
+++ b/tests/data/test_metapath_walker.py
@@ -88,7 +88,7 @@ class TestMetaPathWalk(object):
         # n has to be positive integer
         with pytest.raises(ValueError):
             mrw.run(nodes=nodes, n=-1, length=length, metapaths=metapaths, seed=seed)
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             mrw.run(nodes=nodes, n=11.4, length=length, metapaths=metapaths, seed=seed)
         with pytest.raises(ValueError):
             mrw.run(nodes=nodes, n=0, length=length, metapaths=metapaths, seed=seed)
@@ -97,9 +97,9 @@ class TestMetaPathWalk(object):
             mrw.run(nodes=nodes, n=n, length=-3, metapaths=metapaths, seed=seed)
         with pytest.raises(ValueError):
             mrw.run(nodes=nodes, n=n, length=0, metapaths=metapaths, seed=seed)
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             mrw.run(nodes=nodes, n=n, length=4.6, metapaths=metapaths, seed=seed)
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             mrw.run(nodes=nodes, n=n, length=1.0000001, metapaths=metapaths, seed=seed)
         # metapaths have to start and end with the same node type
         with pytest.raises(ValueError):
@@ -145,7 +145,7 @@ class TestMetaPathWalk(object):
         # seed has to be integer or None
         with pytest.raises(ValueError):
             mrw.run(nodes=nodes, n=n, length=length, metapaths=metapaths, seed=-1)
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             mrw.run(nodes=nodes, n=n, length=length, metapaths=metapaths, seed=1000.345)
 
         # If no root nodes are given, an empty list is returned which is not an error but I thought this method

--- a/tests/data/test_uniform_random_walker.py
+++ b/tests/data/test_uniform_random_walker.py
@@ -41,13 +41,13 @@ class TestUniformRandomWalk(object):
             urw.run(nodes=nodes, n=0, length=length, seed=seed)
         with pytest.raises(ValueError):
             urw.run(nodes=nodes, n=-121, length=length, seed=seed)
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             urw.run(nodes=nodes, n=21.4, length=length, seed=seed)
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             urw.run(nodes=nodes, n=-0.5, length=length, seed=seed)
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             urw.run(nodes=nodes, n=0.0001, length=length, seed=seed)
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             urw.run(nodes=nodes, n="2", length=length, seed=seed)
 
         # length has to be positive integer
@@ -55,17 +55,17 @@ class TestUniformRandomWalk(object):
             urw.run(nodes=nodes, n=n, length=0, seed=seed)
         with pytest.raises(ValueError):
             urw.run(nodes=nodes, n=n, length=-5, seed=seed)
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             urw.run(nodes=nodes, n=n, length=11.9, seed=seed)
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             urw.run(nodes=nodes, n=n, length=-9.9, seed=seed)
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             urw.run(nodes=nodes, n=n, length="10", seed=seed)
 
         # seed has to be None, 0,  or positive integer
         with pytest.raises(ValueError):
             urw.run(nodes=nodes, n=n, length=length, seed=-1)
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             urw.run(nodes=nodes, n=n, length=length, seed=1010.8)
 
         # If no root nodes are given, an empty list is returned which is not an error but I thought this method

--- a/tests/data/test_unsupervised_sampler.py
+++ b/tests/data/test_unsupervised_sampler.py
@@ -95,6 +95,8 @@ def test_walker_uniform_random(line_graph):
 
     batches = sampler.run(batch_size)
 
+    # batches should match the parameters used to create the walker object, instead of the defaults
+    # for UnsupervisedSampler
     expected_num_batches = np.ceil(
         line_graph.number_of_nodes() * number_of_walks * (length - 1) * 2 / batch_size
     )

--- a/tests/data/test_unsupervised_sampler.py
+++ b/tests/data/test_unsupervised_sampler.py
@@ -123,11 +123,11 @@ def test_walker_custom(line_graph):
 
 def test_ignored_param_warning(line_graph):
     walker = UniformRandomWalk(line_graph, n=2, length=3)
-    with pytest.warns(UserWarning):
+    with pytest.raises(ValueError, match="cannot specify both 'walker' and 'length'"):
         UnsupervisedSampler(line_graph, walker=walker, length=5)
 
-    with pytest.warns(UserWarning):
-        UnsupervisedSampler(line_graph, walker=walker, number_of_walks=5)
+    with pytest.raises(ValueError, match="cannot specify both 'walker' and 'number_of_walks'"):
+            UnsupervisedSampler(line_graph, walker=walker, number_of_walks=5)
 
-    with pytest.warns(UserWarning):
+    with pytest.raises(ValueError, match="cannot specify both 'walker' and 'seed'"):
         UnsupervisedSampler(line_graph, walker=walker, seed=1)

--- a/tests/data/test_unsupervised_sampler.py
+++ b/tests/data/test_unsupervised_sampler.py
@@ -117,3 +117,15 @@ def test_walker_custom(line_graph):
     for context_pairs, labels in batches:
         for node, neighbour in context_pairs[labels == 1]:
             assert node == neighbour
+
+
+def test_ignored_param_warning(line_graph):
+    walker = UniformRandomWalk(line_graph, n=2, length=3)
+    with pytest.warns(UserWarning):
+        UnsupervisedSampler(line_graph, walker=walker, length=5)
+
+    with pytest.warns(UserWarning):
+        UnsupervisedSampler(line_graph, walker=walker, number_of_walks=5)
+
+    with pytest.warns(UserWarning):
+        UnsupervisedSampler(line_graph, walker=walker, seed=1)

--- a/tests/data/test_unsupervised_sampler.py
+++ b/tests/data/test_unsupervised_sampler.py
@@ -126,8 +126,10 @@ def test_ignored_param_warning(line_graph):
     with pytest.raises(ValueError, match="cannot specify both 'walker' and 'length'"):
         UnsupervisedSampler(line_graph, walker=walker, length=5)
 
-    with pytest.raises(ValueError, match="cannot specify both 'walker' and 'number_of_walks'"):
-            UnsupervisedSampler(line_graph, walker=walker, number_of_walks=5)
+    with pytest.raises(
+        ValueError, match="cannot specify both 'walker' and 'number_of_walks'"
+    ):
+        UnsupervisedSampler(line_graph, walker=walker, number_of_walks=5)
 
     with pytest.raises(ValueError, match="cannot specify both 'walker' and 'seed'"):
         UnsupervisedSampler(line_graph, walker=walker, seed=1)

--- a/tests/data/test_unsupervised_sampler.py
+++ b/tests/data/test_unsupervised_sampler.py
@@ -19,65 +19,101 @@ import pytest
 import numpy as np
 from collections import defaultdict
 from stellargraph.data.unsupervised_sampler import UnsupervisedSampler
+from stellargraph.data.explorer import UniformRandomWalk
 from ..test_utils.graphs import line_graph
 
 
-class TestUnsupervisedSampler(object):
-    def test_UnsupervisedSampler_parameter(self, line_graph):
+def test_init_parameters(line_graph):
 
-        # if no graph is provided
-        with pytest.raises(ValueError):
-            UnsupervisedSampler(G=None)
+    # if no graph is provided
+    with pytest.raises(ValueError):
+        UnsupervisedSampler(G=None)
 
-        # walk must have length strictly greater than 1
-        with pytest.raises(ValueError):
-            UnsupervisedSampler(G=line_graph, length=1)
+    # walk must have length strictly greater than 1
+    with pytest.raises(ValueError):
+        UnsupervisedSampler(G=line_graph, length=1)
 
-        # at least 1 walk from each root node
-        with pytest.raises(ValueError):
-            UnsupervisedSampler(G=line_graph, number_of_walks=0)
+    # at least 1 walk from each root node
+    with pytest.raises(ValueError):
+        UnsupervisedSampler(G=line_graph, number_of_walks=0)
 
-        # nodes nodes parameter should be an iterable of node IDs
-        with pytest.raises(ValueError):
-            UnsupervisedSampler(G=line_graph, nodes=1)
+    # nodes nodes parameter should be an iterable of node IDs
+    with pytest.raises(ValueError):
+        UnsupervisedSampler(G=line_graph, nodes=1)
 
-        # if no root nodes are provided for sampling defaulting to using all nodes as root nodes
-        sampler = UnsupervisedSampler(G=line_graph, nodes=None)
-        assert sampler.nodes == list(line_graph.nodes())
+    # if no root nodes are provided for sampling defaulting to using all nodes as root nodes
+    sampler = UnsupervisedSampler(G=line_graph, nodes=None)
+    assert sampler.nodes == list(line_graph.nodes())
 
-    def test_run_batch_sizes(self, line_graph):
-        batch_size = 4
-        sampler = UnsupervisedSampler(G=line_graph, length=2, number_of_walks=2)
-        batches = sampler.run(batch_size)
 
-        # check batch sizes
-        assert len(batches) == np.ceil(len(line_graph.nodes()) * 4 / batch_size)
-        for ids, labels in batches[:-1]:
-            assert len(ids) == len(labels) == batch_size
+def test_run_batch_sizes(line_graph):
+    batch_size = 4
+    sampler = UnsupervisedSampler(G=line_graph, length=2, number_of_walks=2)
+    batches = sampler.run(batch_size)
 
-        # last batch can be smaller
-        ids, labels = batches[-1]
-        assert len(ids) == len(labels)
-        assert len(ids) <= batch_size
+    # check batch sizes
+    assert len(batches) == np.ceil(len(line_graph.nodes()) * 4 / batch_size)
+    for ids, labels in batches[:-1]:
+        assert len(ids) == len(labels) == batch_size
 
-    def test_run_context_pairs(self, line_graph):
-        batch_size = 4
-        sampler = UnsupervisedSampler(G=line_graph, length=2, number_of_walks=2)
-        batches = sampler.run(batch_size)
+    # last batch can be smaller
+    ids, labels = batches[-1]
+    assert len(ids) == len(labels)
+    assert len(ids) <= batch_size
 
-        grouped_by_target = defaultdict(list)
 
-        for ids, labels in batches:
-            for (target, context), label in zip(ids, labels):
-                grouped_by_target[target].append((context, label))
+def test_run_context_pairs(line_graph):
+    batch_size = 4
+    sampler = UnsupervisedSampler(G=line_graph, length=2, number_of_walks=2)
+    batches = sampler.run(batch_size)
 
-        assert len(grouped_by_target) == len(line_graph.nodes())
+    grouped_by_target = defaultdict(list)
 
-        for target, sampled in grouped_by_target.items():
-            # exactly 2 positive and 2 negative context pairs for each target node
-            assert len(sampled) == 4
+    for ids, labels in batches:
+        for (target, context), label in zip(ids, labels):
+            grouped_by_target[target].append((context, label))
 
-            # since each walk has length = 2, there must be an edge between each positive context pair
-            for context, label in sampled:
-                if label == 1:
-                    assert context in set(line_graph.neighbors(target))
+    assert len(grouped_by_target) == len(line_graph.nodes())
+
+    for target, sampled in grouped_by_target.items():
+        # exactly 2 positive and 2 negative context pairs for each target node
+        assert len(sampled) == 4
+
+        # since each walk has length = 2, there must be an edge between each positive context pair
+        for context, label in sampled:
+            if label == 1:
+                assert context in set(line_graph.neighbors(target))
+
+
+def test_walker_uniform_random(line_graph):
+    length = 3
+    number_of_walks = 2
+    batch_size = 4
+
+    walker = UniformRandomWalk(line_graph, n=number_of_walks, length=length)
+    sampler = UnsupervisedSampler(line_graph, walker=walker)
+
+    batches = sampler.run(batch_size)
+
+    expected_num_batches = np.ceil(
+        line_graph.number_of_nodes() * number_of_walks * (length - 1) * 2 / batch_size
+    )
+    assert len(batches) == expected_num_batches
+
+
+class CustomWalker:
+    def run(self, nodes):
+        return [[node, node] for node in nodes]
+
+
+def test_walker_custom(line_graph):
+    walker = CustomWalker()
+    sampler = UnsupervisedSampler(line_graph, walker=walker)
+    batches = sampler.run(2)
+
+    assert len(batches) == line_graph.number_of_nodes()
+
+    # all positive examples should be self loops, since we defined our custom walker this way
+    for context_pairs, labels in batches:
+        for node, neighbour in context_pairs[labels == 1]:
+            assert node == neighbour


### PR DESCRIPTION
This introduces a new base class `RandomWalk` which is a more specific type compared to the existing `GraphWalk` class. A `RandomWalk` class is defined as having a `run` method which takes a list of node IDs and returns a list of random walks (list of list of node IDs). Currently these classes belong to this type:

* `UniformRandomWalk`
* `BiasedRandomWalk`
* `UniformRandomMetaPathWalk`

It's useful to define this type, since these are all suitable for use with `UnsupervisedSampler`, and so we can introduce a new `walker` parameter to `UnsupervisedSampler` to allow for some flexibility instead of being hardcoded to use `UniformRandomWalk`. 

Note: `TemporalRandomWalk` could theoretically belong in this family too with some adjustments - currently its `run` method does not take a list of nodes as input, so it might make sense for it to have two different `run` methods - one that follows the reference paper (i.e. takes "number of context windows", etc as parameters), and one that fits into our definition of a `RandomWalk` by making some assumptions (e.g. calculate the parameters based on set of nodes).

also Note: I did try to keep random refactoring to a minimum.. but I thought it was reasonable enough to update the error handling/messages for the classes that were brought into the new `RandomWalk` base class, instead of using the existing checks in `GraphWalk`.

See #919 

Related https://github.com/stellargraph/stellargraph/pull/536#discussion_r400583830
