### PR TITLE
Allow custom poolings in GCNSupervisedGraphClassification

### DIFF
--- a/stellargraph/layer/graph_classification.py
+++ b/stellargraph/layer/graph_classification.py
@@ -26,7 +26,7 @@ from ..core.experimental import experimental
 
 class GCNSupervisedGraphClassification:
     """
-    A stack of :class:`GraphConvolution` layers together with a Keras `GlobalAveragePooling1D` layer
+    A stack of :class:`GraphConvolution` layers together with a Keras `GlobalAveragePooling1D` layer (by default)
     that implement a supervised graph classification network using the GCN convolution operator
     (https://arxiv.org/abs/1609.02907).
 
@@ -60,6 +60,22 @@ class GCNSupervisedGraphClassification:
             training.
         bias (bool, optional): toggles an optional bias in graph convolutional layers.
         dropout (float, optional): dropout rate applied to input features of each GCN layer.
+
+        pooling (callable, optional): a Keras layer or function that takes two arguments and returns
+            a tensor representing the embeddings for each graph in the batch. Arguments:
+
+            - embeddings tensor argument with shape ``batch size × nodes × output size``, where ``nodes``
+              is the maximum number of nodes of a graph in the batch and ``output size`` is the size
+              of the final graph convolutional layer
+            - ``mask`` tensor named argument of booleans with shape ``batch size × nodes``. ``True``
+              values indicate which rows of the embeddings argument are valid, and all other rows
+              (corresponding to ``mask == False``) must be ignored.
+
+            The returned tensor can have any shape ``batch size``, ``batch size × N1``, ``batch size
+            × N1 × N2``, ..., as long as the ``N1``, ``N2``, ... are constant across all graphs:
+            they must not depend on the ``nodes`` dimension or on the number of ``True`` values in
+            ``mask``. ``pooling`` defaults to mean pooling via ``GlobalAveragePooling1D``.
+
         kernel_initializer (str or func, optional): The initialiser to use for the weights of each graph
             convolutional layer.
         kernel_regularizer (str or func, optional): The regulariser to use for the weights of each graph
@@ -72,7 +88,6 @@ class GCNSupervisedGraphClassification:
             convolutional.
         bias_constraint (str or func, optional): The constraint to use for the bias of each layer graph
             convolutional.
-
     """
 
     def __init__(
@@ -82,6 +97,7 @@ class GCNSupervisedGraphClassification:
         generator,
         bias=True,
         dropout=0.0,
+        pooling=None,
         kernel_initializer=None,
         kernel_regularizer=None,
         kernel_constraint=None,
@@ -105,6 +121,11 @@ class GCNSupervisedGraphClassification:
         self.bias = bias
         self.dropout = dropout
         self.generator = generator
+
+        if pooling is not None:
+            self.pooling = pooling
+        else:
+            self.pooling = GlobalAveragePooling1D(data_format="channels_last")
 
         # Initialize a stack of GraphConvolution layers
         n_layers = len(self.layer_sizes)
@@ -154,10 +175,8 @@ class GCNSupervisedGraphClassification:
                 # For other (non-graph) layers only supply the input tensor
                 h_layer = layer(h_layer)
 
-        # add mean pooling layer with mask in order to ignore the padded values
-        h_layer = GlobalAveragePooling1D(data_format="channels_last")(
-            h_layer, mask=mask
-        )
+        # mask to ignore the padded values
+        h_layer = self.pooling(h_layer, mask=mask)
 
         return h_layer
 

--- a/tests/layer/test_gcn_supervised_graph_classification.py
+++ b/tests/layer/test_gcn_supervised_graph_classification.py
@@ -13,7 +13,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import numpy as np
+import tensorflow as tf
 from stellargraph.layer.graph_classification import *
 from stellargraph.mapper import PaddedGraphGenerator, FullBatchNodeGenerator
 import pytest
@@ -129,3 +131,49 @@ def test_stateful():
     embeddings_2 = model_2.predict(train_gen)
 
     assert np.array_equal(embeddings_1, embeddings_2)
+
+
+@pytest.mark.parametrize("pooling", ["default", "custom"])
+def test_pooling(pooling):
+
+    # no GCN layers, to just test the pooling directly
+    if pooling == "default":
+        gcn_graph_model = GCNSupervisedGraphClassification(
+            layer_sizes=[], activations=[], generator=generator
+        )
+
+        def expected_values(array):
+            return array.mean(axis=0)
+
+    else:
+        # shift the features to make it a bit more interesting
+        shift = 10
+
+        def shifted_sum_pooling(tensor, mask):
+            mask_floats = tf.expand_dims(tf.cast(mask, tf.float32), axis=-1)
+            return tf.math.reduce_sum(tf.multiply(mask_floats, shift + tensor), axis=1)
+
+        gcn_graph_model = GCNSupervisedGraphClassification(
+            layer_sizes=[],
+            activations=[],
+            generator=generator,
+            pooling=shifted_sum_pooling,
+        )
+
+        def expected_values(array):
+            return (shift + array).sum(axis=0)
+
+    train_graphs = [0, 1, 2]
+    train_gen = generator.flow(graph_ilocs=train_graphs, batch_size=2, shuffle=False)
+    model = tf.keras.Model(*gcn_graph_model.in_out_tensors())
+
+    predictions = model.predict(train_gen)
+    assert predictions.shape == (3, 4)
+
+    expected = np.vstack(
+        [
+            expected_values(graphs[iloc].node_features(node_type="n-0"))
+            for iloc in train_graphs
+        ]
+    )
+    np.testing.assert_almost_equal(predictions, expected)


### PR DESCRIPTION
Per a question from dogfooding about using max pooling, this generalises `GCNSupervisedGraphClassification` slightly to allow other methods for pooling. This gives more flexibility with less code for experimenting with graph classification. Concrete examples of algorithms with non-mean pooling:

- the graph convolution part of DGCNN (the current `DeepGraphConvolutionalNeuralNetwork` class) can be almost implemented with via `GCNSupervisedGraphClassification(..., pooling=SortPooling(k=k), ...)` (#1373 does the rest of what is required)
- [InfoGraph: Unsupervised and Semi-supervised Graph-Level Representation Learning via Mutual Information Maximization](https://arxiv.org/abs/1908.01000) (page 5) says:
  > [...] we use sum [instead of] mean for READOUT and that can provide important information regarding the size of the graph

This doesn't change the code required for a default "MVP" graph classification model: existing callers of `GCNSupervisedGraphClassification` do not need to change and still get mean pooling. Advanced users can opt-in to other pooling methods if/when they decide they need to.

Rendered documentation, for convenience: https://stellargraph--1369.org.readthedocs.build/en/1369/api.html#gcn-supervised-graph-classification

See: #1357