### PR TITLE
Make DGI easy to extend by moving corruption logic to Generator classes

### DIFF
--- a/stellargraph/mapper/base.py
+++ b/stellargraph/mapper/base.py
@@ -28,3 +28,9 @@ class Generator(abc.ABC):
         Create a Keras Sequence or similar input, appropriate for a graph machine learning model.
         """
         ...
+
+    def corruptible_input_indices(self):
+        return None
+
+    def corrupt_inputs(self, inputs):
+        raise ValueError(f"calling 'corrupt_inputs' on {type(self).__name__} that does not support corrupting inputs")

--- a/stellargraph/mapper/sequences.py
+++ b/stellargraph/mapper/sequences.py
@@ -648,17 +648,12 @@ class CorruptedNodeSequence(Sequence):
     data for training Deep Graph Infomax.
 
     Args:
+        corrupt_inputs: a callable that returns a list of corrupted input values
         base_generator: the uncorrupted Sequence object.
     """
 
-    def __init__(self, base_generator):
-
-        if not isinstance(base_generator, (FullBatchSequence, SparseFullBatchSequence)):
-            raise TypeError(
-                f"base_generator: expected FullBatchSequence or SparseFullBatchSequence, "
-                f"found {type(base_generator).__name__}"
-            )
-
+    def __init__(self, corrupt_inputs, base_generator):
+        self.corrupt_inputs = corrupt_inputs
         self.base_generator = base_generator
         self.targets = np.zeros((1, len(base_generator.target_indices), 2))
         self.targets[0, :, 0] = 1.0
@@ -669,9 +664,5 @@ class CorruptedNodeSequence(Sequence):
     def __getitem__(self, index):
 
         inputs, _ = self.base_generator[index]
-        features = inputs[0]
 
-        shuffled_idxs = np.random.permutation(features.shape[1])
-        shuffled_feats = features[:, shuffled_idxs, :]
-
-        return [shuffled_feats] + inputs, self.targets
+        return self.corrupt_inputs(inputs) + inputs, self.targets


### PR DESCRIPTION
This adds 2 non-abstract (defaulted) methods to the `Generator` base class from #1194:

- `corrupt_inputs`: takes in a list of model input values (tensors/numpy arrays etc.) created by a `flow`'d sequence and returns some corruption of them for DGI
- `corruptible_input_indices`: the input tensor locations that get corrupted by `corrupt_inputs` and so need duplicated input tensors

Notably, the model classes don't have to know anything about corruption or DGI, it's purely a generator/sequence-level concern. Any model that uses that generator with corruption support can thus be trained in an unsupervised fashion. For instance, new models using `FullBatchNodeGenerator` will automatically be able to be trained with DGI.

Things to think about before merging this PR:

- reproducibility: maybe `corrupt_inputs` should take a random state?
- passing `base_generator` vs. the corrupted generator into `DeepGraphInfomax`
- how does this work with `tf.data`-based generators?
- maybe instead of defaulted methods on `Generator` we should add a subclass:
  ```python
  class CorruptibleGenerator(Generator):
      @abc.abstractmethod
      def corrupt_inputs(self, ...): ...
      @abc.abstractmethod
      def corruptible_input_indices(self): ...
   ```
   and then checks for "corruption support" are `isinstance(generator, CorruptibleGenerator)`.
- adding docs

This builds off #1194.