### PR TITLE
Gather output nodes in full batch models, not the layers

### DIFF
--- a/stellargraph/__init__.py
+++ b/stellargraph/__init__.py
@@ -68,6 +68,7 @@ custom_keras_layers = {
     "RelationalGraphConvolution": layer.rgcn.RelationalGraphConvolution,
     "PPNPPropagationLayer": layer.ppnp.PPNPPropagationLayer,
     "APPNPPropagationLayer": layer.appnp.APPNPPropagationLayer,
+    "GatherIndices": layer.misc.GatherIndices,
 }
 
 

--- a/stellargraph/layer/appnp.py
+++ b/stellargraph/layer/appnp.py
@@ -65,7 +65,9 @@ class APPNPPropagationLayer(Layer):
         self.units = units
         self.teleport_probability = teleport_probability
         if final_layer is not None:
-            raise ValueError("'final_layer' is not longer supported, use 'tf.gather' or 'GatherIndices' separately")
+            raise ValueError(
+                "'final_layer' is not longer supported, use 'tf.gather' or 'GatherIndices' separately"
+            )
 
     def get_config(self):
         """
@@ -279,8 +281,7 @@ class APPNP:
             self._layers.append(Dropout(self.dropout))
             self._layers.append(
                 APPNPPropagationLayer(
-                    feature_dim,
-                    teleport_probability=self.teleport_probability,
+                    feature_dim, teleport_probability=self.teleport_probability,
                 )
             )
 

--- a/stellargraph/layer/cluster_gcn.py
+++ b/stellargraph/layer/cluster_gcn.py
@@ -17,7 +17,7 @@
 from tensorflow.keras import backend as K
 from tensorflow.keras import activations, initializers, constraints, regularizers
 from tensorflow.keras.layers import Input, Layer, Lambda, Dropout, Reshape
-from .misc import deprecated_model_function
+from .misc import deprecated_model_function, GatherIndices
 from ..mapper import ClusterNodeGenerator
 
 
@@ -37,25 +37,17 @@ class ClusterGraphConvolution(Layer):
       - The inputs are tensors with a batch dimension of 1:
         Keras requires this batch dimension.
 
-      - There are three inputs required, the node features, the output
-        indices (the nodes that are to be selected in the final layer)
+      - There are two inputs required, the node features,
         and the normalized graph adjacency matrix.
 
       - This class assumes that the normalized graph adjacency matrix is passed as
         input to the Keras methods.
 
-      - The output indices are used when ``final_layer=True`` and the returned outputs
-        are the final-layer features for the nodes indexed by output indices.
-
-      - If ``final_layer=False`` all the node features are output in the same ordering as
-        given by the adjacency matrix.
-
     Args:
         units (int): dimensionality of output feature vectors
         activation (str): nonlinear activation applied to layer's output to obtain output features
         use_bias (bool): toggles an optional bias
-        final_layer (bool): If False the layer returns output for all nodes,
-                            if True it returns the subset specified by the indices passed to it.
+        final_layer (bool): Deprecated, use ``tf.gather`` or :class:`GatherIndices`
         kernel_initializer (str): name of layer bias f the initializer for kernel parameters (weights)
         bias_initializer (str): name of the initializer for bias
         kernel_regularizer (str): name of regularizer to be applied to layer kernel. Must be a Keras regularizer.
@@ -72,7 +64,7 @@ class ClusterGraphConvolution(Layer):
         units,
         activation=None,
         use_bias=True,
-        final_layer=False,
+        final_layer=None,
         kernel_initializer="glorot_uniform",
         bias_initializer="zeros",
         kernel_regularizer=None,
@@ -98,7 +90,8 @@ class ClusterGraphConvolution(Layer):
         self.activity_regularizer = regularizers.get(activity_regularizer)
         self.kernel_constraint = constraints.get(kernel_constraint)
         self.bias_constraint = constraints.get(bias_constraint)
-        self.final_layer = final_layer
+        if final_layer is not None:
+            raise ValueError("'final_layer' is not longer supported, use 'tf.gather' or 'GatherIndices' separately")
 
     def get_config(self):
         """
