### PR TITLE
Optimise feature sampling via row-major (C) order feature array

### DIFF
--- a/stellargraph/core/convert.py
+++ b/stellargraph/core/convert.py
@@ -88,7 +88,11 @@ class ColumnarConverter:
         )
 
         if self.allow_features:
-            features = other.to_numpy(dtype=self.dtype)
+            # to_numpy returns an unspecified order but it's Fortran in practice. Row-level bulk
+            # operations are more common (e.g. slicing out a couple of row, when sampling a few
+            # nodes) than column-level ones so having rows be contiguous (C order) is much more
+            # efficient.
+            features = np.ascontiguousarray(other.to_numpy(dtype=self.dtype))
         elif len(other.columns) == 0:
             features = None
         else:

--- a/stellargraph/core/element_data.py
+++ b/stellargraph/core/element_data.py
@@ -164,12 +164,7 @@ class ElementData:
 
         self._id_index = ExternalIdIndex(all_columns.index)
         self._columns = {
-            # to_numpy returns an unspecified order but it's Fortran in practice. Row-level bulk
-            # operations are more common (e.g. slicing out a couple of row, when sampling a few
-            # nodes) than column-level ones so having rows be contiguous (C order) is much more
-            # efficient.
-            name: np.ascontiguousarray(data.to_numpy())
-            for name, data in all_columns.iteritems()
+            name: data.to_numpy() for name, data in all_columns.iteritems()
         }
 
         # there's typically a small number of types, so we can map them down to a small integer type

--- a/stellargraph/core/element_data.py
+++ b/stellargraph/core/element_data.py
@@ -164,7 +164,12 @@ class ElementData:
 
         self._id_index = ExternalIdIndex(all_columns.index)
         self._columns = {
-            name: data.to_numpy() for name, data in all_columns.iteritems()
+            # to_numpy returns an unspecified order but it's Fortran in practice. Row-level bulk
+            # operations are more common (e.g. slicing out a couple of row, when sampling a few
+            # nodes) than column-level ones so having rows be contiguous (C order) is much more
+            # efficient.
+            name: np.ascontiguousarray(data.to_numpy())
+            for name, data in all_columns.iteritems()
         }
 
         # there's typically a small number of types, so we can map them down to a small integer type

--- a/tests/core/test_graph.py
+++ b/tests/core/test_graph.py
@@ -592,12 +592,13 @@ def test_benchmark_get_neighbours(benchmark):
 @pytest.mark.benchmark(group="StellarGraph node features")
 @pytest.mark.parametrize("num_types", [1, 4])
 @pytest.mark.parametrize("type_arg", ["infer", "specify"])
-def test_benchmark_get_features(benchmark, num_types, type_arg):
+@pytest.mark.parametrize("feature_size", [10, 1000])
+def test_benchmark_get_features(benchmark, num_types, type_arg, feature_size):
     SAMPLE_SIZE = 50
-    N_NODES = 500
-    N_EDGES = 1000
+    N_NODES = 5000
+    N_EDGES = 10000
     nodes, edges = example_benchmark_graph(
-        feature_size=10, n_nodes=N_NODES, n_edges=N_EDGES, n_types=num_types
+        feature_size=feature_size, n_nodes=N_NODES, n_edges=N_EDGES, n_types=num_types
     )
 
     sg = StellarGraph(nodes=nodes, edges=edges)


### PR DESCRIPTION
Pandas `.to_numpy` method ends up converting to Fortran order features in many cases, such as for DataFrames read from CSV files. I suspect this reflects Pandas's columnar nature, which means it's most efficient to build the array by concatenating columns consecutively to give a column-major (Fortran) order, rather than interleaving them to give a row-major (C) order.

Unfortunately, for most of the things StellarGraph does, row-major is better: we work with whole rows at a time, such as when we select features for a subset of nodes with the `node_features` method. This involves copying the whole row of features for each of the specified nodes. In row-major form, this is easy and efficient, because there's spatial cache locality (the elements of each row are all contiguous) so the copy (a) has fewer cache misses, and (b) can use more bulk SIMD instructions.

To make this concrete, the data layout in memory for the different styles is like:

```
index:         0     1     2  ...      998     999  1000  1001  ...    2998     2999  3000  3001
row_major: [N0F0, N0F1, N0F2, ...,  N0F998, N0F999, N1F0, N1F1, ...]
col_major: [N0F0, N1F0, N2F0, ...                                   N2998F0, N2999F0, N0F1, N1F1, ...]
```

where `NxFy` refers to the `y`th feature of node `x`, and there's 1000 features per node and 3000 nodes.

