### PR TITLE
Make sg.utils.plot_history return figure

### DIFF
--- a/stellargraph/utils/history.py
+++ b/stellargraph/utils/history.py
@@ -34,6 +34,10 @@ def plot_history(history, individual_figsize=(7, 4), **kwargs):
         history: the training history, as returned by :meth:`tf.keras.Model.fit`
         individual_figsize (tuple of numbers): the size of the plot for each metric
         kwargs: additional arguments to pass to :meth:`matplotlib.pyplot.subplots`
+
+    Returns:
+        [matplotlib.figure.Figure]: The figure object with the plots
+
     """
 
     # explicit colours are needed if there's multiple train or multiple validation series, because
@@ -88,3 +92,5 @@ def plot_history(history, individual_figsize=(7, 4), **kwargs):
 
     # minimise whitespace
     fig.tight_layout()
+
+    return fig


### PR DESCRIPTION
### Description

The `sg.utils.plot_history` should return the figure `fig`.

### User Story

**As** a developer

**I want to** work on the figure that `sg.utils.plot_history` creates

**So that** I can add titles, export the figure, and so on, ...

This is my first open source PR ever. I was not sure if I should create an Issue for that first. If something is missing please tell me what to do.

### Done Checklist

- [ ] Produced code for required functionality
- [ ] Tests written and coverage checked
- [ ] Code review performed
- [ ] Documentation on Google Docs  (if applicable)
- [ ] Documentation in repo
- [ ] Version number reflects new status
- [ ] CHANGELOG.md updated
- [ ] Team demo
