### PR TITLE
Restore BlogCatalog3 dataset (#907)

### DIFF
--- a/.buildkite/steps/test-demo-notebooks.sh
+++ b/.buildkite/steps/test-demo-notebooks.sh
@@ -33,13 +33,10 @@ f=${NOTEBOOKS[$INDEX]}
 
 case $(basename "$f") in
   'attacks_clustering_analysis.ipynb' | 'hateful-twitters-interpretability.ipynb' | 'hateful-twitters.ipynb' | 'stellargraph-attri2vec-DBLP.ipynb' | \
-    'node-link-importance-demo-gat.ipynb' | 'node-link-importance-demo-gcn.ipynb' | 'node-link-importance-demo-gcn-sparse.ipynb' | 'rgcn-aifb-node-classification-example.ipynb' | \
-    'stellargraph-metapath2vec.ipynb')
+    'node-link-importance-demo-gat.ipynb' | 'node-link-importance-demo-gcn.ipynb' | 'node-link-importance-demo-gcn-sparse.ipynb' | 'rgcn-aifb-node-classification-example.ipynb')
     # These notebooks do not yet work on CI:
     # FIXME #818: datasets can't be downloaded
     # FIXME #819: out-of-memory
-    # FIXME #849: CI does not have neo4j
-    # FIXME #907: socialcomputing.asu.edu is down
     echo "+++ :python: :skull_and_crossbones: skipping $f"
     exit 2 # this will be a soft-fail for buildkite
     ;;

--- a/stellargraph/datasets/datasets.py
+++ b/stellargraph/datasets/datasets.py
@@ -265,7 +265,7 @@ class BlogCatalog3(
     DatasetLoader,
     name="BlogCatalog3",
     directory_name="BlogCatalog-dataset",
-    url="http://socialcomputing.asu.edu/uploads/1283153973/BlogCatalog-dataset.zip",
+    url="https://ndownloader.figshare.com/files/22349970",
     url_archive_format="zip",
     expected_files=[
         "data/edges.csv",
@@ -275,7 +275,7 @@ class BlogCatalog3(
     ],
     description="This dataset is crawled from a social blog directory website BlogCatalog "
     "http://www.blogcatalog.com and contains the friendship network crawled and group memberships.",
-    source="http://socialcomputing.asu.edu/datasets/BlogCatalog3",
+    source="https://figshare.com/articles/BlogCatalog_dataset/11923611",
     data_subdirectory_name="data",
 ):
     def load(self):

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -26,18 +26,7 @@ from unittest.mock import patch
 
 
 # use parametrize to automatically test each of the datasets that (directly) derive from DatasetLoader
-def _marks(cls):
-    if cls == BlogCatalog3:
-        return pytest.mark.xfail(
-            reason="https://github.com/stellargraph/stellargraph/issues/907"
-        )
-    return []
-
-
-@pytest.mark.parametrize(
-    "dataset_class",
-    [pytest.param(cls, marks=_marks(cls)) for cls in DatasetLoader.__subclasses__()],
-)
+@pytest.mark.parametrize("dataset_class", list(DatasetLoader.__subclasses__()))
 def test_dataset_download(dataset_class):
     dataset_class().download(ignore_cache=True)
 
@@ -84,7 +73,6 @@ def test_download_cache(mock_urlretrieve) -> None:
     assert not mock_urlretrieve.called
 
 
-@pytest.mark.xfail(reason="https://github.com/stellargraph/stellargraph/issues/907")
 def test_blogcatalog3_load() -> None:
     g = BlogCatalog3().load()
 

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -84,8 +84,8 @@ def test_blogcatalog3_load() -> None:
     assert g.number_of_nodes() == n_users + n_groups
     assert g.number_of_edges() == n_friendships + n_belongs_to
 
-    assert g.nodes(node_type="user") == [f"u{x}" for x in range(1, n_users + 1)]
-    assert g.nodes(node_type="group") == [f"g{x}" for x in range(1, n_groups + 1)]
+    assert list(g.nodes(node_type="user")) == [f"u{x}" for x in range(1, n_users + 1)]
+    assert list(g.nodes(node_type="group")) == [f"g{x}" for x in range(1, n_groups + 1)]
 
 
 def test_mutag_load() -> None:


### PR DESCRIPTION
The website previously hosting the BlogCatalog3 dataset, http://socialcomputing.asu.edu, is no longer available, however the authors have given permission for it to be re-hosted on figshare: https://figshare.com/articles/BlogCatalog_dataset/11923611

This PR updates the URL of the dataset, restores tests and notebook CI.

See: #907 