### PR TITLE
Check that edge weights are numeric during StellarGraph construction

### DIFF
--- a/stellargraph/core/convert.py
+++ b/stellargraph/core/convert.py
@@ -148,6 +148,13 @@ def convert_edges(
     edges, edge_features = converter.convert(data)
     assert all(features is None for features in edge_features.values())
 
+    for type_name, type_df in edges.items():
+        weight_col = type_df[WEIGHT]
+        if not pd.api.types.is_numeric_dtype(weight_col):
+            raise TypeError(
+                f"{converter.name(type_name)}: expected weight column {weight_column!r} to be numeric, found dtype '{weight_col.dtype}'"
+            )
+
     return EdgeData(edges)
 
 

--- a/tests/core/test_convert.py
+++ b/tests/core/test_convert.py
@@ -121,6 +121,33 @@ def test_columnar_convert_invalid_input():
         converter.convert({"x": 1})
 
 
+def test_convert_edges_weights():
+    def run(ws):
+        dfs = {
+            name: pd.DataFrame({"s": [0], "t": [1], "w": [w]}, index=[i])
+            for i, (name, w) in enumerate(ws.items())
+        }
+        convert_edges(
+            dfs,
+            name="some_name",
+            default_type="d",
+            source_column="s",
+            target_column="t",
+            weight_column="w",
+        )
+
+    # various numbers are valid
+    run({"x": np.int8(1)})
+    run({"x": np.complex64(1)})
+    run({"x": np.complex128(1), "y": np.uint16(2), "z": np.float32(3.0)})
+    # non-numbers are not
+    with pytest.raises(
+        TypeError,
+        match=r"some_name\['x'\]: expected weight column 'w' to be numeric, found dtype 'object'",
+    ):
+        run({"x": "ab", "y": 1, "z": np.float32(2)})
+
+
 def from_networkx_for_testing(g, node_features=None, dtype="float32"):
     return from_networkx(
         g,


### PR DESCRIPTION
Most (all?) algorithms using edge weights will be using them as numbers, so we can centralise the error handling code by doing it when creating a `StellarGraph`. That is, after this patch, the edge weights in any `StellarGraph` will be enforced to be numeric.

See: #1118 