@@ -112,7 +105,6 @@ class ClusterGraphConvolution(Layer):
         config = {
             "units": self.units,
             "use_bias": self.use_bias,
-            "final_layer": self.final_layer,
             "activation": activations.serialize(self.activation),
             "kernel_initializer": initializers.serialize(self.kernel_initializer),
             "bias_initializer": initializers.serialize(self.bias_initializer),
@@ -138,13 +130,10 @@ class ClusterGraphConvolution(Layer):
         Returns:
             An input shape tuple.
         """
-        feature_shape, out_shape, *As_shapes = input_shapes
+        feature_shape, *As_shapes = input_shapes
 
         batch_dim = feature_shape[0]
-        if self.final_layer:
-            out_dim = out_shape[1]
-        else:
-            out_dim = feature_shape[1]
+        out_dim = feature_shape[1]
 
         return batch_dim, out_dim, self.units
 
@@ -186,7 +175,6 @@ class ClusterGraphConvolution(Layer):
         Args:
             inputs (list): a list of 3 input tensors that includes
                 node features (size 1 x N x F),
-                output indices (size 1 x M)
                 graph adjacency matrix (size 1 x N x N),
                 where N is the number of nodes in the graph, and
                 F is the dimensionality of node features.
@@ -194,11 +182,10 @@ class ClusterGraphConvolution(Layer):
         Returns:
             Keras Tensor that represents the output of the layer.
         """
-        features, out_indices, *As = inputs
+        features, *As = inputs
 
         # Remove singleton batch dimension
         features = K.squeeze(features, 0)
-        out_indices = K.squeeze(out_indices, 0)
 
         # Calculate the layer operation of GCN multiplying the normalized adjacency matrix
         # width the node features matrix.
@@ -210,14 +197,7 @@ class ClusterGraphConvolution(Layer):
         if self.bias is not None:
             output += self.bias
         output = self.activation(output)
-
-        # On the final layer we gather the nodes referenced by the indices
-        if self.final_layer:
-            # Select the indices that are non-zero
-            output = K.gather(output, out_indices)
-        else:
-            output = K.expand_dims(output, 0)
-
+        output = K.expand_dims(output, 0)
         return output
 
 
@@ -316,7 +296,6 @@ class ClusterGCN:
                     l,
                     activation=a,
                     use_bias=self.bias,
-                    final_layer=ii == (n_layers - 1),
                     kernel_initializer=kernel_initializer,
                     kernel_regularizer=kernel_regularizer,
                     kernel_constraint=kernel_constraint,
@@ -353,12 +332,14 @@ class ClusterGCN:
 
         for layer in self._layers:
             if isinstance(layer, ClusterGraphConvolution):
-                # For a GCN layer add the matrix and output indices
-                # Note that the output indices are only used if `final_layer=True`
-                h_layer = layer([h_layer, out_indices] + Ainput)
+                # For a GCN layer add the matrix
+                h_layer = layer([h_layer] + Ainput)
             else:
                 # For other (non-graph) layers only supply the input tensor
                 h_layer = layer(h_layer)
+
+        # only return data for the requested nodes
+        h_layer = GatherIndices(batch_dims=1)([h_layer, out_indices])
 
         return h_layer
 
@@ -376,7 +357,7 @@ class ClusterGCN:
 
         # Inputs for features & target indices
         x_t = Input(batch_shape=(1, None, N_feat))
-        out_indices_t = Input(batch_shape=(1, None, None), dtype="int32")
+        out_indices_t = Input(batch_shape=(1, None), dtype="int32")
 
         # Placeholders for the dense adjacency matrix
         A_m = Input(batch_shape=(1, None, None))

--- a/stellargraph/layer/cluster_gcn.py
+++ b/stellargraph/layer/cluster_gcn.py
@@ -91,7 +91,9 @@ class ClusterGraphConvolution(Layer):
         self.kernel_constraint = constraints.get(kernel_constraint)
         self.bias_constraint = constraints.get(bias_constraint)
         if final_layer is not None:
-            raise ValueError("'final_layer' is not longer supported, use 'tf.gather' or 'GatherIndices' separately")
+            raise ValueError(
+                "'final_layer' is not longer supported, use 'tf.gather' or 'GatherIndices' separately"
+            )
 
     def get_config(self):
         """

--- a/stellargraph/layer/gcn.py
+++ b/stellargraph/layer/gcn.py
@@ -20,7 +20,7 @@ from tensorflow.keras import activations, initializers, constraints, regularizer
 from tensorflow.keras.layers import Input, Layer, Lambda, Dropout, Reshape
 
 from ..mapper import FullBatchGenerator
-from .misc import SqueezedSparseConversion, deprecated_model_function
+from .misc import SqueezedSparseConversion, deprecated_model_function, GatherIndices
 from .preprocessing_layer import GraphPreProcessingLayer
 
 
@@ -38,25 +38,17 @@ class GraphConvolution(Layer):
         Keras requires this batch dimension, and for full-batch methods
         we only have a single "batch".
 
-      - There are three inputs required, the node features, the output
-        indices (the nodes that are to be selected in the final layer)
+      - There are two inputs required, the node features,
         and the normalized graph Laplacian matrix
 
       - This class assumes that the normalized Laplacian matrix is passed as
         input to the Keras methods.
 
-      - The output indices are used when ``final_layer=True`` and the returned outputs
-        are the final-layer features for the nodes indexed by output indices.
-
-      - If ``final_layer=False`` all the node features are output in the same ordering as
-        given by the adjacency matrix.
-
     Args:
         units (int): dimensionality of output feature vectors
         activation (str or func): nonlinear activation applied to layer's output to obtain output features
         use_bias (bool): toggles an optional bias
-        final_layer (bool): If False the layer returns output for all nodes,
-                            if True it returns the subset specified by the indices passed to it.
+        final_layer (bool): Deprecated, use ``tf.gather`` or :class:`GatherIndices`
         kernel_initializer (str or func, optional): The initialiser to use for the weights.
         kernel_regularizer (str or func, optional): The regulariser to use for the weights.
         kernel_constraint (str or func, optional): The constraint to use for the weights.
@@ -70,7 +62,7 @@ class GraphConvolution(Layer):
         units,
         activation=None,
         use_bias=True,
-        final_layer=False,
+        final_layer=None,
         input_dim=None,
         kernel_initializer="glorot_uniform",
         kernel_regularizer=None,
@@ -86,7 +78,8 @@ class GraphConvolution(Layer):
         self.units = units
         self.activation = activations.get(activation)
         self.use_bias = use_bias
-        self.final_layer = final_layer
+        if final_layer is not None:
+            raise ValueError("'final_layer' is not longer supported, use 'tf.gather' or 'GatherIndices' separately")
 
         self.kernel_initializer = initializers.get(kernel_initializer)
         self.kernel_regularizer = regularizers.get(kernel_regularizer)
@@ -109,7 +102,6 @@ class GraphConvolution(Layer):
         config = {
             "units": self.units,
             "use_bias": self.use_bias,
-            "final_layer": self.final_layer,
             "activation": activations.serialize(self.activation),
             "kernel_initializer": initializers.serialize(self.kernel_initializer),
             "kernel_regularizer": regularizers.serialize(self.kernel_regularizer),
@@ -134,13 +126,10 @@ class GraphConvolution(Layer):
         Returns:
             An input shape tuple.
         """
-        feature_shape, out_shape, *As_shapes = input_shapes
+        feature_shape, *As_shapes = input_shapes
 
         batch_dim = feature_shape[0]
-        if self.final_layer:
-            out_dim = out_shape[1]
-        else:
-            out_dim = feature_shape[1]
+        out_dim = feature_shape[1]
 
         return batch_dim, out_dim, self.units
 
@@ -182,7 +171,6 @@ class GraphConvolution(Layer):
         Args:
             inputs (list): a list of 3 input tensors that includes
                 node features (size 1 x N x F),
-                output indices (size 1 x M)
                 graph adjacency matrix (size N x N),
                 where N is the number of nodes in the graph, and
                 F is the dimensionality of node features.
@@ -190,7 +178,7 @@ class GraphConvolution(Layer):
         Returns:
             Keras Tensor that represents the output of the layer.
         """
-        features, out_indices, *As = inputs
+        features, *As = inputs
         batch_dim, n_nodes, _ = K.int_shape(features)
         if batch_dim != 1:
             raise ValueError(
@@ -199,7 +187,6 @@ class GraphConvolution(Layer):
 
         # Remove singleton batch dimension
         features = K.squeeze(features, 0)
-        out_indices = K.squeeze(out_indices, 0)
 
         # Calculate the layer operation of GCN
         A = As[0]
@@ -210,10 +197,6 @@ class GraphConvolution(Layer):
         if self.bias is not None:
             output += self.bias
         output = self.activation(output)
-
-        # On the final layer we gather the nodes referenced by the indices
-        if self.final_layer:
-            output = K.gather(output, out_indices)
 
         # Add batch dimension back if we removed it
         # print("BATCH DIM:", batch_dim)
@@ -340,7 +323,6 @@ class GCN:
                     self.layer_sizes[ii],
                     activation=self.activations[ii],
                     use_bias=self.bias,
-                    final_layer=ii == (n_layers - 1),
                     kernel_initializer=kernel_initializer,
                     kernel_regularizer=kernel_regularizer,
                     kernel_constraint=kernel_constraint,
@@ -403,12 +385,14 @@ class GCN:
             Ainput = [self.graph_norm_layer(Ainput[0])]
         for layer in self._layers:
             if isinstance(layer, GraphConvolution):
-                # For a GCN layer add the matrix and output indices
-                # Note that the output indices are only used if `final_layer=True`
-                h_layer = layer([h_layer, out_indices] + Ainput)
+                # For a GCN layer add the matrix
+                h_layer = layer([h_layer] + Ainput)
             else:
                 # For other (non-graph) layers only supply the input tensor
                 h_layer = layer(h_layer)
+
+        # only return data for the requested nodes
+        h_layer = GatherIndices(batch_dims=1)([h_layer, out_indices])
 
         return h_layer
 

--- a/stellargraph/layer/gcn.py
+++ b/stellargraph/layer/gcn.py
@@ -79,7 +79,9 @@ class GraphConvolution(Layer):
         self.activation = activations.get(activation)
         self.use_bias = use_bias
         if final_layer is not None:
-            raise ValueError("'final_layer' is not longer supported, use 'tf.gather' or 'GatherIndices' separately")
+            raise ValueError(
+                "'final_layer' is not longer supported, use 'tf.gather' or 'GatherIndices' separately"
+            )
 
         self.kernel_initializer = initializers.get(kernel_initializer)
         self.kernel_regularizer = regularizers.get(kernel_regularizer)

--- a/stellargraph/layer/graph_attention.py
+++ b/stellargraph/layer/graph_attention.py
@@ -26,7 +26,7 @@ from tensorflow.keras import activations, constraints, initializers, regularizer
 from tensorflow.keras.layers import Input, Layer, Dropout, LeakyReLU, Lambda, Reshape
 
 from ..mapper import FullBatchNodeGenerator, FullBatchGenerator
-from .misc import SqueezedSparseConversion, deprecated_model_function
+from .misc import SqueezedSparseConversion, deprecated_model_function, GatherIndices
 
 
 class GraphAttention(Layer):
@@ -42,18 +42,11 @@ class GraphAttention(Layer):
         Keras requires this batch dimension, and for full-batch methods
         we only have a single "batch".
 
-      - There are three inputs required, the node features, the output
-        indices (the nodes that are to be selected in the final layer)
+      - There are two inputs required, the node features,
         and the graph adjacency matrix
 
       - This does not add self loops to the adjacency matrix, you should preprocess
         the adjacency matrix to add self-loops
-
-      - The output indices are used when ``final_layer=True`` and the returned outputs
-        are the final-layer features for the nodes indexed by output indices.
-
-      - If ``final_layer=False`` all the node features are output in the same ordering as
-        given by the adjacency matrix.
 
     Args:
         F_out (int): dimensionality of output feature vectors
@@ -63,8 +56,7 @@ class GraphAttention(Layer):
         in_dropout_rate (float): dropout rate applied to features
         attn_dropout_rate (float): dropout rate applied to attention coefficients
         activation (str): nonlinear activation applied to layer's output to obtain output features (eq. 4 of the GAT paper)
-        final_layer (bool): If False the layer returns output for all nodes,
-                            if True it returns the subset specified by the indices passed to it.
+        final_layer (bool): Deprecated, use ``tf.gather`` or :class:`GatherIndices`
         use_bias (bool): toggles an optional bias
         saliency_map_support (bool): If calculating saliency maps using the tools in
             stellargraph.interpretability.saliency_maps this should be True. Otherwise this should be False (default).
@@ -88,7 +80,7 @@ class GraphAttention(Layer):
         attn_dropout_rate=0.0,
         activation="relu",
         use_bias=True,
-        final_layer=False,
+        final_layer=None,
         saliency_map_support=False,
         kernel_initializer="glorot_uniform",
         kernel_regularizer=None,
@@ -116,7 +108,8 @@ class GraphAttention(Layer):
         self.attn_dropout_rate = attn_dropout_rate  # dropout rate for attention coefs
         self.activation = activations.get(activation)  # Eq. 4 in the paper
         self.use_bias = use_bias
-        self.final_layer = final_layer
+        if final_layer is not None:
+            raise ValueError("'final_layer' is not longer supported, use 'tf.gather' or 'GatherIndices' separately")
 
         self.saliency_map_support = saliency_map_support
         # Populated by build()
@@ -156,7 +149,6 @@ class GraphAttention(Layer):
             "attn_dropout_rate": self.attn_dropout_rate,
             "activation": activations.serialize(self.activation),
             "use_bias": self.use_bias,
-            "final_layer": self.final_layer,
             "saliency_map_support": self.saliency_map_support,
             "kernel_initializer": initializers.serialize(self.kernel_initializer),
             "kernel_regularizer": regularizers.serialize(self.kernel_regularizer),
@@ -189,13 +181,10 @@ class GraphAttention(Layer):
         Returns:
             An input shape tuple.
         """
-        feature_shape, out_shape, *As_shapes = input_shapes
+        feature_shape, *As_shapes = input_shapes
 
         batch_dim = feature_shape[0]
-        if self.final_layer:
-            out_dim = out_shape[1]
-        else:
-            out_dim = feature_shape[1]
+        out_dim = feature_shape[1]
 
         return batch_dim, out_dim, self.output_dim
 
@@ -270,26 +259,22 @@ class GraphAttention(Layer):
         Keras requires this batch dimension, and for full-batch methods
         we only have a single "batch".
 
-        There are three inputs required, the node features, the output
-        indices (the nodes that are to be selected in the final layer)
+        There are two inputs required, the node features,
         and the graph adjacency matrix
 
         Notes:
             This does not add self loops to the adjacency matrix.
-            The output indices are only used when ``final_layer=True``
 
         Args:
             inputs (list): list of inputs with 3 items:
             node features (size 1 x N x F),
-            output indices (size 1 x M),
             graph adjacency matrix (size N x N),
             where N is the number of nodes in the graph,
                   F is the dimensionality of node features
                   M is the number of output nodes
         """
         X = inputs[0]  # Node features (1 x N x F)
-        out_indices = inputs[1]  # output indices (1 x K)
-        A = inputs[2]  # Adjacency matrix (N x N)
+        A = inputs[1]  # Adjacency matrix (N x N)
         N = K.int_shape(A)[-1]
 
         batch_dim, n_nodes, _ = K.int_shape(X)
@@ -301,7 +286,6 @@ class GraphAttention(Layer):
         else:
             # Remove singleton batch dimension
             X = K.squeeze(X, 0)
-            out_indices = K.squeeze(out_indices, 0)
 
         outputs = []
         for head in range(self.attn_heads):
@@ -373,10 +357,6 @@ class GraphAttention(Layer):
         # Nonlinear activation function
         output = self.activation(output)
 
-        # On the final layer we gather the nodes referenced by the indices
-        if self.final_layer:
-            output = K.gather(output, out_indices)
-
         # Add batch dimension back if we removed it
         if batch_dim == 1:
             output = K.expand_dims(output, 0)
@@ -403,13 +383,6 @@ class GraphAttentionSparse(GraphAttention):
       - This does not add self loops to the adjacency matrix, you should preprocess
         the adjacency matrix to add self-loops
 
-      - The output indices are used when `final_layer=True` and the returned outputs
-        are the final-layer features for the nodes indexed by output indices.
-
-      - If `final_layer=False` all the node features are output in the same ordering as
-        given by the adjacency matrix.
-
-
     Args:
         F_out (int): dimensionality of output feature vectors
         attn_heads (int or list of int): number of attention heads
@@ -418,8 +391,7 @@ class GraphAttentionSparse(GraphAttention):
         in_dropout_rate (float): dropout rate applied to features
         attn_dropout_rate (float): dropout rate applied to attention coefficients
         activation (str): nonlinear activation applied to layer's output to obtain output features (eq. 4 of the GAT paper)
-        final_layer (bool): If False the layer returns output for all nodes,
-                            if True it returns the subset specified by the indices passed to it.
+        final_layer (bool): Deprecated, use ``tf.gather`` or :class:`GatherIndices`
         use_bias (bool): toggles an optional bias
         saliency_map_support (bool): If calculating saliency maps using the tools in
             stellargraph.interpretability.saliency_maps this should be True. Otherwise this should be False (default).
@@ -440,20 +412,17 @@ class GraphAttentionSparse(GraphAttention):
 
         Notes:
             This does not add self loops to the adjacency matrix.
-            The output indices are only used when `final_layer=True`
 
         Args:
             inputs (list): list of inputs with 4 items:
             node features (size b x N x F),
-            output indices (size b x M),
             sparse graph adjacency matrix (size N x N),
             where N is the number of nodes in the graph,
                   F is the dimensionality of node features
                   M is the number of output nodes
         """
         X = inputs[0]  # Node features (1 x N x F)
-        out_indices = inputs[1]  # output indices (1 x K)
-        A_sparse = inputs[2]  # Adjacency matrix (1 x N x N)
+        A_sparse = inputs[1]  # Adjacency matrix (1 x N x N)
 
         if not isinstance(A_sparse, tf.SparseTensor):
             raise TypeError("A is not sparse")
@@ -468,7 +437,6 @@ class GraphAttentionSparse(GraphAttention):
             )
         else:
             # Remove singleton batch dimension
