### PR TITLE
Install specific version of SG on Colab, in notebooks

### DIFF
--- a/RELEASE_PROCEDURE.md
+++ b/RELEASE_PROCEDURE.md
@@ -19,7 +19,7 @@
        - Version bumping: Change version from “X.X.Xb” to “X.X.X”. E.g. version=”0.2.0b” to version=”0.2.0”
          - `stellargraph/version.py`
          - `meta.yaml`
-       - Update expected versions of demo notebooks: `scripts/format_notebooks.py --version_validation --overwrite demos/`
+       - Update expected versions of demo notebooks: `scripts/format_notebooks.py --default --overwrite demos/`
        - Update Changelog section header and "Full Changelog" link to point to specific version tag instead of `HEAD`. Note: these links will be broken until the tag is pushed later.
      - CAN do:
        - Minor bug fixes if necessary

--- a/demos/basics/loading-networkx.ipynb
+++ b/demos/basics/loading-networkx.ipynb
@@ -54,7 +54,7 @@
     "# install StellarGraph if running on Google Colab\n",
     "import sys\n",
     "if 'google.colab' in sys.modules:\n",
-    "  %pip install -q stellargraph[demos]"
+    "  %pip install -q stellargraph[demos]==1.0.0b"
    ]
   },
   {

--- a/demos/basics/loading-pandas.ipynb
+++ b/demos/basics/loading-pandas.ipynb
@@ -63,7 +63,7 @@
     "# install StellarGraph if running on Google Colab\n",
     "import sys\n",
     "if 'google.colab' in sys.modules:\n",
-    "  %pip install -q stellargraph[demos]"
+    "  %pip install -q stellargraph[demos]==1.0.0b"
    ]
   },
   {

--- a/demos/basics/loading-saving-neo4j.ipynb
+++ b/demos/basics/loading-saving-neo4j.ipynb
@@ -54,7 +54,7 @@
     "# install StellarGraph if running on Google Colab\n",
     "import sys\n",
     "if 'google.colab' in sys.modules:\n",
-    "  %pip install -q stellargraph[demos]"
+    "  %pip install -q stellargraph[demos]==1.0.0b"
    ]
   },
   {

--- a/demos/calibration/calibration-pubmed-link-prediction.ipynb
+++ b/demos/calibration/calibration-pubmed-link-prediction.ipynb
@@ -57,7 +57,7 @@
     "# install StellarGraph if running on Google Colab\n",
     "import sys\n",
     "if 'google.colab' in sys.modules:\n",
-    "  %pip install -q stellargraph[demos]"
+    "  %pip install -q stellargraph[demos]==1.0.0b"
    ]
   },
   {

--- a/demos/calibration/calibration-pubmed-node-classification.ipynb
+++ b/demos/calibration/calibration-pubmed-node-classification.ipynb
@@ -51,7 +51,7 @@
     "# install StellarGraph if running on Google Colab\n",
     "import sys\n",
     "if 'google.colab' in sys.modules:\n",
-    "  %pip install -q stellargraph[demos]"
+    "  %pip install -q stellargraph[demos]==1.0.0b"
    ]
   },
   {

--- a/demos/community_detection/attacks_clustering_analysis.ipynb
+++ b/demos/community_detection/attacks_clustering_analysis.ipynb
@@ -93,7 +93,7 @@
     "# install StellarGraph if running on Google Colab\n",
     "import sys\n",
     "if 'google.colab' in sys.modules:\n",
-    "  %pip install -q stellargraph[demos]"
+    "  %pip install -q stellargraph[demos]==1.0.0b"
    ]
   },
   {

--- a/demos/connector/neo4j/directed-graphsage-on-cora-neo4j-example.ipynb
+++ b/demos/connector/neo4j/directed-graphsage-on-cora-neo4j-example.ipynb
@@ -35,7 +35,7 @@
     "# install StellarGraph if running on Google Colab\n",
     "import sys\n",
     "if 'google.colab' in sys.modules:\n",
-    "  %pip install -q stellargraph[demos]"
+    "  %pip install -q stellargraph[demos]==1.0.0b"
    ]
   },
   {

--- a/demos/connector/neo4j/load-cora-into-neo4j.ipynb
+++ b/demos/connector/neo4j/load-cora-into-neo4j.ipynb
@@ -33,7 +33,7 @@
     "# install StellarGraph if running on Google Colab\n",
     "import sys\n",
     "if 'google.colab' in sys.modules:\n",
-    "  %pip install -q stellargraph[demos]"
+    "  %pip install -q stellargraph[demos]==1.0.0b"
    ]
   },
   {

--- a/demos/connector/neo4j/undirected-graphsage-on-cora-neo4j-example.ipynb
+++ b/demos/connector/neo4j/undirected-graphsage-on-cora-neo4j-example.ipynb
@@ -31,7 +31,7 @@
     "# install StellarGraph if running on Google Colab\n",
     "import sys\n",
     "if 'google.colab' in sys.modules:\n",
-    "  %pip install -q stellargraph[demos]"
+    "  %pip install -q stellargraph[demos]==1.0.0b"
    ]
   },
   {

--- a/demos/embeddings/deep-graph-infomax-cora.ipynb
+++ b/demos/embeddings/deep-graph-infomax-cora.ipynb
@@ -35,7 +35,7 @@
     "# install StellarGraph if running on Google Colab\n",
     "import sys\n",
     "if 'google.colab' in sys.modules:\n",
-    "  %pip install -q stellargraph[demos]"
+    "  %pip install -q stellargraph[demos]==1.0.0b"
    ]
   },
   {

--- a/demos/embeddings/embeddings-unsupervised-graphsage-cora.ipynb
+++ b/demos/embeddings/embeddings-unsupervised-graphsage-cora.ipynb
@@ -58,7 +58,7 @@
     "# install StellarGraph if running on Google Colab\n",
     "import sys\n",
     "if 'google.colab' in sys.modules:\n",
-    "  %pip install -q stellargraph[demos]"
+    "  %pip install -q stellargraph[demos]==1.0.0b"
    ]
   },
   {

--- a/demos/embeddings/graphwave-barbell.ipynb
+++ b/demos/embeddings/graphwave-barbell.ipynb
@@ -40,7 +40,7 @@
     "# install StellarGraph if running on Google Colab\n",
     "import sys\n",
     "if 'google.colab' in sys.modules:\n",
-    "  %pip install -q stellargraph[demos]"
+    "  %pip install -q stellargraph[demos]==1.0.0b"
    ]
   },
   {

--- a/demos/embeddings/stellargraph-attri2vec-citeseer.ipynb
+++ b/demos/embeddings/stellargraph-attri2vec-citeseer.ipynb
@@ -49,7 +49,7 @@
     "# install StellarGraph if running on Google Colab\n",
     "import sys\n",
     "if 'google.colab' in sys.modules:\n",
-    "  %pip install -q stellargraph[demos]"
+    "  %pip install -q stellargraph[demos]==1.0.0b"
    ]
   },
   {

--- a/demos/embeddings/stellargraph-metapath2vec.ipynb
+++ b/demos/embeddings/stellargraph-metapath2vec.ipynb
@@ -43,7 +43,7 @@
     "# install StellarGraph if running on Google Colab\n",
     "import sys\n",
     "if 'google.colab' in sys.modules:\n",
-    "  %pip install -q stellargraph[demos]"
+    "  %pip install -q stellargraph[demos]==1.0.0b"
    ]
   },
   {

--- a/demos/embeddings/stellargraph-node2vec.ipynb
+++ b/demos/embeddings/stellargraph-node2vec.ipynb
@@ -42,7 +42,7 @@
     "# install StellarGraph if running on Google Colab\n",
     "import sys\n",
     "if 'google.colab' in sys.modules:\n",
-    "  %pip install -q stellargraph[demos]"
+    "  %pip install -q stellargraph[demos]==1.0.0b"
    ]
   },
   {

--- a/demos/embeddings/watch-your-step-cora-demo.ipynb
+++ b/demos/embeddings/watch-your-step-cora-demo.ipynb
@@ -24,7 +24,7 @@
     "# install StellarGraph if running on Google Colab\n",
     "import sys\n",
     "if 'google.colab' in sys.modules:\n",
-    "  %pip install -q stellargraph[demos]"
+    "  %pip install -q stellargraph[demos]==1.0.0b"
    ]
   },
   {

--- a/demos/ensembles/ensemble-link-prediction-example.ipynb
+++ b/demos/ensembles/ensemble-link-prediction-example.ipynb
@@ -49,7 +49,7 @@
     "# install StellarGraph if running on Google Colab\n",
     "import sys\n",
     "if 'google.colab' in sys.modules:\n",
-    "  %pip install -q stellargraph[demos]"
+    "  %pip install -q stellargraph[demos]==1.0.0b"
    ]
   },
   {

--- a/demos/ensembles/ensemble-node-classification-example.ipynb
+++ b/demos/ensembles/ensemble-node-classification-example.ipynb
@@ -46,7 +46,7 @@
     "# install StellarGraph if running on Google Colab\n",
     "import sys\n",
     "if 'google.colab' in sys.modules:\n",
-    "  %pip install -q stellargraph[demos]"
+    "  %pip install -q stellargraph[demos]==1.0.0b"
    ]
   },
   {

--- a/demos/graph-classification/supervised-graph-classification.ipynb
+++ b/demos/graph-classification/supervised-graph-classification.ipynb
@@ -45,7 +45,7 @@
     "# install StellarGraph if running on Google Colab\n",
     "import sys\n",
     "if 'google.colab' in sys.modules:\n",
-    "  %pip install -q stellargraph[demos]"
+    "  %pip install -q stellargraph[demos]==1.0.0b"
    ]
   },
   {

--- a/demos/interpretability/gat/node-link-importance-demo-gat.ipynb
+++ b/demos/interpretability/gat/node-link-importance-demo-gat.ipynb
@@ -37,7 +37,7 @@
     "# install StellarGraph if running on Google Colab\n",
     "import sys\n",
     "if 'google.colab' in sys.modules:\n",
-    "  %pip install -q stellargraph[demos]"
+    "  %pip install -q stellargraph[demos]==1.0.0b"
    ]
   },
   {

--- a/demos/interpretability/gcn/hateful-twitters-interpretability.ipynb
+++ b/demos/interpretability/gcn/hateful-twitters-interpretability.ipynb
@@ -48,7 +48,7 @@
     "# install StellarGraph if running on Google Colab\n",
     "import sys\n",
     "if 'google.colab' in sys.modules:\n",
-    "  %pip install -q stellargraph[demos]"
+    "  %pip install -q stellargraph[demos]==1.0.0b"
    ]
   },
   {

--- a/demos/interpretability/gcn/node-link-importance-demo-gcn-sparse.ipynb
+++ b/demos/interpretability/gcn/node-link-importance-demo-gcn-sparse.ipynb
@@ -43,7 +43,7 @@
     "# install StellarGraph if running on Google Colab\n",
     "import sys\n",
     "if 'google.colab' in sys.modules:\n",
-    "  %pip install -q stellargraph[demos]"
+    "  %pip install -q stellargraph[demos]==1.0.0b"
    ]
   },
   {

--- a/demos/interpretability/gcn/node-link-importance-demo-gcn.ipynb
+++ b/demos/interpretability/gcn/node-link-importance-demo-gcn.ipynb
@@ -43,7 +43,7 @@
     "# install StellarGraph if running on Google Colab\n",
     "import sys\n",
     "if 'google.colab' in sys.modules:\n",
-    "  %pip install -q stellargraph[demos]"
+    "  %pip install -q stellargraph[demos]==1.0.0b"
    ]
   },
   {

--- a/demos/link-prediction/attri2vec/stellargraph-attri2vec-DBLP.ipynb
+++ b/demos/link-prediction/attri2vec/stellargraph-attri2vec-DBLP.ipynb
@@ -50,7 +50,7 @@
     "# install StellarGraph if running on Google Colab\n",
     "import sys\n",
     "if 'google.colab' in sys.modules:\n",
-    "  %pip install -q stellargraph[demos]"
+    "  %pip install -q stellargraph[demos]==1.0.0b"
    ]
   },
   {

--- a/demos/link-prediction/gcn/cora-gcn-links-example.ipynb
+++ b/demos/link-prediction/gcn/cora-gcn-links-example.ipynb
@@ -40,7 +40,7 @@
     "# install StellarGraph if running on Google Colab\n",
     "import sys\n",
     "if 'google.colab' in sys.modules:\n",
-    "  %pip install -q stellargraph[demos]"
+    "  %pip install -q stellargraph[demos]==1.0.0b"
    ]
   },
   {

--- a/demos/link-prediction/graphsage/cora-links-example.ipynb
+++ b/demos/link-prediction/graphsage/cora-links-example.ipynb
@@ -40,7 +40,7 @@
     "# install StellarGraph if running on Google Colab\n",
     "import sys\n",
     "if 'google.colab' in sys.modules:\n",
-    "  %pip install -q stellargraph[demos]"
+    "  %pip install -q stellargraph[demos]==1.0.0b"
    ]
   },
   {

--- a/demos/link-prediction/hinsage/movielens-recommender.ipynb
+++ b/demos/link-prediction/hinsage/movielens-recommender.ipynb
@@ -40,7 +40,7 @@
     "# install StellarGraph if running on Google Colab\n",
     "import sys\n",
     "if 'google.colab' in sys.modules:\n",
-    "  %pip install -q stellargraph[demos]"
+    "  %pip install -q stellargraph[demos]==1.0.0b"
    ]
   },
   {

--- a/demos/link-prediction/knowledge-graphs/complex.ipynb
+++ b/demos/link-prediction/knowledge-graphs/complex.ipynb
@@ -35,7 +35,7 @@
     "# install StellarGraph if running on Google Colab\n",
     "import sys\n",
     "if 'google.colab' in sys.modules:\n",
-    "  %pip install -q stellargraph[demos]"
+    "  %pip install -q stellargraph[demos]==1.0.0b"
    ]
   },
   {

--- a/demos/link-prediction/knowledge-graphs/distmult.ipynb
+++ b/demos/link-prediction/knowledge-graphs/distmult.ipynb
@@ -40,7 +40,7 @@
     "# install StellarGraph if running on Google Colab\n",
     "import sys\n",
     "if 'google.colab' in sys.modules:\n",
-    "  %pip install -q stellargraph[demos]"
+    "  %pip install -q stellargraph[demos]==1.0.0b"
    ]
   },
   {

--- a/demos/link-prediction/random-walks/cora-lp-demo.ipynb
+++ b/demos/link-prediction/random-walks/cora-lp-demo.ipynb
@@ -52,7 +52,7 @@
     "# install StellarGraph if running on Google Colab\n",
     "import sys\n",
     "if 'google.colab' in sys.modules:\n",
-    "  %pip install -q stellargraph[demos]"
+    "  %pip install -q stellargraph[demos]==1.0.0b"
    ]
   },
   {

--- a/demos/link-prediction/random-walks/ctdne-link-prediction.ipynb
+++ b/demos/link-prediction/random-walks/ctdne-link-prediction.ipynb
@@ -37,7 +37,7 @@
     "# install StellarGraph if running on Google Colab\n",
     "import sys\n",
     "if 'google.colab' in sys.modules:\n",
-    "  %pip install -q stellargraph[demos]"
+    "  %pip install -q stellargraph[demos]==1.0.0b"
    ]
   },
   {

--- a/demos/node-classification/attri2vec/attri2vec-citeseer-node-classification-example.ipynb
+++ b/demos/node-classification/attri2vec/attri2vec-citeseer-node-classification-example.ipynb
@@ -49,7 +49,7 @@
     "# install StellarGraph if running on Google Colab\n",
     "import sys\n",
     "if 'google.colab' in sys.modules:\n",
-    "  %pip install -q stellargraph[demos]"
+    "  %pip install -q stellargraph[demos]==1.0.0b"
    ]
   },
   {

--- a/demos/node-classification/cluster-gcn/cluster-gcn-node-classification.ipynb
+++ b/demos/node-classification/cluster-gcn/cluster-gcn-node-classification.ipynb
@@ -58,7 +58,7 @@
     "# install StellarGraph if running on Google Colab\n",
     "import sys\n",
     "if 'google.colab' in sys.modules:\n",
-    "  %pip install -q stellargraph[demos]"
+    "  %pip install -q stellargraph[demos]==1.0.0b"
    ]
   },
   {

--- a/demos/node-classification/gat/gat-cora-node-classification-example.ipynb
+++ b/demos/node-classification/gat/gat-cora-node-classification-example.ipynb
@@ -38,7 +38,7 @@
     "# install StellarGraph if running on Google Colab\n",
     "import sys\n",
     "if 'google.colab' in sys.modules:\n",
-    "  %pip install -q stellargraph[demos]"
+    "  %pip install -q stellargraph[demos]==1.0.0b"
    ]
   },
   {

--- a/demos/node-classification/gcn/gcn-cora-node-classification-example.ipynb
+++ b/demos/node-classification/gcn/gcn-cora-node-classification-example.ipynb
@@ -65,7 +65,7 @@
     "# install StellarGraph if running on Google Colab\n",
     "import sys\n",
     "if 'google.colab' in sys.modules:\n",
-    "  %pip install -q stellargraph[demos]"
+    "  %pip install -q stellargraph[demos]==1.0.0b"
    ]
   },
   {

--- a/demos/node-classification/graphsage/directed-graphsage-on-cora-example.ipynb
+++ b/demos/node-classification/graphsage/directed-graphsage-on-cora-example.ipynb
@@ -40,7 +40,7 @@
     "# install StellarGraph if running on Google Colab\n",
     "import sys\n",
     "if 'google.colab' in sys.modules:\n",
-    "  %pip install -q stellargraph[demos]"
+    "  %pip install -q stellargraph[demos]==1.0.0b"
    ]
   },
   {

--- a/demos/node-classification/graphsage/graphsage-cora-node-classification-example.ipynb
+++ b/demos/node-classification/graphsage/graphsage-cora-node-classification-example.ipynb
@@ -38,7 +38,7 @@
     "# install StellarGraph if running on Google Colab\n",
     "import sys\n",
     "if 'google.colab' in sys.modules:\n",
-    "  %pip install -q stellargraph[demos]"
+    "  %pip install -q stellargraph[demos]==1.0.0b"
    ]
   },
   {

--- a/demos/node-classification/graphsage/graphsage-pubmed-inductive-node-classification-example.ipynb
+++ b/demos/node-classification/graphsage/graphsage-pubmed-inductive-node-classification-example.ipynb
@@ -43,7 +43,7 @@
     "# install StellarGraph if running on Google Colab\n",
     "import sys\n",
     "if 'google.colab' in sys.modules:\n",
-    "  %pip install -q stellargraph[demos]"
+    "  %pip install -q stellargraph[demos]==1.0.0b"
    ]
   },
   {

--- a/demos/node-classification/node2vec/stellargraph-node2vec-node-classification.ipynb
+++ b/demos/node-classification/node2vec/stellargraph-node2vec-node-classification.ipynb
@@ -46,7 +46,7 @@
     "# install StellarGraph if running on Google Colab\n",
     "import sys\n",
     "if 'google.colab' in sys.modules:\n",
-    "  %pip install -q stellargraph[demos]"
+    "  %pip install -q stellargraph[demos]==1.0.0b"
    ]
   },
   {

--- a/demos/node-classification/node2vec/stellargraph-node2vec-weighted-random-walks.ipynb
+++ b/demos/node-classification/node2vec/stellargraph-node2vec-weighted-random-walks.ipynb
@@ -62,7 +62,7 @@
     "# install StellarGraph if running on Google Colab\n",
     "import sys\n",
     "if 'google.colab' in sys.modules:\n",
-    "  %pip install -q stellargraph[demos]"
+    "  %pip install -q stellargraph[demos]==1.0.0b"
    ]
   },
   {

--- a/demos/node-classification/ppnp/ppnp-cora-node-classification-example.ipynb
+++ b/demos/node-classification/ppnp/ppnp-cora-node-classification-example.ipynb
@@ -38,7 +38,7 @@
     "# install StellarGraph if running on Google Colab\n",
     "import sys\n",
     "if 'google.colab' in sys.modules:\n",
-    "  %pip install -q stellargraph[demos]"
+    "  %pip install -q stellargraph[demos]==1.0.0b"
    ]
   },
   {

--- a/demos/node-classification/rgcn/rgcn-aifb-node-classification-example.ipynb
+++ b/demos/node-classification/rgcn/rgcn-aifb-node-classification-example.ipynb
@@ -42,7 +42,7 @@
     "# install StellarGraph if running on Google Colab\n",
     "import sys\n",
     "if 'google.colab' in sys.modules:\n",
-    "  %pip install -q stellargraph[demos]"
+    "  %pip install -q stellargraph[demos]==1.0.0b"
    ]
   },
   {

--- a/demos/node-classification/sgc/sgc-node-classification-example.ipynb
+++ b/demos/node-classification/sgc/sgc-node-classification-example.ipynb
@@ -59,7 +59,7 @@
     "# install StellarGraph if running on Google Colab\n",
     "import sys\n",
     "if 'google.colab' in sys.modules:\n",
-    "  %pip install -q stellargraph[demos]"
+    "  %pip install -q stellargraph[demos]==1.0.0b"
    ]
   },
   {

--- a/demos/spatio-temporal/gcn-lstm-LA.ipynb
+++ b/demos/spatio-temporal/gcn-lstm-LA.ipynb
@@ -49,7 +49,7 @@
     "# install StellarGraph if running on Google Colab\n",
     "import sys\n",
     "if 'google.colab' in sys.modules:\n",
-    "  %pip install -q stellargraph[demos]"
+    "  %pip install -q stellargraph[demos]==1.0.0b"
    ]
   },
   {

--- a/demos/use-cases/hateful-twitters.ipynb
+++ b/demos/use-cases/hateful-twitters.ipynb
@@ -51,7 +51,7 @@
     "# install StellarGraph if running on Google Colab\n",
     "import sys\n",
     "if 'google.colab' in sys.modules:\n",
-    "  %pip install -q stellargraph[demos]"
+    "  %pip install -q stellargraph[demos]==1.0.0b"
    ]
   },
   {

--- a/scripts/format_notebooks.py
+++ b/scripts/format_notebooks.py
@@ -36,6 +36,12 @@ from pathlib import Path
 from nbconvert import NotebookExporter, HTMLExporter, writers, preprocessors
 from black import format_str, FileMode, InvalidInput
 
+# determine the current stellargraph version
+version = {}
+with open("stellargraph/version.py", "r") as fh:
+    exec(fh.read(), version)
+SG_VERSION = version["__version__"]
+
 
 class ClearWarningsPreprocessor(preprocessors.Preprocessor):
     filter_all_stderr = Bool(True, help="Remove all stderr outputs.").tag(config=True)
@@ -148,11 +154,11 @@ class CloudRunnerPreprocessor(InsertTaggedCellsPreprocessor):
     git_branch = "master"
     demos_path_prefix = "demos/"
 
-    colab_import_code = """\
+    colab_import_code = f"""\
 # install StellarGraph if running on Google Colab
 import sys
 if 'google.colab' in sys.modules:
-  %pip install -q stellargraph[demos]"""
+  %pip install -q stellargraph[demos]=={SG_VERSION}"""
 
     def _binder_url(self, notebook_path):
         return f"https://mybinder.org/v2/gh/stellargraph/stellargraph/{self.git_branch}?urlpath=lab/tree/{notebook_path}"
@@ -196,12 +202,6 @@ if 'google.colab' in sys.modules:
 
 class VersionValidationPreprocessor(InsertTaggedCellsPreprocessor):
     metadata_tag = "VersionCheck"
-
-    # determine the current stellargraph version
-    version = {}
-    with open("stellargraph/version.py", "r") as fh:
-        exec(fh.read(), version)
-    SG_VERSION = version["__version__"]
 
     version_check_code = f"""\
 # verify that we're using the correct version of StellarGraph for this notebook


### PR DESCRIPTION
This uses the versioning logic we've already got for the notebook version checks (#1242) to install a specific version of StellarGraph on Google Colab. This has a few benefits:
- it ensures that we can install exactly the version the notebook is designed for, even if there's been releases in the mean time
- it allows Colab to work with prereleases and release candidates, which pip won't install by default (https://pip.pypa.io/en/stable/reference/pip_install/#pre-release-versions)

To validate that this is correct syntax, I ran `%pip install stellargraph[demos]==0.4.0b0` in a jupyter notebook (using a random old pre-release version we've published). It worked to install that version.

See: #1313 