### PR TITLE
Fix sphinx warnings in non-demo code

### DIFF
--- a/docs/api.txt
+++ b/docs/api.txt
@@ -23,7 +23,7 @@ Generators
 
 
 Layers and models
------------
+-----------------
 
 .. automodule:: stellargraph.layer
 
@@ -190,7 +190,7 @@ Calibration
 ------------------------
 
 .. automodule:: stellargraph.calibration
-  :members: expected_calibration_error, plot_reliability_diagram, TemperatureCalibration, IsotonicCalibration, fit, predict
+  :members: expected_calibration_error, plot_reliability_diagram, TemperatureCalibration, IsotonicCalibration
 
 Utilities
 ------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -89,7 +89,7 @@ language = None
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path .
-exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "requirements.txt"]
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = "sphinx"

--- a/stellargraph/layer/deep_graph_infomax.py
+++ b/stellargraph/layer/deep_graph_infomax.py
@@ -55,8 +55,8 @@ class DGIDiscriminator(Layer):
 
         Args:
             inputs: a list or tuple of tensors with shapes ``[(1, N, F), (1, F)]`` for full batch methods and shapes
-              ``[(B, F), (F,)]`` for sampled node methods, containing the node features and a summary feature vector.
-              Where ``N`` is the number of nodes in the graph, ``F`` is the feature dimension, and ``B`` is the batch size.
+                ``[(B, F), (F,)]`` for sampled node methods, containing the node features and a summary feature vector.
+                Where ``N`` is the number of nodes in the graph, ``F`` is the feature dimension, and ``B`` is the batch size.
         Returns:
             a Tensor with shape ``(1, N)`` for full batch methods and shape ``(B,)`` for sampled node methods.
         """

--- a/stellargraph/layer/deep_graph_infomax.py
+++ b/stellargraph/layer/deep_graph_infomax.py
@@ -54,11 +54,11 @@ class DGIDiscriminator(Layer):
         Applies the layer to the inputs.
 
         Args:
-            inputs: a list or tuple of tensors with shapes `[(1, N, F), (1, F)]` for full batch methods and shapes
-            `[(B, F), (F,)]` for sampled node methods, containing the node features and a summary feature vector.
-            Where `N` is the number of nodes in the graph, `F` is the feature dimension, and `B` is the batch size.
+            inputs: a list or tuple of tensors with shapes ``[(1, N, F), (1, F)]`` for full batch methods and shapes
+              ``[(B, F), (F,)]`` for sampled node methods, containing the node features and a summary feature vector.
+              Where ``N`` is the number of nodes in the graph, ``F`` is the feature dimension, and ``B`` is the batch size.
         Returns:
-            a Tensor with shape `(1, N)` for full batch methods and shape `(B,)` for sampled node methods.
+            a Tensor with shape ``(1, N)`` for full batch methods and shape ``(B,)`` for sampled node methods.
         """
 
         features, summary = inputs

--- a/stellargraph/layer/link_inference.py
+++ b/stellargraph/layer/link_inference.py
@@ -100,12 +100,12 @@ class LinkEmbedding(Layer):
             or any activation function supported by Keras, see https://keras.io/activations/ for more information.
         method (str), optional: Name of the method of combining (src,dst) node features or embeddings into edge embeddings.
             One of:
-             * 'concat' -- concatenation,
-             * 'ip' or 'dot' -- inner product, :math:`ip(u,v) = sum_{i=1..d}{u_i*v_i}`,
-             * 'mul' or 'hadamard' -- element-wise multiplication, :math:`h(u,v)_i = u_i*v_i`,
-             * 'l1' -- L1 operator, :math:`l_1(u,v)_i = |u_i-v_i|`,
-             * 'l2' -- L2 operator, :math:`l_2(u,v)_i = (u_i-v_i)^2`,
-             * 'avg' -- average, :math:`avg(u,v) = (u+v)/2`.
+            * 'concat' -- concatenation,
+            * 'ip' or 'dot' -- inner product, :math:`ip(u,v) = sum_{i=1..d}{u_i*v_i}`,
+            * 'mul' or 'hadamard' -- element-wise multiplication, :math:`h(u,v)_i = u_i*v_i`,
+            * 'l1' -- L1 operator, :math:`l_1(u,v)_i = |u_i-v_i|`,
+            * 'l2' -- L2 operator, :math:`l_2(u,v)_i = (u_i-v_i)^2`,
+            * 'avg' -- average, :math:`avg(u,v) = (u+v)/2`.
             For all methods except 'ip' or 'dot' a dense layer is applied on top of the combined
             edge embedding to transform to a vector of size `output_dim`.
 
