### PR TITLE
Fix demo notebooks in docs

### DIFF
--- a/docs/demos/basics/index.txt
+++ b/docs/demos/basics/index.txt
@@ -5,4 +5,5 @@ Basics
     :titlesonly:
     :glob:
 
+    */index
     ./*

--- a/docs/demos/calibration/index.txt
+++ b/docs/demos/calibration/index.txt
@@ -5,4 +5,5 @@ Calibration
     :titlesonly:
     :glob:
 
+    */index
     ./*

--- a/docs/demos/community_detection/index.txt
+++ b/docs/demos/community_detection/index.txt
@@ -5,4 +5,5 @@ Community Detection
     :titlesonly:
     :glob:
 
+    */index
     ./*

--- a/docs/demos/connector/index.txt
+++ b/docs/demos/connector/index.txt
@@ -5,4 +5,5 @@ Connector
     :titlesonly:
     :glob:
 
+    */index
     ./*

--- a/docs/demos/connector/neo4j/index.txt
+++ b/docs/demos/connector/neo4j/index.txt
@@ -5,4 +5,5 @@ Neo4j
     :titlesonly:
     :glob:
 
+    */index
     ./*

--- a/docs/demos/embeddings/index.txt
+++ b/docs/demos/embeddings/index.txt
@@ -5,4 +5,5 @@ Embeddings
     :titlesonly:
     :glob:
 
+    */index
     ./*

--- a/docs/demos/ensembles/index.txt
+++ b/docs/demos/ensembles/index.txt
@@ -5,4 +5,5 @@ Ensembles
     :titlesonly:
     :glob:
 
+    */index
     ./*

--- a/docs/demos/graph-classification/index.txt
+++ b/docs/demos/graph-classification/index.txt
@@ -5,4 +5,5 @@ Graph Classification
     :titlesonly:
     :glob:
 
+    */index
     ./*

--- a/docs/demos/index.txt
+++ b/docs/demos/index.txt
@@ -5,4 +5,5 @@ Demos
     :titlesonly:
     :glob:
 
+    */index
     ./*

--- a/docs/demos/interpretability/gat/index.txt
+++ b/docs/demos/interpretability/gat/index.txt
@@ -5,4 +5,5 @@ Gat
     :titlesonly:
     :glob:
 
+    */index
     ./*

--- a/docs/demos/interpretability/gcn/index.txt
+++ b/docs/demos/interpretability/gcn/index.txt
@@ -5,4 +5,5 @@ Gcn
     :titlesonly:
     :glob:
 
+    */index
     ./*

--- a/docs/demos/interpretability/index.txt
+++ b/docs/demos/interpretability/index.txt
@@ -5,4 +5,5 @@ Interpretability
     :titlesonly:
     :glob:
 
+    */index
     ./*

--- a/docs/demos/link-prediction/attri2vec/index.txt
+++ b/docs/demos/link-prediction/attri2vec/index.txt
@@ -5,4 +5,5 @@ Attri2vec
     :titlesonly:
     :glob:
 
+    */index
     ./*

--- a/docs/demos/link-prediction/gcn/index.txt
+++ b/docs/demos/link-prediction/gcn/index.txt
@@ -5,4 +5,5 @@ Gcn
     :titlesonly:
     :glob:
 
+    */index
     ./*

--- a/docs/demos/link-prediction/graphsage/index.txt
+++ b/docs/demos/link-prediction/graphsage/index.txt
@@ -5,4 +5,5 @@ Graphsage
     :titlesonly:
     :glob:
 
+    */index
     ./*

--- a/docs/demos/link-prediction/hinsage/index.txt
+++ b/docs/demos/link-prediction/hinsage/index.txt
@@ -5,4 +5,5 @@ Hinsage
     :titlesonly:
     :glob:
 
+    */index
     ./*

--- a/docs/demos/link-prediction/index.txt
+++ b/docs/demos/link-prediction/index.txt
@@ -5,4 +5,5 @@ Link Prediction
     :titlesonly:
     :glob:
 
+    */index
     ./*

--- a/docs/demos/link-prediction/knowledge-graphs/index.txt
+++ b/docs/demos/link-prediction/knowledge-graphs/index.txt
@@ -5,4 +5,5 @@ Knowledge Graphs
     :titlesonly:
     :glob:
 
+    */index
     ./*

--- a/docs/demos/link-prediction/random-walks/index.txt
+++ b/docs/demos/link-prediction/random-walks/index.txt
@@ -5,4 +5,5 @@ Random Walks
     :titlesonly:
     :glob:
 
+    */index
     ./*

--- a/docs/demos/node-classification/attri2vec/index.txt
+++ b/docs/demos/node-classification/attri2vec/index.txt
@@ -5,4 +5,5 @@ Attri2vec
     :titlesonly:
     :glob:
 
+    */index
     ./*

--- a/docs/demos/node-classification/cluster-gcn/index.txt
+++ b/docs/demos/node-classification/cluster-gcn/index.txt
@@ -5,4 +5,5 @@ Cluster Gcn
     :titlesonly:
     :glob:
 
+    */index
     ./*

--- a/docs/demos/node-classification/gat/index.txt
+++ b/docs/demos/node-classification/gat/index.txt
@@ -5,4 +5,5 @@ Gat
     :titlesonly:
     :glob:
 
+    */index
     ./*

--- a/docs/demos/node-classification/gcn/index.txt
+++ b/docs/demos/node-classification/gcn/index.txt
@@ -5,4 +5,5 @@ Gcn
     :titlesonly:
     :glob:
 
+    */index
     ./*

--- a/docs/demos/node-classification/graphsage/index.txt
+++ b/docs/demos/node-classification/graphsage/index.txt
@@ -5,4 +5,5 @@ Graphsage
     :titlesonly:
     :glob:
 
+    */index
     ./*

--- a/docs/demos/node-classification/index.txt
+++ b/docs/demos/node-classification/index.txt
@@ -5,4 +5,5 @@ Node Classification
     :titlesonly:
     :glob:
 
+    */index
     ./*

--- a/docs/demos/node-classification/node2vec/index.txt
+++ b/docs/demos/node-classification/node2vec/index.txt
@@ -5,4 +5,5 @@ Node2vec
     :titlesonly:
     :glob:
 
+    */index
     ./*

--- a/docs/demos/node-classification/ppnp/index.txt
+++ b/docs/demos/node-classification/ppnp/index.txt
@@ -5,4 +5,5 @@ Ppnp
     :titlesonly:
     :glob:
 
+    */index
     ./*

--- a/docs/demos/node-classification/rgcn/index.txt
+++ b/docs/demos/node-classification/rgcn/index.txt
@@ -5,4 +5,5 @@ Rgcn
     :titlesonly:
     :glob:
 
+    */index
     ./*

--- a/docs/demos/node-classification/sgc/index.txt
+++ b/docs/demos/node-classification/sgc/index.txt
@@ -5,4 +5,5 @@ Sgc
     :titlesonly:
     :glob:
 
+    */index
     ./*

--- a/docs/demos/use-cases/index.txt
+++ b/docs/demos/use-cases/index.txt
@@ -5,4 +5,5 @@ Use Cases
     :titlesonly:
     :glob:
 
+    */index
     ./*

--- a/scripts/create-nbsphinx-links.sh
+++ b/scripts/create-nbsphinx-links.sh
@@ -26,6 +26,7 @@ $section_title
     :titlesonly:
     :glob:
 
+    */index
     ./*
 EOF
     else


### PR DESCRIPTION
Notebooks didn't end up getting included in the docs in #1279 due to this change https://github.com/stellargraph/stellargraph/pull/1279#discussion_r411867518

Seems like the glob does not search recursively down the subdirectories, but we want to add all `*/index` files to the toc tree (subdirectories containing notebooks) as well as the notebooks in the current directory `./*`.

Part of #1159 

Should be correct this time 🤞 https://stellargraph--1304.org.readthedocs.build/en/1304/demos/index.html