### PR TITLE
Rename GraphGenerator to PaddedGraphGenerator

### DIFF
--- a/demos/graph-classification/supervised-graph-classification.ipynb
+++ b/demos/graph-classification/supervised-graph-classification.ipynb
@@ -58,7 +58,7 @@
     "import numpy as np\n",
     "\n",
     "import stellargraph as sg\n",
-    "from stellargraph.mapper import GraphGenerator\n",
+    "from stellargraph.mapper import PaddedGraphGenerator\n",
     "from stellargraph.layer import GCNSupervisedGraphClassification\n",
     "from stellargraph import StellarGraph\n",
     "\n",
@@ -121,7 +121,7 @@
    "source": [
     "### Prepare graph generator\n",
     "\n",
-    "To feed data to the `tf.Keras` model that we will create later, we need a data generator. For supervised graph classification, we create an instance of `StellarGraph`'s `GraphGenerator` class."
+    "To feed data to the `tf.Keras` model that we will create later, we need a data generator. For supervised graph classification, we create an instance of `StellarGraph`'s `PaddedGraphGenerator` class."
    ]
   },
   {
@@ -130,7 +130,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "generator = GraphGenerator(graphs=graphs)"
+    "generator = PaddedGraphGenerator(graphs=graphs)"
    ]
   },
   {

--- a/docs/api.txt
+++ b/docs/api.txt
@@ -19,7 +19,7 @@ Generators
 -----------
 
 .. automodule:: stellargraph.mapper
-  :members: FullBatchNodeGenerator, FullBatchLinkGenerator, GraphSAGENodeGenerator, DirectedGraphSAGENodeGenerator, DirectedGraphSAGELinkGenerator, ClusterNodeGenerator, GraphSAGELinkGenerator, HinSAGENodeGenerator, HinSAGELinkGenerator, Attri2VecNodeGenerator, Attri2VecLinkGenerator, RelationalFullBatchNodeGenerator, AdjacencyPowerGenerator, GraphWaveGenerator, CorruptedGenerator, GraphGenerator, KGTripleGenerator
+  :members: FullBatchNodeGenerator, FullBatchLinkGenerator, GraphSAGENodeGenerator, DirectedGraphSAGENodeGenerator, DirectedGraphSAGELinkGenerator, ClusterNodeGenerator, GraphSAGELinkGenerator, HinSAGENodeGenerator, HinSAGELinkGenerator, Attri2VecNodeGenerator, Attri2VecLinkGenerator, RelationalFullBatchNodeGenerator, AdjacencyPowerGenerator, GraphWaveGenerator, CorruptedGenerator, PaddedGraphGenerator, KGTripleGenerator
 
 
 Layers and models

--- a/stellargraph/layer/graph_classification.py
+++ b/stellargraph/layer/graph_classification.py
@@ -29,7 +29,7 @@ from tensorflow.keras.layers import (
 )
 
 from .misc import deprecated_model_function
-from ..mapper import GraphGenerator
+from ..mapper import PaddedGraphGenerator
 from .cluster_gcn import ClusterGraphConvolution
 
 
@@ -105,14 +105,14 @@ class GCNSupervisedGraphClassification:
     activation functions for each hidden layers, and a generator object.
 
     To use this class as a Keras model, the features and pre-processed adjacency matrix
-    should be supplied using the :class:`GraphGenerator` class.
+    should be supplied using the :class:`PaddedGraphGenerator` class.
 
     Examples:
         Creating a graph classification model from a list of :class:`StellarGraph`
         objects (``graphs``). We also add two fully connected dense layers using the last one for binary classification
         with `softmax` activation::
 
-            generator = GraphGenerator(graphs)
+            generator = PaddedGraphGenerator(graphs)
             model = GCNSupervisedGraphClassification(
                              layer_sizes=[32, 32],
                              activations=["elu","elu"],
@@ -126,7 +126,7 @@ class GCNSupervisedGraphClassification:
     Args:
         layer_sizes (list of int): list of output sizes of the graph GCN layers in the stack.
         activations (list of str): list of activations applied to each GCN layer's output.
-        generator (GraphGenerator): an instance of :class:`GraphGenerator` class constructed on the graphs used for
+        generator (PaddedGraphGenerator): an instance of :class:`PaddedGraphGenerator` class constructed on the graphs used for
             training.
         bias (bool, optional): toggles an optional bias in graph convolutional layers.
         dropout (float, optional): dropout rate applied to input features of each GCN layer.
@@ -159,9 +159,9 @@ class GCNSupervisedGraphClassification:
         bias_regularizer=None,
         bias_constraint=None,
     ):
-        if not isinstance(generator, GraphGenerator):
+        if not isinstance(generator, PaddedGraphGenerator):
             raise TypeError(
-                f"generator: expected instance of GraphGenerator, found {type(generator).__name__}"
+                f"generator: expected instance of PaddedGraphGenerator, found {type(generator).__name__}"
             )
 
         if len(layer_sizes) != len(activations):

--- a/stellargraph/mapper/__init__.py
+++ b/stellargraph/mapper/__init__.py
@@ -31,4 +31,4 @@ from .mini_batch_node_generators import *
 from .graphwave_generator import *
 from .adjacency_generators import *
 from .knowledge_graph import *
-from .graph_generator import *
+from .padded_graph_generator import *

--- a/stellargraph/mapper/padded_graph_generator.py
+++ b/stellargraph/mapper/padded_graph_generator.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 from ..core.graph import StellarGraph
 from ..core.utils import is_real_iterable
-from .sequences import GraphSequence
+from .sequences import PaddedGraphSequence
 
 
 class PaddedGraphGenerator:
@@ -80,7 +80,7 @@ class PaddedGraphGenerator:
             name (str, optional): An optional name for the returned generator object.
 
         Returns:
-            A :class:`GraphSequence` object to use with Keras methods :meth:`fit`, :meth:`evaluate`, and :meth:`predict`
+            A :class:`PaddedGraphSequence` object to use with Keras methods :meth:`fit`, :meth:`evaluate`, and :meth:`predict`
 
         """
         if targets is not None:
@@ -106,7 +106,7 @@ class PaddedGraphGenerator:
                 f"expected batch_size to be strictly positive integer, found {batch_size}"
             )
 
-        return GraphSequence(
+        return PaddedGraphSequence(
             graphs=[self.graphs[i] for i in graph_ilocs],
             targets=targets,
             batch_size=batch_size,

--- a/stellargraph/mapper/padded_graph_generator.py
+++ b/stellargraph/mapper/padded_graph_generator.py
@@ -18,7 +18,7 @@ from ..core.utils import is_real_iterable
 from .sequences import GraphSequence
 
 
-class GraphGenerator:
+class PaddedGraphGenerator:
     """
     A data generator for use with graph classification algorithms.
 
@@ -27,8 +27,10 @@ class GraphGenerator:
     Use the :meth:`flow` method supplying the graph indexes and (optionally) targets
     to get an object that can be used as a Keras data generator.
 
-    This generator supplies the features arrays and the adjacency matrices to a
-    mini-batch Keras graph classification model.
+    This generator supplies the features arrays and the adjacency matrices to a mini-batch Keras
+    graph classification model. Differences in the number of nodes are resolved by padding each
+    batch of features and adjacency matrices, and supplying a boolean mask indicating which are
+    valid and which are padding.
 
     Args:
         graphs (list): a collection of ready for machine-learning StellarGraph-type objects

--- a/stellargraph/mapper/sequences.py
+++ b/stellargraph/mapper/sequences.py
@@ -25,7 +25,7 @@ __all__ = [
     "FullBatchSequence",
     "SparseFullBatchSequence",
     "RelationalFullBatchNodeSequence",
-    "GraphSequence",
+    "PaddedGraphSequence",
     "CorruptedNodeSequence",
 ]
 

--- a/stellargraph/mapper/sequences.py
+++ b/stellargraph/mapper/sequences.py
@@ -533,7 +533,7 @@ class RelationalFullBatchNodeSequence(Sequence):
         return self.inputs, self.targets
 
 
-class GraphSequence(Sequence):
+class PaddedGraphSequence(Sequence):
     """
     A Keras-compatible data generator for training and evaluating graph classification models.
     Use this class with the Keras methods :meth:`keras.Model.fit`,
@@ -541,7 +541,7 @@ class GraphSequence(Sequence):
         :meth:`keras.Model.predict`,
 
     This class should be created using the `.flow(...)` method of
-    :class:`GraphGenerator`.
+    :class:`PaddedGraphGenerator`.
 
     Args:
         graphs (list)): The graphs as StellarGraph objects.

--- a/tests/layer/test_gcn_supervised_graph_classification.py
+++ b/tests/layer/test_gcn_supervised_graph_classification.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from stellargraph.layer.graph_classification import *
-from stellargraph.mapper import GraphGenerator, FullBatchNodeGenerator
+from stellargraph.mapper import PaddedGraphGenerator, FullBatchNodeGenerator
 import pytest
 from ..test_utils.graphs import example_graph_random
 
@@ -25,7 +25,7 @@ graphs = [
     example_graph_random(feature_size=4, n_nodes=3),
 ]
 
-generator = GraphGenerator(graphs=graphs)
+generator = PaddedGraphGenerator(graphs=graphs)
 
 
 def test_init():
@@ -40,7 +40,7 @@ def test_init():
     assert model.activations[0] == "relu"
 
     with pytest.raises(
-        TypeError, match="generator: expected.*GraphGenerator, found NoneType"
+        TypeError, match="generator: expected.*PaddedGraphGenerator, found NoneType"
     ):
         GCNSupervisedGraphClassification(
             layer_sizes=[16], activations=["relu"], generator=None
@@ -48,7 +48,7 @@ def test_init():
 
     with pytest.raises(
         TypeError,
-        match="generator: expected.*GraphGenerator, found FullBatchNodeGenerator",
+        match="generator: expected.*PaddedGraphGenerator, found FullBatchNodeGenerator",
     ):
         GCNSupervisedGraphClassification(
             layer_sizes=[16],

--- a/tests/layer/test_misc.py
+++ b/tests/layer/test_misc.py
@@ -154,7 +154,7 @@ def test_deprecated_model_functions():
         ),
         GraphSAGENodeGenerator(G, batch_size=1, num_samples=[2]),
         RelationalFullBatchNodeGenerator(G),
-        GraphGenerator([G]),
+        PaddedGraphGenerator([G]),
     ]
 
     model_types = [

--- a/tests/mapper/test_padded_graph_generator.py
+++ b/tests/mapper/test_padded_graph_generator.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from stellargraph.core.graph import *
-from stellargraph.mapper.graph_generator import GraphGenerator, GraphSequence
+from stellargraph.mapper.graph_generator import PaddedGraphGenerator, PaddedPaddedGraphSequence
 
 import numpy as np
 import pytest
@@ -28,7 +28,7 @@ graphs = [
 
 
 def test_generator_init():
-    generator = GraphGenerator(graphs=graphs)
+    generator = PaddedGraphGenerator(graphs=graphs)
     assert len(generator.graphs) == len(graphs)
 
 
@@ -42,7 +42,7 @@ def test_generator_init_different_feature_numbers():
         ValueError,
         match="graphs: expected node features for all graph to have same dimensions,.*2.*4",
     ):
-        generator = GraphGenerator(graphs=graphs_diff_num_features)
+        generator = PaddedGraphGenerator(graphs=graphs_diff_num_features)
 
 
 def test_generator_init_nx_graph():
@@ -56,7 +56,7 @@ def test_generator_init_nx_graph():
     with pytest.raises(
         TypeError, match="graphs: expected.*StellarGraph.*found MultiGraph."
     ):
-        generator = GraphGenerator(graphs=graphs_nx)
+        generator = PaddedGraphGenerator(graphs=graphs_nx)
 
 
 def test_generator_init_hin():
@@ -69,29 +69,29 @@ def test_generator_init_hin():
         ValueError,
         match="graphs: node generator requires graphs with single node type.*found.*2",
     ):
-        generator = GraphGenerator(graphs=graphs_mixed)
+        generator = PaddedGraphGenerator(graphs=graphs_mixed)
 
 
 def test_generator_flow_invalid_batch_size():
     with pytest.raises(
         ValueError, match="expected batch_size.*strictly positive integer, found -1"
     ):
-        GraphGenerator(graphs=graphs).flow(graph_ilocs=[0], batch_size=-1)
+        PaddedGraphGenerator(graphs=graphs).flow(graph_ilocs=[0], batch_size=-1)
 
     with pytest.raises(
         TypeError, match="expected batch_size.*integer type, found float"
     ):
-        GraphGenerator(graphs=graphs).flow(graph_ilocs=[0], batch_size=2.0)
+        PaddedGraphGenerator(graphs=graphs).flow(graph_ilocs=[0], batch_size=2.0)
 
     with pytest.raises(
         ValueError, match="expected batch_size.*strictly positive integer, found 0"
     ):
-        GraphGenerator(graphs=graphs).flow(graph_ilocs=[0], batch_size=0)
+        PaddedGraphGenerator(graphs=graphs).flow(graph_ilocs=[0], batch_size=0)
 
 
 def test_generator_flow_incorrect_targets():
 
-    generator = GraphGenerator(graphs=graphs)
+    generator = PaddedGraphGenerator(graphs=graphs)
 
     with pytest.raises(
         ValueError, match="expected targets to be the same length as node_ids,.*1 vs 2"
@@ -106,10 +106,10 @@ def test_generator_flow_incorrect_targets():
 
 def test_generator_flow_no_targets():
 
-    generator = GraphGenerator(graphs=graphs)
+    generator = PaddedGraphGenerator(graphs=graphs)
 
     seq = generator.flow(graph_ilocs=[0, 1, 2], batch_size=2)
-    assert isinstance(seq, GraphSequence)
+    assert isinstance(seq, PaddedGraphSequence)
 
     assert len(seq) == 2  # two batches
 
@@ -129,10 +129,10 @@ def test_generator_flow_no_targets():
 
 def test_generator_flow_check_padding():
 
-    generator = GraphGenerator(graphs=graphs)
+    generator = PaddedGraphGenerator(graphs=graphs)
 
     seq = generator.flow(graph_ilocs=[0, 2], batch_size=2)
-    assert isinstance(seq, GraphSequence)
+    assert isinstance(seq, PaddedGraphSequence)
 
     assert len(seq) == 1
 
@@ -150,10 +150,10 @@ def test_generator_flow_check_padding():
 
 def test_generator_flow_with_targets():
 
-    generator = GraphGenerator(graphs=graphs)
+    generator = PaddedGraphGenerator(graphs=graphs)
 
     seq = generator.flow(graph_ilocs=[1, 2], targets=np.array([0, 1]), batch_size=1)
-    assert isinstance(seq, GraphSequence)
+    assert isinstance(seq, PaddedGraphSequence)
 
     for batch in seq:
         assert batch[0][0].shape[0] == 1

--- a/tests/mapper/test_padded_graph_generator.py
+++ b/tests/mapper/test_padded_graph_generator.py
@@ -14,7 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from stellargraph.core.graph import *
-from stellargraph.mapper.padded_graph_generator import PaddedGraphGenerator, PaddedGraphSequence
+from stellargraph.mapper.padded_graph_generator import (
+    PaddedGraphGenerator,
+    PaddedGraphSequence,
+)
 
 import numpy as np
 import pytest

--- a/tests/mapper/test_padded_graph_generator.py
+++ b/tests/mapper/test_padded_graph_generator.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from stellargraph.core.graph import *
-from stellargraph.mapper.graph_generator import PaddedGraphGenerator, PaddedPaddedGraphSequence
+from stellargraph.mapper.graph_generator import PaddedGraphGenerator, PaddedGraphSequence
 
 import numpy as np
 import pytest

--- a/tests/mapper/test_padded_graph_generator.py
+++ b/tests/mapper/test_padded_graph_generator.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from stellargraph.core.graph import *
-from stellargraph.mapper.graph_generator import PaddedGraphGenerator, PaddedGraphSequence
+from stellargraph.mapper.padded_graph_generator import PaddedGraphGenerator, PaddedGraphSequence
 
 import numpy as np
 import pytest


### PR DESCRIPTION
The `GraphGenerator` name is accurate, because the type generates a sequence of graphs. However, it is very general, despite it currently performing one specific style of generating graphs (plopping the features and adjacency matrices into batched tensors, with padding to make sure the sizes are ok).

Per our off-github discussion, we decided that it is more future-proof to start with a more specific name than `GraphGenerator`, in case we end up with other approaches for generating sequences of graphs for training graph classification algorithms (off the top of my head, possibilities are using ragged tensors, or some sort of Cluster-GCN-like algorithm that yields equal-sized subgraphs). This means that our current functionality takes up less "API space", and gives us more room to manoeuvre.

If we decide that this is the only graph generator type we'll have, we can always rename (without breaking existing code) in future.

See: #1198