-            out_indices = K.squeeze(out_indices, 0)
             X = K.squeeze(X, 0)
 
         outputs = []
@@ -532,10 +500,6 @@ class GraphAttentionSparse(GraphAttention):
             output = K.mean(K.stack(outputs), axis=0)  # N x F')
 
         output = self.activation(output)
-
-        # On the final layer we gather the nodes referenced by the indices
-        if self.final_layer:
-            output = K.gather(output, out_indices)
 
         # Add batch dimension back if we removed it
         if batch_dim == 1:
@@ -829,7 +793,6 @@ class GAT:
                     attn_dropout_rate=self.attn_dropout,
                     activation=self.activations[ii],
                     use_bias=self.bias,
-                    final_layer=ii == (n_layers - 1),
                     saliency_map_support=self.saliency_map_support,
                     kernel_initializer=kernel_initializer,
                     kernel_regularizer=kernel_regularizer,
@@ -889,15 +852,17 @@ class GAT:
         h_layer = x_in
         for layer in self._layers:
             if isinstance(layer, self._gat_layer):
-                # For a GAT layer add the matrix and output indices
-                # Note that the output indices are only used if `final_layer=True`
-                h_layer = layer([h_layer, out_indices] + Ainput)
+                # For a GAT layer add the matrix
+                h_layer = layer([h_layer] + Ainput)
 
             else:
                 # For other (non-graph) layers only supply the input tensor
                 h_layer = layer(h_layer)
 
             # print("Hlayer:", h_layer)
