### PR TITLE
Add a release procedure step to pre-generate the binder docker image

### DIFF
--- a/RELEASE_PROCEDURE.md
+++ b/RELEASE_PROCEDURE.md
@@ -131,6 +131,13 @@
      ```
    - Turn branch protection back on.
 
+7. **Prompt Binder to generate the docker image**
+
+   [Binder](https://mybinder.org) uses a docker image to package up the state of a repository. It takes a long time to build, and is only built lazily, for the first user to click one of our "launch binder" buttons. It is your job to do this:
+
+   - Find [any demo notebook](https://github.com/stellargraph/stellargraph/blob/master/demos/basics/loading-pandas.ipynb) on the `master` branch
+   - Click [the "launch binder" button](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/basics/loading-pandas.ipynb) (or just click this link)
+   - Wait for the "Starting repository: stellargraph/stellargraph" loading screen to switch to a Jupyter environment
 
 ## More Information
 


### PR DESCRIPTION
The first start of a Binder after a StellarGraph release is very slow: building the docker image has to download and install tensorflow (etc.) and then push the resulting multi-gigabyte image. We can ensure no user hits this by doing it ourselves as part of creating the release.

See: #1196