### PR TITLE
Break notebooks to demonstrate buildkite annotations for blogpost

### DIFF
--- a/demos/basics/loading-pandas.ipynb
+++ b/demos/basics/loading-pandas.ipynb
@@ -198,7 +198,7 @@
    ],
    "source": [
     "square_edges = pd.DataFrame(\n",
-    "    {\"source\": [\"a\", \"b\", \"c\", \"d\", \"a\"], \"target\": [\"b\", \"c\", \"d\", \"a\", \"c\"]}\n",
+    "    {\"source\": [\"a\", \"b\", \"c\", \"d\", \"a\"], \"target\": [\"b\", \"c\", \"d\", \"a\", \"dangling node ID\"]}\n",
     ")\n",
     "square_edges"
    ]

--- a/demos/embeddings/deep-graph-infomax-cora.ipynb
+++ b/demos/embeddings/deep-graph-infomax-cora.ipynb
@@ -120,7 +120,7 @@
     }
    ],
    "source": [
-    "fullbatch_generator = FullBatchNodeGenerator(G, sparse=False)\n",
+    "fullbatch_generator=FullBatchNodeGenerator(G, sparse=False)\n",
     "gcn_model = GCN(layer_sizes=[128], activations=[\"relu\"], generator=fullbatch_generator)\n",
     "\n",
     "corrupted_generator = CorruptedGenerator(fullbatch_generator)\n",

--- a/demos/link-prediction/graphsage/cora-links-example.ipynb
+++ b/demos/link-prediction/graphsage/cora-links-example.ipynb
@@ -410,7 +410,7 @@
     "model.compile(\n",
     "    optimizer=keras.optimizers.Adam(lr=1e-3),\n",
     "    loss=keras.losses.binary_crossentropy,\n",
-    "    metrics=[\"acc\"],\n",
+    "    metrics=[\"acc\"]\n",
     ")"
    ]
   },

--- a/demos/node-classification/gcn/gcn-cora-node-classification-example.ipynb
+++ b/demos/node-classification/gcn/gcn-cora-node-classification-example.ipynb
@@ -127,7 +127,7 @@
    "source": [
     "dataset = sg.datasets.Cora()\n",
     "display(HTML(dataset.description))\n",
-    "G, node_subjects = dataset.load()"
+    "G, node_subjects = dataset.load(mispelled_argument=True)"
    ]
   },
   {


### PR DESCRIPTION
This pull request purposely breaks the formatting of several notebooks, and introduces bugs into others, as a demonstration for https://medium.com/stellargraph/better-notebooks-through-ci-automatically-testing-documentation-for-graph-machine-learning-5789e277e597

The changes are:

- `demos/basics/loading-pandas.ipynb`: a dangling vertex is added to an edge list, meaning an exception is thrown when constructing the `StellarGraph`; this also causes the line to be too long and thus have incorrect formatting
- `demos/embeddings/deep-graph-infomax-cora.ipynb`: spaces are removed around an `=`, which is incorrect formatting
- `demos/link-prediction/graphsage/cora-links-example.ipynb`: the trailing comma is removed from the last argument of a multi-line function call, which is incorrect formatting
- `demos/node-classification/gcn/gcn-cora-node-classification-example.ipynb`: an incorrect argument is added to a `Cora.load` call, simulating the API changing (and thus the notebook needing updating) or a mistake in an edit to the notebook 

https://buildkite.com/stellar/stellargraph-public/builds/2998 is a build with these failures. When the PR is still open, it is linked in the GitHub status checks at the end of the PR:

![image](https://user-images.githubusercontent.com/1203825/78730939-97a2ea80-7981-11ea-927f-84a1e5bd0046.png)


See all of StellarGraph's (working!) demos at https://github.com/stellargraph/stellargraph/tree/develop/demos