If we want to get the feature for node 0, we have to copy `N0F0`, `N0F1`, etc. For `row_major`, this is a straightforward memory access: copy the `1000 * 4` bytes from index 0 to index 999 (inclusive) which likely results in more cache hits and more ability to [use bulk SIMD instructions](http://codearcana.com/posts/2013/05/18/achieving-maximum-memory-bandwidth.html) (even without any bulk instructions, reading the 4 byte float at index 0 likely loads into L1 cache a 32 byte cache line that incorporates index 0 to index 7, so the next 7 load operations are L1 cache hits, which is [much faster](https://colin-scott.github.io/personal_website/research/interactive_latency.html) than having to go further out, or all the way to main memory). For `col_major`, the memory access pattern is much more complicated: copy 4 bytes from index 0, then skip 12000 bytes forward indices to copy 4 bytes from index 3000, which means there's not going to be [any spatial locality](https://en.wikipedia.org/wiki/Locality_of_reference) and so much poorer cache behaviour (in addition to not being able to use SIMD easily).

### Minimal example

This is visible in the following example, that demonstrates the core indexing operation (adapted from https://github.com/stellargraph/stellargraph/pull/1167#issuecomment-610783801):

```python
import numpy as np

row_major = np.ones((3000, 1000), order='C')
col_major = np.ones((3000, 1000), order='F')
lookup = np.random.randint(3000, size=800).astype(int)

%timeit -n 100 row_major[lookup, :]
# 1.35 ms ± 164 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
%timeit -n 100 col_major[lookup, :]
# 8.58 ms ± 265 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

I recorded some information about the execution of this using Instruments's Counter mode (e.g. https://www.robertpieta.com/counters-in-instruments/) by increasing to `-n 10000` and letting the loop run for ~15s while while recording before killing it manually. This shows various counters reported by my CPU, in units of millions of events per second.

| array       | # instructions executed | # loads executed | load density | # L1 cache misses | L1 misses per load | # L2 cache misses | L2 misses per load |
|-------------|-------------------------|------------------|--------------|-------------------|--------------------|-------------------|--------------------|
| `row_major` | 2900                    | 590              | 20%          | 49                | 8%                 | 28                | 5%                 |
| `col_major` | 1200                    | 240              | 20%          | 93                | 39%                | 90                | 38%                |
| **details** | <sup><sup><code>INST_RETIRED.ANY_P</code> event</sup> | <sup><sup><code>MEM_INST_RETIRED.ALL_LOADS</code> event</sup>  | loads executed / instructions executed | <sup><sup><code>MEM_LOAD_RETIRED.L1_MISS</code> event</sup> | L1 cache misses / loads executed | <sup><sup><code>MEM_LOAD_RETIRED.L2_MISS</code> event</sup> | L2 cache misses / loads executed |

That is, the row-major form executes significantly more slowly than the column-major form (1.2 giga-instructions-per-second, vs. 2.9 giga-instructions-per-second), because there were way more cache misses (7.5&times; more L2 misses and 4.5&times; more L1 misses per load).

### StellarGraph benchmarks

This patch expands the `test_benchmark_get_features` benchmark to demonstrate/catch this problem. Previously, the number of nodes was too small, as was the size of the features. This patch doesn't change the performance for the existing `feature_size = 10` (when comparing with the new number of nodes), but on the new parametrisation with `feature_size = 1000`, the performance improves dramatically (just the `num_types = 1`, and `type_arg = specify` options, but the others are similar):

| code | min | mean | max | std | median | iqr |
|---|---|---|---|---|---|---|
| this PR | 100 | 121 | 432 | 19 | 122 | 17 |
| develop | 366 | 487 | 1048 |  48 | 485 | 57 |

That is, this patch makes the new microbenchmark ~4&times; faster.

A larger benchmark is doing extreme feature sampling for GraphSAGE on Cora, which involves selecting out a significant number of features with its long feature rows (`1433 features per node * 4 bytes per feature = 6KB` per node). In this benchmark, we sample  `200 (batch size) * (1 + 20 + 20 * 20) (nodes in 2-hops) = 84200` nodes per batch, which results in copying at least `84200 nodes * 6KB per node = 480MB` of data per batch. The long feature rows benefit a lot from being able to do bulk row-major copies, as we saw in the minimal example.

```python
import stellargraph as sg

G, _ = sg.datasets.Cora().load()

gen = sg.mapper.GraphSAGENodeGenerator(G, 200, [20, 20])
seq = gen.flow(G.nodes())

%timeit -n 5 -r 5 list(seq)
```

Before: `9.78 s ± 20.6 ms per loop (mean ± std. dev. of 5 runs, 5 loops each)`
After: `4.27 s ± 17.4 ms per loop (mean ± std. dev. of 5 runs, 5 loops each)`
#1167: `3.2 s ± 136 ms per loop (mean ± std. dev. of 5 runs, 5 loops each)`

This is enough of a win for a one-line change that we should land it separately to #1167, so that any performance improvements in #1167 are clearly from the Tensorflow change, instead of this major data layout one.

See: #1168