### PR TITLE
Support switching Neo4j versions to test against Neo4j 4 again

### DIFF
--- a/docker/stellargraph-neo4j/Dockerfile
+++ b/docker/stellargraph-neo4j/Dockerfile
@@ -1,10 +1,8 @@
-FROM neo4j:3.5
+ARG NEO4J_VERSION
+FROM neo4j:${NEO4J_VERSION}
 
-SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+ARG NEO4J_VERSION
 
 USER neo4j
-
-ENV APOC_VERSION="3.5.0.9" APOC_SHA="b4b1a8f8940ad250c17b45296459afcfff2eb1beee18b8c8a394e2b5a434183b924b34cb5b04fea1a371fbfb87a286228bd4ae814829e0ef99f9e190a764fa1d"
-RUN echo "--- downloading apoc jar" && \
-    wget --no-verbose "https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/download/${APOC_VERSION}/apoc-${APOC_VERSION}-all.jar" --directory-prefix plugins/ && \
-    echo "${APOC_SHA}  ${PWD}/plugins/apoc-${APOC_VERSION}-all.jar" | sha512sum -c
+COPY install-apoc.sh /
+RUN bash /install-apoc.sh


### PR DESCRIPTION
This reapplies the change to the `stellargraph-neo4j/Dockerfile` from #1161 to ensure we build and test against a Neo4j 4.0 image (using the `NEO4J_VERSION` build arg that is set in the pipeline, via the docker compose file:

https://github.com/stellargraph/stellargraph/blob/2b5ca9f5c33a67db0b758783ab542bf5a5811edb/.buildkite/pipeline.yml#L112

https://github.com/stellargraph/stellargraph/blob/2b5ca9f5c33a67db0b758783ab542bf5a5811edb/.buildkite/docker-compose.yml#L55-L59

Post mortem: I think this change was accidentally reverted in the back merge from `master` to `develop` after the 0.11 release (a58b202d612d7142bbbe5f6518051f86d9233868). In particular, we had to change the Dockerfile in the release branch (e9b07236605d4de16bcd395b581a30e275af0123) to fix #1170 so that the release passed CI. This edit to the dockerfile then conflicted with #1161 which landed concurrently on `develop` and the merge conflict resolution unfortunately picked the wrong version.

See: #1229 