### PR TITLE
Fix formatting of StellarGraph.edges doc string

### DIFF
--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -498,10 +498,12 @@ class StellarGraph:
         Obtains the collection of edges in the graph.
 
         Args:
-            include_edge_type (bool): A flag that indicates whether to return edge types
-            of format (node 1, node 2, edge type) or edge pairs of format (node 1, node 2).
-            include_edge_weight (bool): A flag that indicates whether to return edge weights.
-            Weights are returned in a separate list.
+            include_edge_type (bool):
+                A flag that indicates whether to return edge types of format (node 1, node 2, edge
+                type) or edge pairs of format (node 1, node 2).
+            include_edge_weight (bool):
+                A flag that indicates whether to return edge weights.  Weights are returned in a
+                separate list.
 
         Returns:
             The graph edges. If edge weights are included then a tuple of (edges, weights)


### PR DESCRIPTION
Updated: https://stellargraph--1246.org.readthedocs.build/en/1246/api.html#stellargraph.StellarGraph.edges

![image](https://user-images.githubusercontent.com/1203825/79396014-4d8fb980-7fbe-11ea-81fd-6d80985e1e3e.png)


See: #1245