+
+        # only return data for the requested nodes
+        h_layer = GatherIndices(batch_dims=1)([h_layer, out_indices])
 
         return self._normalization(h_layer)
 

--- a/stellargraph/layer/graph_attention.py
+++ b/stellargraph/layer/graph_attention.py
@@ -109,7 +109,9 @@ class GraphAttention(Layer):
         self.activation = activations.get(activation)  # Eq. 4 in the paper
         self.use_bias = use_bias
         if final_layer is not None:
-            raise ValueError("'final_layer' is not longer supported, use 'tf.gather' or 'GatherIndices' separately")
+            raise ValueError(
+                "'final_layer' is not longer supported, use 'tf.gather' or 'GatherIndices' separately"
+            )
 
         self.saliency_map_support = saliency_map_support
         # Populated by build()

--- a/stellargraph/layer/misc.py
+++ b/stellargraph/layer/misc.py
@@ -98,6 +98,14 @@ class SqueezedSparseConversion(Layer):
 
 
 class GatherIndices(Layer):
+    """
+    Gathers slices from a data tensor, based on an indices tensors (``tf.gather`` in Layer form).
+
+    Args:
+        axis (int or Tensor): the data axis to gather from.
+        batch_dims (int): the number of batch dimensions in the data and indices.
+    """
+
     def __init__(self, axis=None, batch_dims=0, **kwargs):
         super().__init__(**kwargs)
         self._axis = axis
