### PR TITLE
Optimise FullBatch...Generator construction (3× speedup, 480× smaller)

### DIFF
--- a/stellargraph/mapper/full_batch_generators.py
+++ b/stellargraph/mapper/full_batch_generators.py
@@ -94,7 +94,7 @@ class FullBatchGenerator(Generator):
         # Create sparse adjacency matrix:
         # Use the node orderings the same as in the graph features
         self.node_list = G.nodes()
-        self.Aadj = G.to_adjacency_matrix(self.node_list)
+        self.Aadj = G.to_adjacency_matrix()
 
         # Function to map node IDs to indices for quicker node index lookups
         # TODO: Move this to the graph class

--- a/stellargraph/mapper/full_batch_generators.py
+++ b/stellargraph/mapper/full_batch_generators.py
@@ -115,7 +115,7 @@ class FullBatchGenerator(Generator):
             self.use_sparse = sparse
 
         # Get the features for the nodes
-        self.features = G.node_features(self.node_list)
+        self.features = G.node_features(node_type=node_types[0])
 
         if transform is not None:
             if callable(transform):

--- a/stellargraph/mapper/full_batch_generators.py
+++ b/stellargraph/mapper/full_batch_generators.py
@@ -96,11 +96,6 @@ class FullBatchGenerator(Generator):
         self.node_list = G.nodes()
         self.Aadj = G.to_adjacency_matrix()
 
-        # Function to map node IDs to indices for quicker node index lookups
-        # TODO: Move this to the graph class
-        node_index_dict = dict(zip(self.node_list, range(len(self.node_list))))
-        self._node_lookup = np.vectorize(node_index_dict.get, otypes=[np.int64])
-
         # Power-user feature: make the generator yield dense adjacency matrix instead
         # of the default sparse one.
         # If sparse is specified, check that the backend is tensorflow
@@ -186,7 +181,7 @@ class FullBatchGenerator(Generator):
                 raise TypeError("Targets must be the same length as node_ids")
 
         # The list of indices of the target nodes in self.node_list
-        node_indices = self._node_lookup(node_ids)
+        node_indices = self.graph._get_index_for_nodes(node_ids)
 
         if self.use_sparse:
             return SparseFullBatchSequence(

--- a/stellargraph/mapper/full_batch_generators.py
+++ b/stellargraph/mapper/full_batch_generators.py
@@ -180,8 +180,13 @@ class FullBatchGenerator(Generator):
             if len(targets) != len(node_ids):
                 raise TypeError("Targets must be the same length as node_ids")
 
-        # The list of indices of the target nodes in self.node_list
-        node_indices = self.graph._get_index_for_nodes(node_ids)
+        # find the indices of the nodes, handling both multiplicity 1 [node, node, ...] and 2
+        # [(source, target), ...]
+        node_ids = np.asarray(node_ids)
+        flat_node_ids = node_ids.reshape(-1)
+        flat_node_indices = self.graph._get_index_for_nodes(flat_node_ids)
+        # back to the original shape
+        node_indices = flat_node_indices.reshape(node_ids.shape)
 
         if self.use_sparse:
             return SparseFullBatchSequence(


### PR DESCRIPTION
This does three things to make preparing data for full batch methods (in the form of `FullBatchNodeGenerator` and `FullBatchLinkGenerator`) faster, mostly by removing code due to the new StellarGraph having stronger requirements.

I benchmarked time in the same manner as #1276, on the PubMed diabetes dataset (19717 nodes, 44338 edges), running:

```python
import stellargraph as sg

pubmed, _ = sg.datasets.PubMedDiabetes().load()
print(pubmed.info())

%timeit -n 10 sg.mapper.FullBatchNodeGenerator(pubmed)
```

I benchmarked memory usage using pympler, subtracting out the size of the graph to show the incremental memory use over the raw StellarGraph data:

```python
from pympler.asizeof import asizeof
(asizeof(sg.mapper.FullBatchNodeGenerator(pubmed)) - asizeof(pubmed))
```

| code | time (ms) | total speedup (incremental) | memory (KiB) | memory reduction (incremental) |
|---|---|---|---|---|
| original (`develop`/#1274) | 54 | 1.0× (1.0×) | 38600 | 0% (0%) |
| use `node_features(node_type=...)` | 35 |  1.5× (1.5×) | 80 | -99.8% (-99.8%) |
| no no-op node filtering in `to_adjacency_matrix` | 21 | 2.6× (1.7×) | 80 |  -99.8% (0%)  |
| use `_get_index_for_nodes`, not manual dict | 18 | 3.0× (1.2×) | 79 | -99.8% (-1.3%) |

This builds on the changes to `StellarGraph` in #1274.

Similar to #1274, this no longer duplicates the features, resulting in the massive memory reduction (the features are `19717 nodes * 500 features per node * 4 bytes per feature = 38500KiB`).

(The speedup is even larger, like 100× or more, if the nodes have a complicated index type, such as a multiindex, related to #1346.)

See: #1276