### PR TITLE
Move SortPooling k validation into SortPooling itself

### DIFF
--- a/stellargraph/layer/graph_classification.py
+++ b/stellargraph/layer/graph_classification.py
@@ -273,14 +273,6 @@ class DeepGraphConvolutionalNeuralNetwork(GCNSupervisedGraphClassification):
             bias_constraint=bias_constraint,
         )
 
-        if not isinstance(k, int):
-            raise TypeError(
-                f"k: expected k to be integer type, found {type(k).__name__}."
-            )
-
-        if k <= 0:
-            raise ValueError(f"k: expected k to be strictly positive, found {k}")
-
         self.k = k
 
         # Add the SortPooling layer

--- a/stellargraph/layer/sort_pooling.py
+++ b/stellargraph/layer/sort_pooling.py
@@ -17,6 +17,7 @@
 import tensorflow as tf
 from tensorflow.keras.layers import Layer
 from ..core.experimental import experimental
+from ..core.validation import require_integer_in_range
 
 
 @experimental(reason="Missing unit tests and generally untested.", issues=[1044])
@@ -37,6 +38,8 @@ class SortPooling(Layer):
 
     def __init__(self, k, flatten_output=False):
         super().__init__()
+
+        require_integer_in_range(k, "k", min_val=1)
 
         self.trainable = False
         self.k = k

--- a/tests/layer/test_sort_pooling.py
+++ b/tests/layer/test_sort_pooling.py
@@ -122,3 +122,11 @@ def test_flatten_output():
     data_out = layer([data, mask])
 
     assert np.array_equal(data_out, data_sorted)
+
+
+def test_invalid_k():
+    with pytest.raises(TypeError, match="k: expected int, found str"):
+        SortPooling(k="false")
+
+    with pytest.raises(ValueError, match="k: expected integer >= 1, found 0"):
+        SortPooling(k=0)


### PR DESCRIPTION
The `k` argument must be an integer >= 1 for every user of `SortPooling`, so it makes sense for `SortPooling` itself to validate this requirement. By doing this, users of `SortPooling` outside of the `DeepGraphConvolutionalNeuralNetwork`/DGCNN class still get helpful error messages if they make a mistake.

See: #1372 