@@ -111,9 +119,19 @@ class GatherIndices(Layer):
     def compute_output_shape(self, input_shapes):
         data_shape, indices_shape = input_shapes
         axis = self._batch_dims if self._axis is None else self._axis
-        return data_shape[:axis] + indices_shape[self._batch_dims:] + data_shape[axis + 1:]
+        # per https://www.tensorflow.org/api_docs/python/tf/gather
+        return (
+            data_shape[:axis]
+            + indices_shape[self._batch_dims :]
+            + data_shape[axis + 1 :]
+        )
 
     def call(self, inputs):
+        """
+        Args:
+            inputs (list): a pair of tensors, corresponding to the ``params`` and ``indices``
+                parameters to ``tf.gather``.
+        """
         data, indices = inputs
         return tf.gather(data, indices, axis=self._axis, batch_dims=self._batch_dims)
 

--- a/stellargraph/layer/misc.py
+++ b/stellargraph/layer/misc.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import tensorflow as tf
 from tensorflow.keras.layers import Layer
 from tensorflow.keras import backend as K
 import warnings
@@ -94,6 +95,27 @@ class SqueezedSparseConversion(Layer):
             indices=indices, values=values, dense_shape=self.matrix_shape
         )
         return output
+
+
+class GatherIndices(Layer):
+    def __init__(self, axis=None, batch_dims=0, **kwargs):
+        super().__init__(**kwargs)
+        self._axis = axis
+        self._batch_dims = batch_dims
+
+    def get_config(self):
+        config = super().get_config()
+        config.update(axis=self._axis, batch_dims=self._batch_dims)
+        return config
+
+    def compute_output_shape(self, input_shapes):
+        data_shape, indices_shape = input_shapes
+        axis = self._batch_dims if self._axis is None else self._axis
+        return data_shape[:axis] + indices_shape[self._batch_dims:] + data_shape[axis + 1:]
+
+    def call(self, inputs):
+        data, indices = inputs
+        return tf.gather(data, indices, axis=self._axis, batch_dims=self._batch_dims)
 
 
 def deprecated_model_function(function, old_name):

--- a/stellargraph/layer/ppnp.py
+++ b/stellargraph/layer/ppnp.py
@@ -20,7 +20,7 @@ import tensorflow.keras.backend as K
 import tensorflow as tf
 import numpy as np
 
-from .misc import SqueezedSparseConversion
+from .misc import SqueezedSparseConversion, GatherIndices
 from ..mapper import FullBatchNodeGenerator
 from .misc import deprecated_model_function
 from .preprocessing_layer import GraphPreProcessingLayer
@@ -37,36 +37,28 @@ class PPNPPropagationLayer(Layer):
         Keras requires this batch dimension, and for full-batch methods
         we only have a single "batch".
 
-      - There are three inputs required, the node features, the output
-        indices (the nodes that are to be selected in the final layer)
+      - There are two inputs required, the node features,
         and the graph personalized page rank matrix
 
       - This class assumes that the personalized page rank matrix (specified in paper) matrix is passed as
         input to the Keras methods.
 
-      - The output indices are used when ``final_layer=True`` and the returned outputs
-        are the final-layer features for the nodes indexed by output indices.
-
-      - If ``final_layer=False`` all the node features are output in the same ordering as
-        given by the adjacency matrix.
-
-
     Args:
         units (int): dimensionality of output feature vectors
-        final_layer (bool): If False the layer returns output for all nodes,
-                            if True it returns the subset specified by the indices passed to it.
+        final_layer (bool): Deprecated, use ``tf.gather`` or :class:`GatherIndices`
         input_dim (int, optional): the size of the input shape, if known.
         kwargs: any additional arguments to pass to :class:`tensorflow.keras.layers.Layer`
     """
 
-    def __init__(self, units, final_layer=False, input_dim=None, **kwargs):
+    def __init__(self, units, final_layer=None, input_dim=None, **kwargs):
         if "input_shape" not in kwargs and input_dim is not None:
             kwargs["input_shape"] = (input_dim,)
 
         super().__init__(**kwargs)
 
         self.units = units
-        self.final_layer = final_layer
+        if final_layer is not None:
+            raise ValueError("'final_layer' is not longer supported, use 'tf.gather' or 'GatherIndices' separately")
 
     def get_config(self):
         """
@@ -77,7 +69,7 @@ class PPNPPropagationLayer(Layer):
             A dictionary that contains the config of the layer
         """
 
-        config = {"units": self.units, "final_layer": self.final_layer}
+        config = {"units": self.units}
 
         base_config = super().get_config()
         return {**base_config, **config}
@@ -94,13 +86,10 @@ class PPNPPropagationLayer(Layer):
         Returns:
             An input shape tuple.
         """