@@ -219,12 +219,12 @@ def link_inference(
             or any activation function supported by Keras, see https://keras.io/activations/ for more information.
         edge_embedding_method (str), optional: Name of the method of combining (src,dst) node features or embeddings into edge embeddings.
             One of:
-             * 'concat' -- concatenation,
-             * 'ip' or 'dot' -- inner product, :math:`ip(u,v) = sum_{i=1..d}{u_i*v_i}`,
-             * 'mul' or 'hadamard' -- element-wise multiplication, :math:`h(u,v)_i = u_i*v_i`,
-             * 'l1' -- L1 operator, :math:`l_1(u,v)_i = |u_i-v_i|`,
-             * 'l2' -- L2 operator, :math:`l_2(u,v)_i = (u_i-v_i)^2`,
-             * 'avg' -- average, :math:`avg(u,v) = (u+v)/2`.
+            * 'concat' -- concatenation,
+            * 'ip' or 'dot' -- inner product, :math:`ip(u,v) = sum_{i=1..d}{u_i*v_i}`,
+            * 'mul' or 'hadamard' -- element-wise multiplication, :math:`h(u,v)_i = u_i*v_i`,
+            * 'l1' -- L1 operator, :math:`l_1(u,v)_i = |u_i-v_i|`,
+            * 'l2' -- L2 operator, :math:`l_2(u,v)_i = (u_i-v_i)^2`,
+            * 'avg' -- average, :math:`avg(u,v) = (u+v)/2`.
         clip_limits (Tuple[float]): lower and upper thresholds for LeakyClippedLinear unit on top. If None (not provided),
             the LeakyClippedLinear unit is not applied.
         name (str): optional name of the defined function, used for error logging
@@ -294,12 +294,12 @@ def link_classification(
             or any activation function supported by Keras, see https://keras.io/activations/ for more information.
         edge_embedding_method (str), optional: Name of the method of combining (src,dst) node features/embeddings into edge embeddings.
             One of:
-             * 'concat' -- concatenation,
-             * 'ip' or 'dot' -- inner product, :math:`ip(u,v) = sum_{i=1..d}{u_i*v_i}`,
-             * 'mul' or 'hadamard' -- element-wise multiplication, :math:`h(u,v)_i = u_i*v_i`,
-             * 'l1' -- L1 operator, :math:`l_1(u,v)_i = |u_i-v_i|`,
-             * 'l2' -- L2 operator, :math:`l_2(u,v)_i = (u_i-v_i)^2`,
-             * 'avg' -- average, :math:`avg(u,v) = (u+v)/2`.
+            * 'concat' -- concatenation,
+            * 'ip' or 'dot' -- inner product, :math:`ip(u,v) = sum_{i=1..d}{u_i*v_i}`,
+            * 'mul' or 'hadamard' -- element-wise multiplication, :math:`h(u,v)_i = u_i*v_i`,
+            * 'l1' -- L1 operator, :math:`l_1(u,v)_i = |u_i-v_i|`,
+            * 'l2' -- L2 operator, :math:`l_2(u,v)_i = (u_i-v_i)^2`,
+            * 'avg' -- average, :math:`avg(u,v) = (u+v)/2`.
 
     Returns:
         Function taking edge tensors with src, dst node embeddings (i.e., pairs of (node_src, node_dst) tensors) and
@@ -340,12 +340,12 @@ def link_regression(
             the LeakyClippedLinear unit is not applied.
         edge_embedding_method (str), optional: Name of the method of combining (src,dst) node features/embeddings into edge embeddings.
             One of:
-             * 'concat' -- concatenation,
-             * 'ip' or 'dot' -- inner product, :math:`ip(u,v) = sum_{i=1..d}{u_i*v_i}`,
-             * 'mul' or 'hadamard' -- element-wise multiplication, :math:`h(u,v)_i = u_i*v_i`,
-             * 'l1' -- L1 operator, :math:`l_1(u,v)_i = |u_i-v_i|`,
-             * 'l2' -- L2 operator, :math:`l_2(u,v)_i = (u_i-v_i)^2`,
-             * 'avg' -- average, :math:`avg(u,v) = (u+v)/2`.
+            * 'concat' -- concatenation,
+            * 'ip' or 'dot' -- inner product, :math:`ip(u,v) = sum_{i=1..d}{u_i*v_i}`,
+            * 'mul' or 'hadamard' -- element-wise multiplication, :math:`h(u,v)_i = u_i*v_i`,
+            * 'l1' -- L1 operator, :math:`l_1(u,v)_i = |u_i-v_i|`,
+            * 'l2' -- L2 operator, :math:`l_2(u,v)_i = (u_i-v_i)^2`,
+            * 'avg' -- average, :math:`avg(u,v) = (u+v)/2`.
 
     Returns:
         Function taking edge tensors with src, dst node embeddings (i.e., pairs of (node_src, node_dst) tensors) and

--- a/stellargraph/layer/rgcn.py
+++ b/stellargraph/layer/rgcn.py
@@ -27,8 +27,7 @@ class RelationalGraphConvolution(Layer):
         Relational Graph Convolution (RGCN) Keras layer.
 
         Original paper: Modeling Relational Data with Graph Convolutional Networks.
-        Thomas N. Kipf, Michael Schlichtkrull (2017).
-            https://arxiv.org/pdf/1703.06103.pdf
+        Thomas N. Kipf, Michael Schlichtkrull (2017). https://arxiv.org/pdf/1703.06103.pdf
 
         Notes:
           - The inputs are tensors with a batch dimension of 1:

--- a/stellargraph/mapper/sampled_link_generators.py
+++ b/stellargraph/mapper/sampled_link_generators.py
@@ -205,7 +205,7 @@ class GraphSAGELinkGenerator(BatchedLinkGenerator):
     machine learning. Currently the model requires node features for all
     nodes in the graph.
 
-    Use the :meth:`.flow` method supplying the nodes and (optionally) targets,
+    Use the :meth:`flow` method supplying the nodes and (optionally) targets,
     or an UnsupervisedSampler instance that generates node samples on demand,
     to get an object that can be used as a Keras data generator.
 
@@ -462,7 +462,7 @@ class Attri2VecLinkGenerator(BatchedLinkGenerator):
     machine learning. Currently the model requires node features for all
     nodes in the graph.
 
-    Use the :meth:`.flow` method supplying the nodes and targets,
+    Use the :meth:`flow` method supplying the nodes and targets,
     or an UnsupervisedSampler instance that generates node samples on demand,
     to get an object that can be used as a Keras data generator.
 
@@ -516,7 +516,7 @@ class DirectedGraphSAGELinkGenerator(BatchedLinkGenerator):
     machine learning. Currently the model requires node features for all
     nodes in the graph.
 
-    Use the :meth:`.flow` method supplying the nodes and (optionally) targets,
+    Use the :meth:`flow` method supplying the nodes and (optionally) targets,
     or an UnsupervisedSampler instance that generates node samples on demand,
     to get an object that can be used as a Keras data generator.
 


### PR DESCRIPTION
There's various minor formatting and other mistakes, most of which have no influence on the rendering, but some do (in `DGIDiscriminator` in particular).

The specific warnings this fixes:

```
.../docs/api.txt:23: WARNING: Title underline too short.
.../docs/api.txt:23: WARNING: Title underline too short.
.../stellargraph/layer/rgcn.py:docstring of stellargraph.layer.RelationalGraphConvolution:5: WARNING: Unexpected indentation.
.../stellargraph/layer/deep_graph_infomax.py:docstring of stellargraph.layer.DGIDiscriminator.call:4: WARNING: Inline interpreted text or phrase reference start-string without end-string.
.../stellargraph/layer/deep_graph_infomax.py:docstring of stellargraph.layer.DGIDiscriminator.call:5: WARNING: Inline interpreted text or phrase reference start-string without end-string.
.../stellargraph/layer/link_inference.py:docstring of stellargraph.layer.LinkEmbedding:29: WARNING: Unexpected indentation.
.../stellargraph/layer/link_inference.py:docstring of stellargraph.layer.LinkEmbedding:35: WARNING: Block quote ends without a blank line; unexpected unindent.
.../stellargraph/layer/link_inference.py:docstring of stellargraph.layer.link_classification:20: WARNING: Unexpected indentation.
.../stellargraph/layer/link_inference.py:docstring of stellargraph.layer.link_regression:20: WARNING: Unexpected indentation.
.../stellargraph/layer/link_inference.py:docstring of stellargraph.layer.link_inference:20: WARNING: Unexpected indentation.
WARNING: missing attribute mentioned in :members: or __all__: module stellargraph.calibration, attribute fit
WARNING: missing attribute mentioned in :members: or __all__: module stellargraph.calibration, attribute predict
checking consistency... .../docs/requirements.txt: WARNING: document isn't included in any toctree
.../stellargraph/mapper/sampled_link_generators.py:docstring of stellargraph.mapper.DirectedGraphSAGELinkGenerator:10: WARNING: more than one target found for cross-reference 'flow': stellargraph.mapper.Generator.flow, stellargraph.mapper.FullBatchNodeGenerator.flow, stellargraph.mapper.FullBatchLinkGenerator.flow, stellargraph.mapper.ClusterNodeGenerator.flow, stellargraph.mapper.Attri2VecNodeGenerator.flow, stellargraph.mapper.RelationalFullBatchNodeGenerator.flow, stellargraph.mapper.AdjacencyPowerGenerator.flow, stellargraph.mapper.GraphWaveGenerator.flow, stellargraph.mapper.CorruptedGenerator.flow, stellargraph.mapper.PaddedGraphGenerator.flow, stellargraph.mapper.KGTripleGenerator.flow
.../stellargraph/mapper/sampled_link_generators.py:docstring of stellargraph.mapper.GraphSAGELinkGenerator:10: WARNING: more than one target found for cross-reference 'flow': stellargraph.mapper.Generator.flow, stellargraph.mapper.FullBatchNodeGenerator.flow, stellargraph.mapper.FullBatchLinkGenerator.flow, stellargraph.mapper.ClusterNodeGenerator.flow, stellargraph.mapper.Attri2VecNodeGenerator.flow, stellargraph.mapper.RelationalFullBatchNodeGenerator.flow, stellargraph.mapper.AdjacencyPowerGenerator.flow, stellargraph.mapper.GraphWaveGenerator.flow, stellargraph.mapper.CorruptedGenerator.flow, stellargraph.mapper.PaddedGraphGenerator.flow, stellargraph.mapper.KGTripleGenerator.flow
.../stellargraph/mapper/sampled_link_generators.py:docstring of stellargraph.mapper.Attri2VecLinkGenerator:9: WARNING: more than one target found for cross-reference 'flow': stellargraph.mapper.Generator.flow, stellargraph.mapper.FullBatchNodeGenerator.flow, stellargraph.mapper.FullBatchLinkGenerator.flow, stellargraph.mapper.ClusterNodeGenerator.flow, stellargraph.mapper.Attri2VecNodeGenerator.flow, stellargraph.mapper.RelationalFullBatchNodeGenerator.flow, stellargraph.mapper.AdjacencyPowerGenerator.flow, stellargraph.mapper.GraphWaveGenerator.flow, stellargraph.mapper.CorruptedGenerator.flow, stellargraph.mapper.PaddedGraphGenerator.flow, stellargraph.mapper.KGTripleGenerator.flow
```

There's various warnings related to demos, that this doesn't fix (https://github.com/stellargraph/stellargraph/issues/1360).

See: #1154