### PR TITLE
Use ilocs end-to-end for knowledge graph ranking

### DIFF
--- a/stellargraph/layer/knowledge_graph.py
+++ b/stellargraph/layer/knowledge_graph.py
@@ -602,27 +602,18 @@ def _ranks_from_score_columns(
     # the filtered rank is the number of unknown elements scored higher, where an element is
     # known if the edge (s, r, n) (for modified-object) or (n, r, o) (for modified-subject)
     # exists in known_edges_graph.
-
-    # FIXME(#870): this would be better without external IDs <-> ilocs translation
-    unmodified_nodes = known_edges_graph._nodes.ids.from_iloc(unmodified_node_ilocs)
-    true_rels = known_edges_graph._edges.types.from_iloc(true_rel_ilocs)
     if modified_object:
         neigh_func = known_edges_graph.out_nodes
     else:
         neigh_func = known_edges_graph.in_nodes
 
-    # collect all the neighbours into a single array to do one node_ids_to_ilocs call,
-    # which has relatively high constant cost
-    neighbours = []
-    columns = []
-    for batch_column, (unmodified, r) in enumerate(zip(unmodified_nodes, true_rels)):
-        this_neighs = neigh_func(unmodified, edge_types=[r])
-        neighbours.extend(this_neighs)
-        columns.extend(batch_column for _ in this_neighs)
+    for batch_column, (unmodified, r) in enumerate(
+        zip(unmodified_node_ilocs, true_rel_ilocs)
+    ):
+        this_neighs = neigh_func(unmodified, edge_types=[r], use_ilocs=True)
+        greater[this_neighs, batch_column] = False
+        greater_equal[this_neighs, batch_column] = False
 
-    neighbour_ilocs = known_edges_graph.node_ids_to_ilocs(neighbours)
-    greater[neighbour_ilocs, columns] = False
-    greater_equal[neighbour_ilocs, columns] = False
     # the actual elements should be counted as equal, whether or not it was a known edge or not
     greater_equal[true_modified_node_ilocs, range(batch_size)] = True
 

--- a/stellargraph/mapper/knowledge_graph.py
+++ b/stellargraph/mapper/knowledge_graph.py
@@ -88,8 +88,7 @@ class KGTripleGenerator(Generator):
                 )
 
         source_ilocs = self.G.node_ids_to_ilocs(sources)
-        # FIXME(#870): this would be best expressed without poking into the _edges proprety of G
-        rel_ilocs = self.G._edges.types.to_iloc(rels, strict=True)
+        rel_ilocs = self.G.edge_type_names_to_ilocs(rels)
         target_ilocs = self.G.node_ids_to_ilocs(targets)
 
         return KGTripleSequence(


### PR DESCRIPTION
With #1366, there are native and supported APIs for working with edge type ilocs. This allows us to use ilocs end-to-end in knowledge graph ranking. This both simplifies the code and makes it faster, e.g. ranking is performed in the DistMult notebook approximately as follows (the model doesn't need to be trained, because we don't care about the actual ranks, just the time to compute):

```python
import stellargraph as sg
import tensorflow as tf

def run(dataset):
    graph, train, test, valid = dataset.load()
    gen = sg.mapper.KGTripleGenerator(graph, batch_size=5000)
    test_seq = gen.flow(test)
    
    model = sg.layer.DistMult(gen, embedding_dimension=100)
    tf.keras.Model(*model.in_out_tensors()).compile("adam", loss="mse")
    %time model.rank_edges_against_all_nodes(test_seq, graph)

run(sg.datasets.WN18())
run(sg.datasets.FB15k())
```

Results:

| dataset | pre-ilocs f2a96aab (s) | develop f5e519be (s) | this PR (s) |
|---|---|---|---|
| WN18 | 4.99 | 5.87 | 3.80 |
| FB15k | 42.6 | 59.2 | 20.7 |

That is, it's somewhere between 1.5-3× faster for DistMult on these datasets.