-        feature_shape, out_shape, *As_shapes = input_shapes
+        feature_shape, *As_shapes = input_shapes
 
         batch_dim = feature_shape[0]
-        if self.final_layer:
-            out_dim = out_shape[1]
-        else:
-            out_dim = feature_shape[1]
+        out_dim = feature_shape[1]
 
         return batch_dim, out_dim, self.units
 
@@ -120,7 +109,6 @@ class PPNPPropagationLayer(Layer):
         Args:
             inputs (list): a list of 3 input tensors that includes
                 node features (size 1 x N x F),
-                output indices (size 1 x M)
                 graph personalized page rank matrix (size N x N),
                 where N is the number of nodes in the graph, and
                 F is the dimensionality of node features.
@@ -128,7 +116,7 @@ class PPNPPropagationLayer(Layer):
         Returns:
             Keras Tensor that represents the output of the layer.
         """
-        features, out_indices, *As = inputs
+        features, *As = inputs
         batch_dim, n_nodes, _ = K.int_shape(features)
         if batch_dim != 1:
             raise ValueError(
@@ -137,15 +125,10 @@ class PPNPPropagationLayer(Layer):
 
         # Remove singleton batch dimension
         features = K.squeeze(features, 0)
-        out_indices = K.squeeze(out_indices, 0)
 
         # Propagate the features
         A = As[0]
         output = K.dot(A, features)
-
-        # On the final layer we gather the nodes referenced by the indices
-        if self.final_layer:
-            output = K.gather(output, out_indices)
 
         # Add batch dimension back if we removed it
         if batch_dim == 1:
@@ -248,7 +231,7 @@ class PPNP:
 
         self._layers.append(Dropout(self.dropout))
         self._layers.append(
-            PPNPPropagationLayer(self.layer_sizes[-1], final_layer=True)
+            PPNPPropagationLayer(self.layer_sizes[-1])
         )
 
     def __call__(self, x):
@@ -301,9 +284,12 @@ class PPNP:
         h_layer = x_in
         for layer in self._layers:
             if isinstance(layer, PPNPPropagationLayer):
-                h_layer = layer([h_layer, out_indices] + Ainput)
+                h_layer = layer([h_layer] + Ainput)
             else:
                 h_layer = layer(h_layer)
+
+        # only return data for the requested nodes
+        h_layer = GatherIndices(batch_dims=1)([h_layer, out_indices])
 
         return h_layer
 

--- a/stellargraph/layer/ppnp.py
+++ b/stellargraph/layer/ppnp.py
@@ -58,7 +58,9 @@ class PPNPPropagationLayer(Layer):
 
         self.units = units
         if final_layer is not None:
-            raise ValueError("'final_layer' is not longer supported, use 'tf.gather' or 'GatherIndices' separately")
+            raise ValueError(
+                "'final_layer' is not longer supported, use 'tf.gather' or 'GatherIndices' separately"
+            )
 
     def get_config(self):
         """
@@ -230,9 +232,7 @@ class PPNP:
             )
 
         self._layers.append(Dropout(self.dropout))
