### PR TITLE
Optimise RelationalFullBatchNodeGenerator construction (18× speedup, 560× smaller)

### DIFF
--- a/.buildkite/steps/test-demo-notebooks.sh
+++ b/.buildkite/steps/test-demo-notebooks.sh
@@ -33,7 +33,7 @@ f=${NOTEBOOKS[$INDEX]}
 
 case $(basename "$f") in
   'attacks_clustering_analysis.ipynb' | 'hateful-twitters-interpretability.ipynb' | 'hateful-twitters.ipynb' | 'stellargraph-attri2vec-DBLP.ipynb' | \
-    'node-link-importance-demo-gat.ipynb' | 'node-link-importance-demo-gcn.ipynb' | 'node-link-importance-demo-gcn-sparse.ipynb' | 'rgcn-aifb-node-classification-example.ipynb' | \
+    'node-link-importance-demo-gat.ipynb' | 'node-link-importance-demo-gcn.ipynb' | 'node-link-importance-demo-gcn-sparse.ipynb' | \
     'stellargraph-metapath2vec.ipynb')
     # These notebooks do not yet work on CI:
     # FIXME #818: datasets can't be downloaded

--- a/.buildkite/steps/test-demo-notebooks.sh
+++ b/.buildkite/steps/test-demo-notebooks.sh
@@ -33,7 +33,7 @@ f=${NOTEBOOKS[$INDEX]}
 
 case $(basename "$f") in
   'attacks_clustering_analysis.ipynb' | 'hateful-twitters-interpretability.ipynb' | 'hateful-twitters.ipynb' | 'stellargraph-attri2vec-DBLP.ipynb' | \
-    'node-link-importance-demo-gat.ipynb' | 'node-link-importance-demo-gcn.ipynb' | 'node-link-importance-demo-gcn-sparse.ipynb' | \
+    'node-link-importance-demo-gat.ipynb' | 'node-link-importance-demo-gcn.ipynb' | 'node-link-importance-demo-gcn-sparse.ipynb' | 'rgcn-aifb-node-classification-example.ipynb' | \
     'stellargraph-metapath2vec.ipynb')
     # These notebooks do not yet work on CI:
     # FIXME #818: datasets can't be downloaded

--- a/stellargraph/core/element_data.py
+++ b/stellargraph/core/element_data.py
@@ -259,6 +259,15 @@ class NodeData(ElementData):
 
         self._features = features
 
+    def features_of_type(self, type_name) -> np.ndarray:
+        """
+        Returns all features for a given type.
+
+        Args:
+            type_name (hashable): the name of the type
+        """
+        return self._features[type_name]
+
     def features(self, type_name, id_ilocs) -> np.ndarray:
         """
         Return features for a set of IDs within a given type.

--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -732,20 +732,33 @@ class StellarGraph:
 
         # TODO: check the feature node_ids against the graph node ids?
 
-    def node_features(self, nodes, node_type=None):
+    def node_features(self, nodes=None, node_type=None):
         """
-        Get the numeric feature vectors for the specified node or nodes.
-        If the node type is not specified the node types will be found
-        for all nodes. It is therefore important to supply the ``node_type``
-        for this method to be fast.
+        Get the numeric feature vectors for the specified nodes or node type.
+
+        If ``nodes`` is not specified, this returns all features of the specified ``node_type``,
+        where the rows are ordered the same as ``self.nodes(node_type=node_type)``.
+
+        At least one of ``nodes`` and ``node_type`` must be passed. If ``nodes`` is passed without
+        specifying ``node_type``, the node type of ``nodes`` will be inferred (passing ``node_type``
+        in addition to ``nodes`` will therefore be faster).
+
 
         Args:
-            nodes (list or hashable): Node ID or list of node IDs
-            node_type (hashable): the type of the nodes.
+            nodes (list or hashable, optional): Node ID or list of node IDs, all of the same type
+            node_type (hashable, optional): the type of the nodes.
 
         Returns:
-            Numpy array containing the node features for the requested nodes.
+            Numpy array containing the node features for the requested nodes or node type.
         """
+        if nodes is None:
+            if node_type is None:
+                raise ValueError(
+                    "node_type: expected a node type to be specified when 'nodes' is not passed, found None"
+                )
+
+            return self._nodes.features_of_type(node_type)
+
         nodes = np.asarray(nodes)
 
         node_ilocs = self._nodes.ids.to_iloc(nodes)

--- a/stellargraph/mapper/full_batch_generators.py
+++ b/stellargraph/mapper/full_batch_generators.py
@@ -47,6 +47,7 @@ from . import (
 from ..core.graph import StellarGraph
 from ..core.utils import is_real_iterable
 from ..core.utils import GCN_Aadj_feats_op, PPNP_Aadj_feats_op
+from ..core.validation import comma_sep
 
 
 class FullBatchGenerator(Generator):
@@ -423,8 +424,8 @@ class RelationalFullBatchNodeGenerator(Generator):
         # extract node, feature, and edge type info from G
         node_types = list(G.node_types)
         if len(node_types) != 1:
-            raise ValuError(
-                f"{type(self).__name__}: expected one node type, found {num_node_types} types",
+            raise ValueError(
+                f"G: expected one node type, found {comma_sep(sorted(node_types))}",
             )
 
         self.features = G.node_features(node_type=node_types[0])

--- a/stellargraph/mapper/full_batch_generators.py
+++ b/stellargraph/mapper/full_batch_generators.py
@@ -421,7 +421,13 @@ class RelationalFullBatchNodeGenerator(Generator):
         G.check_graph_for_ml()
 
         # extract node, feature, and edge type info from G
-        self.features = G.node_features(G.nodes())
+        node_types = list(G.node_types)
+        if len(node_types) != 1:
+            raise ValuError(
+                f"{type(self).__name__}: expected one node type, found {num_node_types} types",
+            )
+
+        self.features = G.node_features(node_type=node_types[0])
 
         # create a list of adjacency matrices - one adj matrix for each edge type
         # an adjacency matrix is created for each edge type from all edges of that type

--- a/stellargraph/mapper/full_batch_generators.py
+++ b/stellargraph/mapper/full_batch_generators.py
@@ -425,14 +425,13 @@ class RelationalFullBatchNodeGenerator(Generator):
 
         self.features = G.node_features(self.node_list)
 
-        edge_types = G.edge_types
         self.node_index = dict(zip(self.node_list, range(len(self.node_list))))
 
         # create a list of adjacency matrices - one adj matrix for each edge type
         # an adjacency matrix is created for each edge type from all edges of that type
         self.As = []
 
-        for edge_type in edge_types:
+        for edge_type in G.edge_types:
             # note that A is the transpose of the standard adjacency matrix
             # this is to aggregate features from incoming nodes
             A = G.to_adjacency_matrix(edge_type=edge_type).transpose()

--- a/stellargraph/mapper/full_batch_generators.py
+++ b/stellargraph/mapper/full_batch_generators.py
@@ -421,11 +421,7 @@ class RelationalFullBatchNodeGenerator(Generator):
         G.check_graph_for_ml()
 
         # extract node, feature, and edge type info from G
-        self.node_list = list(G.nodes())
-
-        self.features = G.node_features(self.node_list)
-
-        self.node_index = dict(zip(self.node_list, range(len(self.node_list))))
+        self.features = G.node_features(G.nodes())
 
         # create a list of adjacency matrices - one adj matrix for each edge type
         # an adjacency matrix is created for each edge type from all edges of that type
@@ -478,9 +474,7 @@ class RelationalFullBatchNodeGenerator(Generator):
             if len(targets) != len(node_ids):
                 raise TypeError("Targets must be the same length as node_ids")
 
-        # The list of indices of the target nodes in self.node_list
-        # use dictionary for faster index look-up time
-        node_indices = np.array([self.node_index[n] for n in node_ids])
+        node_indices = self.graph._get_index_for_nodes(node_ids)
 
         return RelationalFullBatchNodeSequence(
             self.features, self.As, self.use_sparse, targets, node_indices

--- a/stellargraph/mapper/full_batch_generators.py
+++ b/stellargraph/mapper/full_batch_generators.py
@@ -467,9 +467,6 @@ class RelationalFullBatchNodeGenerator(Generator):
             A = A.tocoo()
             self.As.append(A)
 
-        # Get the features for the nodes
-        self.features = G.node_features(self.node_list)
-
     def num_batch_dims(self):
         return 2
 

--- a/stellargraph/mapper/full_batch_generators.py
+++ b/stellargraph/mapper/full_batch_generators.py
@@ -425,7 +425,7 @@ class RelationalFullBatchNodeGenerator(Generator):
 
         self.features = G.node_features(self.node_list)
 
-        edge_types = sorted(set(e[-1] for e in G.edges(include_edge_type=True)))
+        edge_types = G.edge_types
         self.node_index = dict(zip(self.node_list, range(len(self.node_list))))
 
         # create a list of adjacency matrices - one adj matrix for each edge type
@@ -433,25 +433,9 @@ class RelationalFullBatchNodeGenerator(Generator):
         self.As = []
 
         for edge_type in edge_types:
-
-            col_index = [
-                self.node_index[n1]
-                for n1, n2, etype in G.edges(include_edge_type=True)
-                if etype == edge_type
-            ]
-            row_index = [
-                self.node_index[n2]
-                for n1, n2, etype in G.edges(include_edge_type=True)
-                if etype == edge_type
-            ]
-            data = np.ones(len(col_index), np.float64)
-
             # note that A is the transpose of the standard adjacency matrix
             # this is to aggregate features from incoming nodes
-            A = sps.coo_matrix(
-                (data, (row_index, col_index)),
-                shape=(len(self.node_list), len(self.node_list)),
-            )
+            A = G.to_adjacency_matrix(edge_type=edge_type).transpose()
 
             if transform is None:
                 # normalize here and replace zero row sums with 1

--- a/tests/core/test_graph.py
+++ b/tests/core/test_graph.py
@@ -263,6 +263,40 @@ def test_feature_conversion_from_nodes():
     assert sg.node_feature_sizes()["default"] == 8
 
 
+def test_node_features():
+    feature_sizes = {"A": 4, "B": 6}
+    sg = example_hin_1(feature_sizes=feature_sizes)
+
+    one_zero = np.array([[1] * 4, [0] * 4])
+
+    # inference
+    np.testing.assert_array_equal(sg.node_features(nodes=[1, 0]), one_zero)
+    # specified
+    np.testing.assert_array_equal(
+        sg.node_features(nodes=[1, 0], node_type="A"), one_zero
+    )
+
+    # wrong type
+    with pytest.raises(ValueError, match="unknown IDs"):
+        sg.node_features(nodes=[1, 0], node_type="B")
+
+    # mixed types
+    with pytest.raises(ValueError, match="unknown IDs"):
+        sg.node_features(nodes=[0, 4])
+
+
+def test_node_features_node_type():
+    feature_sizes = {"A": 4, "B": 6}
+    sg = example_hin_1(feature_sizes=feature_sizes)
+
+    np.testing.assert_array_equal(
+        sg.node_features(node_type="A"), [[0] * 4, [1] * 4, [2] * 4, [3] * 4],
+    )
+    np.testing.assert_array_equal(
+        sg.node_features(node_type="B"), [[4] * 6, [5] * 6, [6] * 6]
+    )
+
+
 def test_node_features_missing_id():
     sg = example_graph(feature_size=6)
     with pytest.raises(KeyError, match=r"\[1000, 2000\]"):

--- a/tests/core/test_graph.py
+++ b/tests/core/test_graph.py
@@ -280,9 +280,13 @@ def test_node_features():
     with pytest.raises(ValueError, match="unknown IDs"):
         sg.node_features(nodes=[1, 0], node_type="B")
 
-    # mixed types
-    with pytest.raises(ValueError, match="unknown IDs"):
+    # mixed types, inference
+    with pytest.raises(ValueError, match="all nodes must have the same type"):
         sg.node_features(nodes=[0, 4])
+
+    # mixed types, specified
+    with pytest.raises(ValueError, match="unknown IDs"):
+        sg.node_features(nodes=[0, 4], node_type="A")
 
 
 def test_node_features_node_type():

--- a/tests/core/test_graph.py
+++ b/tests/core/test_graph.py
@@ -1240,7 +1240,7 @@ def test_benchmark_to_adjacency_matrix(is_directed, benchmark):
 def test_edge_weights_undirected():
     g = example_hin_1(is_directed=False, self_loop=True)
 
-    assert g._edge_weights(5, 5) == [11.0, 12.0]
+    assert g._edge_weights(5, 5) == [11.0, 12.0, 1.0]
     assert g._edge_weights(4, 5) == [10.0]
     assert g._edge_weights(5, 4) == [10.0]
     assert g._edge_weights(0, 4) == [1]
@@ -1250,7 +1250,7 @@ def test_edge_weights_undirected():
 def test_edge_weights_directed():
     g = example_hin_1(is_directed=True, self_loop=True)
 
-    assert g._edge_weights(5, 5) == [11.0, 12.0]
+    assert g._edge_weights(5, 5) == [11.0, 12.0, 1.0]
     assert g._edge_weights(4, 5) == [10.0]
     assert g._edge_weights(5, 4) == []
     assert g._edge_weights(0, 4) == []

--- a/tests/layer/test_rgcn.py
+++ b/tests/layer/test_rgcn.py
@@ -80,7 +80,7 @@ def test_RelationalGraphConvolution_init():
 
 def test_RelationalGraphConvolution_sparse():
     G, features = create_graph_features()
-    n_edge_types = len(get_edge_types(G))
+    n_edge_types = len(G.edge_types)
 
     # We need to specify the batch shape as one for the GraphConvolutional logic to work
     n_nodes = features.shape[0]
@@ -129,7 +129,7 @@ def test_RelationalGraphConvolution_sparse():
 def test_RelationalGraphConvolution_dense():
 
     G, features = create_graph_features()
-    n_edge_types = len(get_edge_types(G))
+    n_edge_types = len(G.edge_types)
 
     # We need to specify the batch shape as one for the GraphConvolutional logic to work
     n_nodes = features.shape[0]
@@ -176,7 +176,7 @@ def test_RGCN_init():
 
 
 def test_RGCN_apply_sparse():
-    G, features = create_graph_features()
+    G, features = create_graph_features(is_directed=True)
 
     As = get_As(G)
     As = [A.tocoo() for A in As]
@@ -204,7 +204,7 @@ def test_RGCN_apply_sparse():
 
 
 def test_RGCN_apply_dense():
-    G, features = create_graph_features()
+    G, features = create_graph_features(is_directed=True)
 
     As = get_As(G)
     As = [np.expand_dims(A.todense(), 0) for A in As]
@@ -328,18 +328,13 @@ def test_RelationalGraphConvolution_edge_cases():
     assert str(error) == "units should be positive"
 
 
-def get_edge_types(G):
-    assert isinstance(G, StellarGraph)
-    return sorted(set(etype for _, _, etype in G.edges(include_edge_type=True)))
-
-
 def get_As(G):
 
     As = []
-    edge_types = get_edge_types(G)
     node_list = list(G.nodes())
     node_index = dict(zip(node_list, range(len(node_list))))
-    for edge_type in edge_types:
+
+    for edge_type in G.edge_types:
         col_index = [
             node_index[n1]
             for n1, n2, etype in G.edges(include_edge_type=True)

--- a/tests/mapper/test_relational_node_mappers.py
+++ b/tests/mapper/test_relational_node_mappers.py
@@ -150,7 +150,7 @@ class Test_RelationalFullBatchNodeGenerator:
             generator = RelationalFullBatchNodeGenerator(G, "test", transform=func)
 
     def test_fullbatch_generator_transform(self):
-        G, _ = create_graph_features()
+        G, _ = create_graph_features(is_directed=True)
 
         def func(features, A, **kwargs):
             return features, A.dot(A)

--- a/tests/mapper/test_relational_node_mappers.py
+++ b/tests/mapper/test_relational_node_mappers.py
@@ -24,6 +24,7 @@ import pandas as pd
 import scipy.sparse as sps
 from ..test_utils.graphs import (
     relational_create_graph_features as create_graph_features,
+    example_hin_1,
 )
 
 
@@ -148,6 +149,13 @@ class Test_RelationalFullBatchNodeGenerator:
 
         with pytest.raises(TypeError):
             generator = RelationalFullBatchNodeGenerator(G, "test", transform=func)
+
+    def test_fullbatch_generator_init_heterogeneous_nodes(self):
+        G = example_hin_1(feature_sizes={})
+        with pytest.raises(
+            ValueError, match="G: expected one node type, found 'A', 'B'"
+        ):
+            RelationalFullBatchNodeGenerator(G)
 
     def test_fullbatch_generator_transform(self):
         G, _ = create_graph_features(is_directed=True)

--- a/tests/test_utils/graphs.py
+++ b/tests/test_utils/graphs.py
@@ -126,14 +126,15 @@ def example_hin_1(
     b_ids = [4, 5, 6]
     b = pd.DataFrame(features("B", b_ids), index=b_ids)
 
-    r = pd.DataFrame(
-        [(4, 0), (1, 5), (1, 4), (2, 4), (5, 3)], columns=["source", "target"]
-    )
-    f_edges, f_index = [(4, 5)], [6]
+    r_edges = [(4, 0), (1, 5), (1, 4), (2, 4), (5, 3)]
+    f_edges, f_index = [(4, 5)], [100]
     if self_loop:
-        # make it a multigraph
+        # make it a multigraph, across types and within a single one
+        r_edges.append((5, 5))
         f_edges.extend([(5, 5), (5, 5)])
-        f_index.extend([7, 8])
+        f_index.extend([101, 102])
+
+    r = pd.DataFrame(r_edges, columns=["source", "target"])
 
     # add some weights for the f edges, but not others
     f_columns = ["source", "target", "weight"]


### PR DESCRIPTION
This does four things to make preparing data for RGCN (in the form of creating a `RelationalFullBatchNodeGenerator`) faster, mostly by removing code due to the new StellarGraph having stronger requirements.

I benchmarked time in the same manner as #1272, on the AIFB dataset, running:

```python
import stellargraph as sg

G, affiliation = sg.datasets.AIFB().load()
%timeit -n 3 -r 5 sg.mapper.RelationalFullBatchNodeGenerator(G, sparse=True)
```

I benchmarked memory usage using pympler, subtracting out the size of the graph to show the incremental memory use over the raw `StellarGraph` data:

```python
from pympler.asizeof import asizeof
asizeof(sg.mapper.RelationalFullBatchNodeGenerator(G)) - asizeof(G)
```

| code | time (s) | total speedup (incremental) | memory (MiB) | memory reduction |
|---|---|---|---|---|
| original (`develop`) | 1.64 |  1.0× (1.0×) | 270 | 0% |
| fetch node features once | 1.25 | 1.3× (1.3×) | 270 | 0% |
| edge-type filtering in `to_adjacency_matrix`  | 0.35 | 4.7× (3.6×) | 270 | 0% |
| use `_get_index_for_nodes`, not manual `dict` | 0.26 | 6.3× (1.3×) | 269 | -0.4% |
| don't manually index `node_features`  | 0.09 |  18× (2.9×) | 0.483 | -99.8% |

Using `to_adjacency_matrix` means that the directedness of the graph now matters, so some tests have to be updated to use use `StellarDiGraph` instead of an undirected `StellarGraph`.

Two of these points require updates to `StellarGraph`:

- edge-type filtering in `to_adjacency_matrix`: expands that method to support only including edges of a single type
- don't manually index `node_features`: expands that method to support getting all features for a single type, which doesn't have to do any copying (this doesn't change behaviour, because the node features were in the right order to start with: doing `graph.node_features(graph.nodes())` ends up indexing the underlying array with `[0, 1, 2, ... , num_nodes - 1]`, which requires allocating new memory and copying, without actually changing the order or shape of the data)

The massive memory reduction for the last point is because the feature matrix is now shared with the underlying `StellarGraph` object and so isn't duplicated in memory. The final memory usage is thus dominated by the sparse adjacency matrices for each type, and so should be proportional to `O(number of edge types + number of edges)` (the first term models the constant cost of each sparse matrix). Previously, it included a `O(number of nodes * feature size)` term, which was very large for the AIFB dataset (`8285 nodes * 8285 features per node * 4 bytes per feature = 262MiB`).

Unfortunately, this still isn't enough to allow the notebook to run on CI, as it still hits out-of-memory errors (#819): https://buildkite.com/stellar/stellargraph-public/builds/3220

Some of these optimisations can potentially be applied to other locations in the library too (#1276, #1277).

See: #1272