### PR TITLE
Document the custom_keras_layers dictionary

### DIFF
--- a/docs/api.txt
+++ b/docs/api.txt
@@ -5,7 +5,7 @@ Core
 ----------------
 
 .. automodule:: stellargraph
-  :members: StellarGraph, StellarDiGraph, GraphSchema
+  :members: StellarGraph, StellarDiGraph, GraphSchema, custom_keras_layers
 
 
 Data

--- a/docs/api.txt
+++ b/docs/api.txt
@@ -5,7 +5,10 @@ Core
 ----------------
 
 .. automodule:: stellargraph
-  :members: StellarGraph, StellarDiGraph, GraphSchema, custom_keras_layers
+  :members: StellarGraph, StellarDiGraph, GraphSchema,
+
+.. autodata:: custom_keras_layers
+   :annotation: = {...}
 
 
 Data

--- a/stellargraph/__init__.py
+++ b/stellargraph/__init__.py
@@ -71,6 +71,19 @@ custom_keras_layers = {
     "GatherIndices": layer.misc.GatherIndices,
     "SortPooling": layer.SortPooling,
 }
+"""
+A dictionary of the ``tensorflow.keras`` layers defined by StellarGraph.
+
+When Keras models using StellarGraph layers are saved, they can be loaded by passing this value to
+the ``custom_objects`` parameter to model loading functions like
+``tensorflow.keras.models.load_model``.
+
+Example::
+
+    import stellargraph as sg
+    from tensorflow import keras
+    keras.models.load_model("/path/to/model", custom_objects=sg.custom_keras_layers)
+"""
 
 
 def _top_level_deprecation_warning(name, path):


### PR DESCRIPTION
Rendered docs: https://stellargraph--1362.org.readthedocs.build/en/1362/api.html#stellargraph.custom_keras_layers

<img width="716" alt="image" src="https://user-images.githubusercontent.com/1203825/80337379-0b5b5780-889d-11ea-8771-b683d4e51400.png">

This uses [the `:annotation:` option for Sphinx's `:autodata:`](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#directive-autodata) to control how the value is rendered. Without the `:annotation:` it shows the whole value (see below), which is extremely unwieldy (and will get worse with #1280). With the `:annotation:` we can hint at it being a dictionary without overloading the reader.


Version without `:annotation:`:

![image](https://user-images.githubusercontent.com/1203825/80178316-406b6e00-8641-11ea-902d-406dca3dc290.png)


See: #1261