### PR TITLE
Store edge ilocs in smallest possible format

### DIFF
--- a/stellargraph/core/element_data.py
+++ b/stellargraph/core/element_data.py
@@ -296,8 +296,8 @@ class NodeData(ElementData):
         }
 
 
-def _numpyise(d):
-    return {k: np.array(v) for k, v in d.items()}
+def _numpyise(d, dtype):
+    return {k: np.array(v, dtype=dtype) for k, v in d.items()}
 
 
 class EdgeData(ElementData):
@@ -329,9 +329,10 @@ class EdgeData(ElementData):
             if src != tgt:
                 undirected.setdefault(src, []).append(i)
 
-        self._edges_in_dict = _numpyise(in_dict)
-        self._edges_out_dict = _numpyise(out_dict)
-        self._edges_dict = _numpyise(undirected)
+        dtype = np.min_scalar_type(i)
+        self._edges_in_dict = _numpyise(in_dict, dtype=dtype)
+        self._edges_out_dict = _numpyise(out_dict, dtype=dtype)
+        self._edges_dict = _numpyise(undirected, dtype=dtype)
 
         # when there's no neighbors for something, an empty array should be returned; this uses a
         # tiny dtype to minimise unnecessary type promotion (e.g. if this is used with an int32

--- a/stellargraph/core/element_data.py
+++ b/stellargraph/core/element_data.py
@@ -329,7 +329,7 @@ class EdgeData(ElementData):
             if src != tgt:
                 undirected.setdefault(src, []).append(i)
 
-        dtype = np.min_scalar_type(i)
+        dtype = np.min_scalar_type(len(self.sources))
         self._edges_in_dict = _numpyise(in_dict, dtype=dtype)
         self._edges_out_dict = _numpyise(out_dict, dtype=dtype)
         self._edges_dict = _numpyise(undirected, dtype=dtype)


### PR DESCRIPTION
This PR stores edge ilocs in the smallest possible format, leading to a memory reduction of 35% for the storing the reddit dataset without features.

See: #1288