### PR TITLE
Replace type(...) with type(...).__name__ in error messages

### DIFF
--- a/stellargraph/calibration.py
+++ b/stellargraph/calibration.py
@@ -57,19 +57,19 @@ def expected_calibration_error(prediction_probabilities, accuracy, confidence):
     if not isinstance(prediction_probabilities, np.ndarray):
         raise ValueError(
             "Parameter prediction_probabilities must be type numpy.ndarray but given object of type {}".format(
-                type(prediction_probabilities)
+                type(prediction_probabilities).__name__
             )
         )
     if not isinstance(accuracy, np.ndarray):
         raise ValueError(
             "Parameter accuracy must be type numpy.ndarray but given object of type {}".format(
-                type(accuracy)
+                type(accuracy).__name__
             )
         )
     if not isinstance(confidence, np.ndarray):
         raise ValueError(
             "Parameter confidence must be type numpy.ndarray but given object of type {}".format(
-                type(confidence)
+                type(confidence).__name__
             )
         )
 
@@ -107,26 +107,26 @@ def plot_reliability_diagram(calibration_data, predictions, ece=None, filename=N
     if not isinstance(calibration_data, list):
         raise ValueError(
             "Parameter calibration_data should be list of 2-tuples but received type {}".format(
-                type(calibration_data)
+                type(calibration_data).__name__
             )
         )
 
     if not isinstance(predictions, np.ndarray):
         raise ValueError(
             "Parameter predictions should be of type numpy.ndarray but received type {}".format(
-                type(predictions)
+                type(predictions).__name__
             )
         )
     if ece is not None and not isinstance(ece, list):
         raise ValueError(
             "Parameter ece should be None or list of floating point numbers but received type {}".format(
-                type(ece)
+                type(ece).__name__
             )
         )
     if filename is not None and not isinstance(filename, str):
         raise ValueError(
             "Parameter filename should be None or str type but received type {}".format(
-                type(filename)
+                type(filename).__name__
             )
         )
 
@@ -335,7 +335,7 @@ class TemperatureCalibration(object):
         """
         if not isinstance(x, np.ndarray):
             raise ValueError(
-                "x should be numpy.ndarray but received {}".format(type(x))
+                "x should be numpy.ndarray but received {}".format(type(x).__name__)
             )
 
         if len(x.shape) > 1 and x.shape[1] != self.n_classes:
@@ -380,7 +380,7 @@ class IsotonicCalibration(object):
         if not isinstance(x_train, np.ndarray) or not isinstance(y_train, np.ndarray):
             raise ValueError(
                 "x_train and y_train should be type numpy.ndarray but received {} and {}".format(
-                    type(x_train), type(y_train)
+                    type(x_train).__name__, type(y_train).__name__
                 )
             )
 
@@ -419,7 +419,7 @@ class IsotonicCalibration(object):
         """
         if not isinstance(x, np.ndarray):
             raise ValueError(
-                "x should be numpy.ndarray but received {}".format(type(x))
+                "x should be numpy.ndarray but received {}".format(type(x).__name__)
             )
 
         if self.n_classes > 1 and x.shape[1] != self.n_classes:

--- a/stellargraph/core/convert.py
+++ b/stellargraph/core/convert.py
@@ -107,7 +107,9 @@ class ColumnarConverter:
             elements = {self.default_type: elements}
 
         if not isinstance(elements, dict):
-            raise TypeError(f"{self.name()}: expected dict, found {type(elements).__name__}")
+            raise TypeError(
+                f"{self.name()}: expected dict, found {type(elements).__name__}"
+            )
 
         singles = {
             type_name: self._convert_single(type_name, data)

--- a/stellargraph/core/convert.py
+++ b/stellargraph/core/convert.py
@@ -65,7 +65,7 @@ class ColumnarConverter:
     def _convert_single(self, type_name, data):
         if not isinstance(data, pd.DataFrame):
             raise TypeError(
-                f"{self.name(type_name)}: expected pandas DataFrame, found {type(data)}"
+                f"{self.name(type_name)}: expected pandas DataFrame, found {type(data).__name__}"
             )
 
         existing = set(self.selected_columns).intersection(data.columns)
@@ -107,7 +107,7 @@ class ColumnarConverter:
             elements = {self.default_type: elements}
 
         if not isinstance(elements, dict):
-            raise TypeError(f"{self.name()}: expected dict, found {type(elements)}")
+            raise TypeError(f"{self.name()}: expected dict, found {type(elements).__name__}")
 
         singles = {
             type_name: self._convert_single(type_name, data)

--- a/stellargraph/core/element_data.py
+++ b/stellargraph/core/element_data.py
@@ -128,12 +128,12 @@ class ElementData:
 
     def __init__(self, shared):
         if not isinstance(shared, dict):
-            raise TypeError(f"shared: expected dict, found {type(shared)}")
+            raise TypeError(f"shared: expected dict, found {type(shared).__name__}")
 
         for key, value in shared.items():
             if not isinstance(value, pd.DataFrame):
                 raise TypeError(
-                    f"shared[{key!r}]: expected pandas DataFrame', found {type(value)}"
+                    f"shared[{key!r}]: expected pandas DataFrame', found {type(value).__name__}"
                 )
 
             require_dataframe_has_columns(
@@ -237,12 +237,12 @@ class NodeData(ElementData):
     def __init__(self, shared, features):
         super().__init__(shared)
         if not isinstance(features, dict):
-            raise TypeError(f"features: expected dict, found {type(features)}")
+            raise TypeError(f"features: expected dict, found {type(features).__name__}")
 
         for key, data in features.items():
             if not isinstance(data, (np.ndarray, sps.spmatrix)):
                 raise TypeError(
-                    f"features[{key!r}]: expected numpy or scipy array, found {type(data)}"
+                    f"features[{key!r}]: expected numpy or scipy array, found {type(data).__name__}"
                 )
 
             if len(data.shape) != 2:

--- a/stellargraph/core/utils.py
+++ b/stellargraph/core/utils.py
@@ -172,7 +172,7 @@ def GCN_Aadj_feats_op(features, A, k=1, method="gcn"):
         else:
             raise ValueError(
                 "k should be positive integer for method='sgcn'; but received type {} with value {}.".format(
-                    type(k), k
+                    type(k).__name__, k
                 )
             )
 

--- a/stellargraph/data/epgm.py
+++ b/stellargraph/data/epgm.py
@@ -206,7 +206,7 @@ class EPGM(object):
                     G_epgm[k].append(json.loads(l))
             else:
                 raise Exception(
-                    "type(G[", k, "]): unexpected type", type(G_epgm[k]), ", stopping."
+                    "type(G[", k, "]): unexpected type", type(G_epgm[k]).__name__, ", stopping."
                 )
 
         G_epgm = self._reorder_keys(G=G_epgm)
@@ -547,7 +547,7 @@ class EPGM(object):
                         "type(G[",
                         k,
                         "]): unexpected type",
-                        type(self.G[k]),
+                        type(self.G[k]).__name__,
                         ", stopping.",
                     )
                     raise ()

--- a/stellargraph/data/epgm.py
+++ b/stellargraph/data/epgm.py
@@ -206,7 +206,11 @@ class EPGM(object):
                     G_epgm[k].append(json.loads(l))
             else:
                 raise Exception(
-                    "type(G[", k, "]): unexpected type", type(G_epgm[k]).__name__, ", stopping."
+                    "type(G[",
+                    k,
+                    "]): unexpected type",
+                    type(G_epgm[k]).__name__,
+                    ", stopping.",
                 )
 
         G_epgm = self._reorder_keys(G=G_epgm)

--- a/stellargraph/ensemble.py
+++ b/stellargraph/ensemble.py
@@ -54,7 +54,7 @@ class Ensemble(object):
         if not isinstance(model, K.Model):
             raise ValueError(
                 "({}) model must be a Keras model received object of type {}".format(
-                    type(self).__name__, type(model)
+                    type(self).__name__, type(model).__name__
                 )
             )
         if n_estimators <= 0 or not isinstance(n_estimators, int):
@@ -114,7 +114,7 @@ class Ensemble(object):
         if indx is not None and not isinstance(indx, (int,)):
             raise ValueError(
                 "({}) indx should be None or integer type but received type {}".format(
-                    type(self).__name__, type(indx)
+                    type(self).__name__, type(indx).__name__
                 )
             )
         if isinstance(indx, (int,)) and indx < 0:
@@ -259,7 +259,7 @@ class Ensemble(object):
             raise ValueError(
                 "({}) If train_data is None, generator must be one of type NodeSequence, LinkSequence, FullBatchSequence "
                 "but received object of type {}".format(
-                    type(self).__name__, type(generator)
+                    type(self).__name__, type(generator).__name__
                 )
             )
 
@@ -356,7 +356,7 @@ class Ensemble(object):
             raise ValueError(
                 "({}) generator parameter must be of type GraphSAGENodeGenerator, HinSAGENodeGenerator, FullBatchNodeGenerator, "
                 "GraphSAGELinkGenerator, or HinSAGELinkGenerator. Received type {}".format(
-                    type(self).__name__, type(generator)
+                    type(self).__name__, type(generator).__name__
                 )
             )
         elif not isinstance(
@@ -372,7 +372,7 @@ class Ensemble(object):
                 "({}) If test_data is None, generator must be one of type NodeSequence, "
                 "LinkSequence, FullBatchSequence, or SparseFullBatchSequence "
                 "but received object of type {}".format(
-                    type(self).__name__, type(generator)
+                    type(self).__name__, type(generator).__name__
                 )
             )
         if test_data is not None and test_targets is None:
@@ -468,7 +468,7 @@ class Ensemble(object):
             ):
                 raise ValueError(
                     "({}) generator parameter must be of type GraphSAGENodeGenerator, HinSAGENodeGenerator, or FullBatchNodeGenerator. Received type {}".format(
-                        type(self).__name__, type(generator)
+                        type(self).__name__, type(generator).__name__
                     )
                 )
             data_generator = generator.flow(predict_data)
@@ -653,7 +653,7 @@ class BaggingEnsemble(Ensemble):
             raise ValueError(
                 "({}) generator parameter must be of type GraphSAGENodeGenerator, HinSAGENodeGenerator, "
                 "FullBatchNodeGenerator, GraphSAGELinkGenerator, or HinSAGELinkGenerator if you want to use Bagging. "
-                "Received type {}".format(type(self).__name__, type(generator))
+                "Received type {}".format(type(self).__name__, type(generator).__name__)
             )
         if bag_size is not None and (bag_size > len(train_data) or bag_size <= 0):
             raise ValueError(

--- a/stellargraph/layer/graph_attention.py
+++ b/stellargraph/layer/graph_attention.py
@@ -722,7 +722,7 @@ class GAT:
         if not isinstance(activations, list):
             raise TypeError(
                 "{}: activations should be a list of strings; received {} instead".format(
-                    type(self).__name__, type(activations)
+                    type(self).__name__, type(activations).__name__
                 )
             )
         # check length:

--- a/stellargraph/layer/graphsage.py
+++ b/stellargraph/layer/graphsage.py
@@ -176,7 +176,7 @@ class GraphSAGEAggregator(Layer):
         """
         if not isinstance(input_shape, list):
             raise ValueError(
-                "Expected a list of inputs, not {}".format(type(input_shape))
+                "Expected a list of inputs, not {}".format(type(input_shape).__name__)
             )
 
         # Configure bias vector, if used.

--- a/tests/core/test_convert.py
+++ b/tests/core/test_convert.py
@@ -109,14 +109,11 @@ def test_columnar_convert_disallow_features():
 def test_columnar_convert_invalid_input():
     converter = ColumnarConverter("some_name", "foo", {}, {}, False)
 
-    with pytest.raises(
-        TypeError, match="some_name: expected dict, found <class 'int'>"
-    ):
+    with pytest.raises(TypeError, match="some_name: expected dict, found int"):
         converter.convert(1)
 
     with pytest.raises(
-        TypeError,
-        match=r"some_name\['x'\]: expected pandas DataFrame, found <class 'int'>",
+        TypeError, match=r"some_name\['x'\]: expected pandas DataFrame, found int",
     ):
         converter.convert({"x": 1})
 


### PR DESCRIPTION
This gives a nicer formatting, e.g. `... found int` instead of `... found <class 'int'>`.

See: #1259