-        self._layers.append(
-            PPNPPropagationLayer(self.layer_sizes[-1])
-        )
+        self._layers.append(PPNPPropagationLayer(self.layer_sizes[-1]))
 
     def __call__(self, x):
         """

--- a/stellargraph/layer/rgcn.py
+++ b/stellargraph/layer/rgcn.py
@@ -125,7 +125,9 @@ class RelationalGraphConvolution(Layer):
         self.coefficient_constraint = constraints.get(coefficient_constraint)
 
         if final_layer is not None:
-            raise ValueError("'final_layer' is not longer supported, use 'tf.gather' or 'GatherIndices' separately")
+            raise ValueError(
+                "'final_layer' is not longer supported, use 'tf.gather' or 'GatherIndices' separately"
+            )
 
         super().__init__(**kwargs)
 

--- a/stellargraph/mapper/mini_batch_node_generators.py
+++ b/stellargraph/mapper/mini_batch_node_generators.py
@@ -347,7 +347,7 @@ class ClusterNodeSequence(Sequence):
 
         features = np.reshape(features, (1,) + features.shape)
         adj_cluster = adj_cluster.reshape((1,) + adj_cluster.shape)
-        target_node_indices = target_node_indices[np.newaxis, np.newaxis, :]
+        target_node_indices = target_node_indices[np.newaxis, :]
 
         return [features, target_node_indices, adj_cluster], cluster_targets
 

--- a/tests/layer/test_gcn.py
+++ b/tests/layer/test_gcn.py
@@ -63,27 +63,18 @@ def test_GraphConvolution_dense():
     # We need to specify the batch shape as one for the GraphConvolutional logic to work
     x_t = Input(batch_shape=(1,) + features.shape, name="X")
     A_t = Input(batch_shape=(1, 3, 3), name="A")
-    output_indices_t = Input(batch_shape=(1, None), dtype="int32", name="outind")
 
     # Note we add a batch dimension of 1 to model inputs
     adj = G.to_adjacency_matrix().toarray()[None, :, :]
-    out_indices = np.array([[0, 1]], dtype="int32")
     x = features[None, :, :]
 
     # For dense matrix, remove batch dimension
     A_mat = Lambda(lambda A: K.squeeze(A, 0))(A_t)
 
-    # Test with final_layer=False
-    out = GraphConvolution(2, final_layer=False)([x_t, output_indices_t, A_mat])
-    model = keras.Model(inputs=[x_t, A_t, output_indices_t], outputs=out)
-    preds = model.predict([x, adj, out_indices], batch_size=1)
+    out = GraphConvolution(2)([x_t, A_mat])
+    model = keras.Model(inputs=[x_t, A_t], outputs=out)
+    preds = model.predict([x, adj], batch_size=1)
     assert preds.shape == (1, 3, 2)
-
-    # Now try with final_layer=True
-    out = GraphConvolution(2, final_layer=True)([x_t, output_indices_t, A_mat])
-    model = keras.Model(inputs=[x_t, A_t, output_indices_t], outputs=out)
-    preds = model.predict([x, adj, out_indices], batch_size=1)
-    assert preds.shape == (1, 2, 2)
 
     # Check for errors with batch size != 1
     # We need to specify the batch shape as one for the GraphConvolutional logic to work
@@ -101,13 +92,11 @@ def test_GraphConvolution_sparse():
     x_t = Input(batch_shape=(1,) + features.shape)
     A_ind = Input(batch_shape=(1, None, 2), dtype="int64")
     A_val = Input(batch_shape=(1, None), dtype="float32")
-    output_indices_t = Input(batch_shape=(1, None), dtype="int32")
 
-    # Test with final_layer=False
     A_mat = SqueezedSparseConversion(shape=(n_nodes, n_nodes), dtype=A_val.dtype)(
         [A_ind, A_val]
     )
-    out = GraphConvolution(2, final_layer=False)([x_t, output_indices_t, A_mat])
+    out = GraphConvolution(2)([x_t, A_mat])
 
     # Note we add a batch dimension of 1 to model inputs
     adj = G.to_adjacency_matrix().tocoo()
@@ -116,15 +105,9 @@ def test_GraphConvolution_sparse():
     out_indices = np.array([[0, 1]], dtype="int32")
     x = features[None, :, :]
 
-    model = keras.Model(inputs=[x_t, output_indices_t, A_ind, A_val], outputs=out)
-    preds = model.predict([x, out_indices, A_indices, A_values], batch_size=1)
+    model = keras.Model(inputs=[x_t, A_ind, A_val], outputs=out)
+    preds = model.predict([x, A_indices, A_values], batch_size=1)
     assert preds.shape == (1, 3, 2)
-
-    # Now try with final_layer=True
-    out = GraphConvolution(2, final_layer=True)([x_t, output_indices_t, A_mat])
-    model = keras.Model(inputs=[x_t, output_indices_t, A_ind, A_val], outputs=out)
-    preds = model.predict([x, out_indices, A_indices, A_values], batch_size=1)
-    assert preds.shape == (1, 2, 2)
 
 
 def test_GCN_init():

--- a/tests/layer/test_graph_attention.py
+++ b/tests/layer/test_graph_attention.py
@@ -572,7 +572,11 @@ class Test_GAT:
 
         # Load model from json & set all weights
         model2 = keras.models.model_from_json(
-            model_json, custom_objects={"GraphAttention": GraphAttention, "GatherIndices": GatherIndices}
+            model_json,
+            custom_objects={
+                "GraphAttention": GraphAttention,
+                "GatherIndices": GatherIndices,
+            },
         )
         model2.set_weights(model_weights)
 

--- a/tests/layer/test_misc.py
+++ b/tests/layer/test_misc.py
@@ -43,7 +43,6 @@ def test_squeezedsparseconversion():
     A_ind = keras.Input(batch_shape=(1, None, 2), dtype="int64")
     A_val = keras.Input(batch_shape=(1, None), dtype="float32")
 
-    # Test with final_layer=False
     A_mat = SqueezedSparseConversion(shape=(N, N), dtype=A_val.dtype)([A_ind, A_val])
 
     x_out = keras.layers.Lambda(
@@ -66,7 +65,6 @@ def test_squeezedsparseconversion_dtype():
     A_ind = keras.Input(batch_shape=(1, None, 2), dtype="int64")
     A_val = keras.Input(batch_shape=(1, None), dtype="float32")
 
-    # Test with final_layer=False
     A_mat = SqueezedSparseConversion(shape=(N, N), dtype="float64")([A_ind, A_val])
 
     x_out = keras.layers.Lambda(
@@ -95,7 +93,6 @@ def test_squeezedsparseconversion_axis():
     # Keras reshapes everything to have ndim at least 2, we need to flatten values
     A_val_1 = keras.layers.Lambda(lambda A: K.reshape(A, (-1,)))(A_val)
 
-    # Test with final_layer=False
     A_mat = SqueezedSparseConversion(shape=(N, N), axis=None, dtype=A_val_1.dtype)(
         [A_ind, A_val_1]
     )
@@ -108,6 +105,33 @@ def test_squeezedsparseconversion_axis():
     z = model.predict([A_indices, A_values])
 
     assert np.allclose(z, A.sum(axis=1), atol=1e-7)
+
+
+def test_gather_indices():
+    batch_dim = 3
+    data_in = keras.Input(batch_shape=(batch_dim, 5, 7))
+    indices_in = keras.Input(batch_shape=(batch_dim, 11), dtype="int32")
+
+    data = np.arange(np.product(data_in.shape)).reshape(data_in.shape)
+    indices = np.random.choice(range(min(data_in.shape)), indices_in.shape)
+
+    # check that the layer acts the same as tf.gather
+    def run(**kwargs):
+        layer = GatherIndices(**kwargs)
+        expected = tf.gather(data, indices, **kwargs)
+
+        out = GatherIndices(**kwargs)([data_in, indices_in])
+        model = keras.Model(inputs=[data_in, indices_in], outputs=out)
+        pred = model.predict([data, indices])
+        np.testing.assert_array_equal(pred, expected)
+
+    # default settings
+    run()
+    # with a batch dimension
+    run(batch_dims=1)
+    # various other forms...
+    run(axis=1)
+    run(batch_dims=1, axis=2)
 
 
 def _deprecated_test(sg_model):

--- a/tests/layer/test_rgcn.py
+++ b/tests/layer/test_rgcn.py
@@ -86,9 +86,8 @@ def test_RelationalGraphConvolution_sparse():
     n_nodes = features.shape[0]
     n_feat = features.shape[1]
 
-    # Inputs for features & target indices
+    # Inputs for features
     x_t = Input(batch_shape=(1, n_nodes, n_feat))
-    out_indices_t = Input(batch_shape=(1, None), dtype="int32")
 
     # Create inputs for sparse or dense matrices
 
@@ -99,7 +98,6 @@ def test_RelationalGraphConvolution_sparse():
     As_values = [Input(batch_shape=(1, None)) for i in range(n_edge_types)]
     A_placeholders = As_indices + As_values
 
-    # Test with final_layer=False
     Ainput = [
         SqueezedSparseConversion(shape=(n_nodes, n_nodes), dtype=As_values[i].dtype)(
             [As_indices[i], As_values[i]]
@@ -107,12 +105,10 @@ def test_RelationalGraphConvolution_sparse():
         for i in range(n_edge_types)
     ]
 
-    x_inp_model = [x_t, out_indices_t] + A_placeholders
-    x_inp_conv = [x_t, out_indices_t] + Ainput
+    x_inp_model = [x_t] + A_placeholders
+    x_inp_conv = [x_t] + Ainput
 
-    out = RelationalGraphConvolution(
-        2, num_relationships=n_edge_types, final_layer=False
-    )(x_inp_conv)
+    out = RelationalGraphConvolution(2, num_relationships=n_edge_types)(x_inp_conv)
 
     # Note we add a batch dimension of 1 to model inputs
     As = [A.tocoo() for A in get_As(G)]
@@ -126,16 +122,8 @@ def test_RelationalGraphConvolution_sparse():
     x = features[None, :, :]
 
     model = keras.Model(inputs=x_inp_model, outputs=out)
-    preds = model.predict([x, out_indices] + A_indices + A_values, batch_size=1)
+    preds = model.predict([x] + A_indices + A_values, batch_size=1)
     assert preds.shape == (1, 3, 2)
-
-    # Now try with final_layer=True
-    out = RelationalGraphConvolution(
-        2, num_relationships=n_edge_types, final_layer=True
-    )(x_inp_conv)
-    model = keras.Model(inputs=x_inp_model, outputs=out)
-    preds = model.predict([x, out_indices] + A_indices + A_values, batch_size=1)
-    assert preds.shape == (1, 2, 2)
 
 
 def test_RelationalGraphConvolution_dense():
@@ -160,12 +148,10 @@ def test_RelationalGraphConvolution_dense():
 
     A_in = [Lambda(lambda A: K.squeeze(A, 0))(A_p) for A_p in A_placeholders]
 
-    x_inp_model = [x_t, out_indices_t] + A_placeholders
-    x_inp_conv = [x_t, out_indices_t] + A_in
+    x_inp_model = [x_t] + A_placeholders
+    x_inp_conv = [x_t] + A_in
 
-    out = RelationalGraphConvolution(
-        2, num_relationships=n_edge_types, final_layer=False
-    )(x_inp_conv)
+    out = RelationalGraphConvolution(2, num_relationships=n_edge_types)(x_inp_conv)
 
     As = [np.expand_dims(A.todense(), 0) for A in get_As(G)]
 
@@ -173,16 +159,8 @@ def test_RelationalGraphConvolution_dense():
     x = features[None, :, :]
 
     model = keras.Model(inputs=x_inp_model, outputs=out)
-    preds = model.predict([x, out_indices] + As, batch_size=1)
+    preds = model.predict([x] + As, batch_size=1)
     assert preds.shape == (1, 3, 2)
-
-    # Now try with final_layer=True
-    out = RelationalGraphConvolution(
-        2, num_relationships=n_edge_types, final_layer=True
-    )(x_inp_conv)
-    model = keras.Model(inputs=x_inp_model, outputs=out)
-    preds = model.predict([x, out_indices] + As, batch_size=1)
-    assert preds.shape == (1, 2, 2)
 
 
 def test_RGCN_init():

--- a/tests/mapper/test_cluster_gcn_node_mapper.py
+++ b/tests/mapper/test_cluster_gcn_node_mapper.py
@@ -170,7 +170,7 @@ def test_ClusterNodeSquence():
         assert len(batch) == 2
         # The first dimension is the batch dimension necessary to make this work with Keras
         assert batch[0][0].shape == (1, 1, 2)
-        assert batch[0][1].shape == (1, 1, 1)
+        assert batch[0][1].shape == (1, 1)
         # one node so that adjacency matrix is 1x1
         assert batch[0][2].shape == (1, 1, 1)
         # no targets given
@@ -188,7 +188,7 @@ def test_ClusterNodeSquence():
         assert len(batch) == 2
         # The first dimension is the batch dimension necessary to make this work with Keras
         assert batch[0][0].shape == (1, 2, 2)
-        assert batch[0][1].shape == (1, 1, 2)
+        assert batch[0][1].shape == (1, 2)
         # two nodes so that adjacency matrix is 2x2
         assert batch[0][2].shape == (1, 2, 2)
         # no targets given


### PR DESCRIPTION
The core layer in a full batch method (like `GraphConvolution` inside `GCN`) natively computes information about a whole graph, but this doesn't directly work with machine learning (and, in particular, how it works with `Keras`). In particular, there's usually only a subset of labelled nodes, so training needs to only compute candidate embeddings for those nodes to compare against the ground-truth target array.

We currently handle this in full batch methods by having each layer know whether it is the `final_layer` in the model, and do `tf.gather` using a tensor of indices of relevant nodes. This means that the individual full-batch layers have to:
- always accept the tensor of indices, even if they won't use it (and, potentially, even if they are being used as part of a model that doesn't ever use it)
- do the appropriate `tf.gather` invocation to select the relevant nodes

This patch adjusts this approach to make the output filtering a model level concern: layers always compute all the information, and models that need to can do a `tf.gather` call (via the new `layer.misc.GatherIndices`) to select out the relevant output elements. This has a few benefits:

- it seems conceptually more "correct" to me, because it's the training/using of a overall model that needs to filter out elements, _not_ the operation of an individual layer
- it reduces the amount of code required noticeably, and will reduce if further when we remove the left-over-`final_layer` detection (that is designed to help us migrate).
- it makes #1201 easier (in #1205): graph classification doesn't have any output indices to feed into the graph convolution layers, and so this patch makes `GraphConvolution` closer to the behaviour required for that
- it may also ease implementing models that incorporate information from multiple convolution layers, because it's easy to make sure all the convolution layers compute embeddings for all nodes

See: #1201