### PR TITLE
Infer node types for homogeneous-node graphs with 'unique_node_type'

### DIFF
--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -710,13 +710,13 @@ class StellarGraph:
         """
         return set(self._nodes.types.pandas_index)
 
-    def unique_node_type(self, message=None):
+    def unique_node_type(self, error_message=None):
         """
         Return the unique node type, for a homogeneous-node graph.
 
         Args:
-            message (str, optional): a custom message to use for the exception; this can use the
-                ``%(found)s`` placeholder to insert the real sequence of node types.
+            error_message (str, optional): a custom message to use for the exception; this can use
+                the ``%(found)s`` placeholder to insert the real sequence of node types.
 
         Returns:
             If this graph has only one node type, this returns that node type, otherwise it raises a
@@ -728,12 +728,12 @@ class StellarGraph:
             return all_types[0]
 
         found = comma_sep(all_types)
-        if message is None:
-            message = (
+        if error_message is None:
+            error_message = (
                 "Expected only one node type for 'unique_node_type', found: %(found)s"
             )
 
-        raise ValueError(message % {"found": found})
+        raise ValueError(error_message % {"found": found})
 
     @property
     def edge_types(self):
@@ -802,9 +802,10 @@ class StellarGraph:
             Numpy array containing the node features for the requested nodes or node type.
         """
         if nodes is None:
-            node_type = self.unique_node_type(
-                "node_type: in a non-homogeneous graph, expected a node type and/or 'nodes' to be passed; found neither 'node_type' nor 'nodes', and the graph has node types: %(found)s"
-            )
+            if node_type is None:
+                node_type = self.unique_node_type(
+                    "node_type: in a non-homogeneous graph, expected a node type and/or 'nodes' to be passed; found neither 'node_type' nor 'nodes', and the graph has node types: %(found)s"
+                )
 
             return self._nodes.features_of_type(node_type)
 

--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -780,19 +780,25 @@ class StellarGraph:
         """
         Get the numeric feature vectors for the specified nodes or node type.
 
-        At least, one of the following conditions must be true:
+        For graphs with a single node type:
 
-        - ``node_type`` is passed, in which case ``graph.node_features(node_type=some_type)``
-          returns the features for all nodes of type ``some_type``, in the same order as
-          ``graph.nodes(node_type=some_type)``.
-        - the graph has only one node type, in which case ``graph.node_features()`` returns the
-          features for all nodes (equivalent to the previous case with ``some_type`` set to the
-          single node type of ``graph``)
-        - ``nodes`` is passed, in which case ``graph.node_features(nodes=some_node_ids)`` returns
-          the features for each node in ``some_node_ids`` in the same order as that input. Every
-          node in ``nodes`` must have the same type. If ``nodes`` is passed without specifying
-          ``node_type``, the node type of ``nodes`` will be inferred (passing ``node_type`` in
-          addition to ``nodes`` will therefore be faster).
+        - ``graph.node_features()`` to retrieve features of all nodes, in the same order as
+          ``graph.nodes()``.
+
+        - ``graph.node_features(nodes=some_node_ids)`` to retrieve features for each node in
+          ``some_node_ids``.
+
+        For graphs with multiple node types:
+
+        - ``graph.node_features(node_type=some_type)`` to retrieve features of all nodes of type
+          ``some_type``, in the same order as ``graph.nodes(node_type=some_type)``.
+
+        - ``graph.node_features(nodes=some_node_ids, node_type=some_type)`` to retrieve features for
+          each node in ``some_node_ids``. All of the chosen nodes must be of type ``some_type``.
+
+        - ``graph.node_features(nodes=some_node_ids)`` to retrieve features for each node in
+          ``some_node_ids``. All of the chosen nodes must be of the same type, which will be
+          inferred. This will be slower than providing the node type explicitly in the previous example.
 
         Args:
             nodes (list or hashable, optional): Node ID or list of node IDs, all of the same type

--- a/stellargraph/mapper/full_batch_generators.py
+++ b/stellargraph/mapper/full_batch_generators.py
@@ -82,14 +82,9 @@ class FullBatchGenerator(Generator):
         G.check_graph_for_ml()
 
         # Check that there is only a single node type for GAT or GCN
-        node_types = list(G.node_types)
-        if len(node_types) > 1:
-            raise TypeError(
-                "{}: node generator requires graph with single node type; "
-                "a graph with multiple node types is passed. Stopping.".format(
-                    type(self).__name__
-                )
-            )
+        _ = G.unique_node_type(
+            "G: expected a graph with a single node type, found a graph with node types: %(found)s"
+        )
 
         # Create sparse adjacency matrix:
         # Use the node orderings the same as in the graph features

--- a/stellargraph/mapper/graphwave_generator.py
+++ b/stellargraph/mapper/graphwave_generator.py
@@ -52,14 +52,10 @@ class GraphWaveGenerator(Generator):
         if not isinstance(G, StellarGraph):
             raise TypeError("G must be a StellarGraph object.")
 
-        node_types = list(G.node_types)
-        if len(node_types) > 1:
-            raise TypeError(
-                "{}: node generator requires graph with single node type; "
-                "a graph with multiple node types is passed. Stopping.".format(
-                    type(self).__name__
-                )
-            )
+        # Check that there is only a single node type
+        _ = G.unique_node_type(
+            "G: expected a graph with a single node type, found a graph with node types: %(found)s"
+        )
 
         require_integer_in_range(degree, "degree", min_val=1)
 

--- a/stellargraph/mapper/mini_batch_node_generators.py
+++ b/stellargraph/mapper/mini_batch_node_generators.py
@@ -116,13 +116,9 @@ class ClusterNodeGenerator(Generator):
         self.node_list = list(G.nodes())
 
         # Check that there is only a single node type
-        if len(G.node_types) > 1:
-            raise ValueError(
-                "{}: node generator requires graph with single node type; "
-                "a graph with multiple node types is passed. Stopping.".format(
-                    type(self).__name__
-                )
-            )
+        _ = G.unique_node_type(
+            "G: expected a graph with a single node type, found a graph with node types: %(found)s"
+        )
 
         if isinstance(clusters, int):
             # We are not given graph clusters.

--- a/stellargraph/mapper/padded_graph_generator.py
+++ b/stellargraph/mapper/padded_graph_generator.py
@@ -47,14 +47,14 @@ class PaddedGraphGenerator(Generator):
                     f"graphs: expected every element to be a StellarGraph object, found {type(graph).__name__}."
                 )
             # Check that there is only a single node type for GAT or GCN
-            _ = graph.unique_node_type(
+            node_type = graph.unique_node_type(
                 "graphs: expected only graphs with a single node type, found a graph with node types: %(found)s"
             )
 
             graph.check_graph_for_ml()
 
             # we require that all graphs have node features of the same dimensionality
-            f_dim = graph.node_feature_sizes()[list(graph.node_types)[0]]
+            f_dim = graph.node_feature_sizes()[node_type]
             if self.node_features_size is None:
                 self.node_features_size = f_dim
             elif self.node_features_size != f_dim:

--- a/stellargraph/mapper/padded_graph_generator.py
+++ b/stellargraph/mapper/padded_graph_generator.py
@@ -46,11 +46,10 @@ class PaddedGraphGenerator(Generator):
                 raise TypeError(
                     f"graphs: expected every element to be a StellarGraph object, found {type(graph).__name__}."
                 )
-            if len(graph.node_types) > 1:
-                raise ValueError(
-                    "graphs: node generator requires graphs with single node type, "
-                    f"found a graph with {len(graph.node_types)} node types."
-                )
+            # Check that there is only a single node type for GAT or GCN
+            _ = graph.unique_node_type(
+                "graphs: expected only graphs with a single node type, found a graph with node types: %(found)s"
+            )
 
             graph.check_graph_for_ml()
 

--- a/stellargraph/mapper/sampled_link_generators.py
+++ b/stellargraph/mapper/sampled_link_generators.py
@@ -356,8 +356,8 @@ class HinSAGELinkGenerator(BatchedLinkGenerator):
         self.name = name
 
         # This is a link generator and requires two nodes per query
-        # The head node type
         if head_node_types is None:
+            # infer the head node types, if this is a homogeneous-node graph
             node_type = G.unique_node_type(
                 "head_node_types: expected a pair of head node types because G has more than one node type, found node types: %(found)s"
             )

--- a/stellargraph/mapper/sampled_link_generators.py
+++ b/stellargraph/mapper/sampled_link_generators.py
@@ -331,7 +331,8 @@ class HinSAGELinkGenerator(BatchedLinkGenerator):
         g (StellarGraph): A machine-learning ready graph.
         batch_size (int): Size of batch of links to return.
         num_samples (list): List of number of neighbour node samples per GraphSAGE layer (hop) to take.
-        head_node_types (list): List of the types (str) of the two head nodes forming the node pair.
+        head_node_types (list, optional): List of the types (str) of the two head nodes forming the
+            node pair. This does not need to be specified if ``G`` has only one node type.
         seed (int or str, optional): Random seed for the sampling methods.
 
     Example::
@@ -345,7 +346,7 @@ class HinSAGELinkGenerator(BatchedLinkGenerator):
         G,
         batch_size,
         num_samples,
-        head_node_types,
+        head_node_types=None,
         schema=None,
         seed=None,
         name=None,
@@ -355,6 +356,13 @@ class HinSAGELinkGenerator(BatchedLinkGenerator):
         self.name = name
 
         # This is a link generator and requires two nodes per query
+        # The head node type
+        if head_node_types is None:
+            node_type = G.unique_node_type(
+                "head_node_types: expected a pair of head node types because G has more than one node type, found node types: %(found)s"
+            )
+            head_node_types = [node_type, node_type]
+
         self.head_node_types = head_node_types
         if len(self.head_node_types) != 2:
             raise ValueError(

--- a/stellargraph/mapper/sampled_node_generators.py
+++ b/stellargraph/mapper/sampled_node_generators.py
@@ -414,7 +414,7 @@ class HinSAGENodeGenerator(BatchedNodeGenerator):
          train_data_gen = G_generator.flow(train_node_ids, train_node_labels)
          test_data_gen = G_generator.flow(test_node_ids)
 
-    """
+     """
 
     def __init__(
         self,
@@ -433,6 +433,7 @@ class HinSAGENodeGenerator(BatchedNodeGenerator):
 
         # The head node type
         if head_node_type is None:
+            # infer the head node type, if this is a homogeneous-node graph
             head_node_type = G.unique_node_type(
                 "head_node_type: expected a head node type because G has more than one node type, found node types: %(found)s"
             )

--- a/stellargraph/mapper/sampled_node_generators.py
+++ b/stellargraph/mapper/sampled_node_generators.py
@@ -402,8 +402,9 @@ class HinSAGENodeGenerator(BatchedNodeGenerator):
         G (StellarGraph): The machine-learning ready graph
         batch_size (int): Size of batch to return
         num_samples (list): The number of samples per layer (hop) to take
-        head_node_type (str): The node type that will be given to the generator
-            using the `flow` method, the model will expect this node type.
+        head_node_type (str, optional): The node type that will be given to the generator using the
+            `flow` method, the model will expect this node type. This does not need to be specified
+            if ``G`` has only one node type.
         schema (GraphSchema, optional): Graph schema for G.
         seed (int, optional): Random seed for the node sampler
 
@@ -413,14 +414,14 @@ class HinSAGENodeGenerator(BatchedNodeGenerator):
          train_data_gen = G_generator.flow(train_node_ids, train_node_labels)
          test_data_gen = G_generator.flow(test_node_ids)
 
-     """
+    """
 
     def __init__(
         self,
         G,
         batch_size,
         num_samples,
-        head_node_type,
+        head_node_type=None,
         schema=None,
         seed=None,
         name=None,
@@ -431,6 +432,11 @@ class HinSAGENodeGenerator(BatchedNodeGenerator):
         self.name = name
 
         # The head node type
+        if head_node_type is None:
+            head_node_type = G.unique_node_type(
+                "head_node_type: expected a head node type because G has more than one node type, found node types: %(found)s"
+            )
+
         if head_node_type not in self.schema.node_types:
             raise KeyError("Supplied head node type must exist in the graph")
         self.head_node_types = [head_node_type]

--- a/tests/mapper/test_full_batch_generators.py
+++ b/tests/mapper/test_full_batch_generators.py
@@ -75,7 +75,10 @@ class Test_FullBatchNodeGenerator:
 
     def test_generator_constructor_hin(self):
         Ghin = example_hin_1({})
-        with pytest.raises(TypeError):
+        with pytest.raises(
+            ValueError,
+            match="G: expected a graph with a single node type, found a graph with node types: 'A', 'B'",
+        ):
             generator = FullBatchNodeGenerator(Ghin)
 
     def generator_flow(
@@ -306,7 +309,10 @@ class Test_FullBatchLinkGenerator:
 
     def test_generator_constructor_hin(self):
         Ghin = example_hin_1({})
-        with pytest.raises(TypeError):
+        with pytest.raises(
+            ValueError,
+            match="G: expected a graph with a single node type, found a graph with node types: 'A', 'B'",
+        ):
             generator = FullBatchLinkGenerator(Ghin)
 
     def generator_flow(

--- a/tests/mapper/test_link_mappers.py
+++ b/tests/mapper/test_link_mappers.py
@@ -488,7 +488,9 @@ class Test_HinSAGELinkGenerator(object):
         edge_types = 3
         batch_size = 2
         num_samples = [5, 7]
-        G = example_graph_random(feature_size=feature_size, node_types=1, edge_types=edge_types)
+        G = example_graph_random(
+            feature_size=feature_size, node_types=1, edge_types=edge_types
+        )
 
         # G is homogeneous so the head_node_types argument isn't required
         mapper = HinSAGELinkGenerator(G, batch_size=batch_size, num_samples=num_samples)
@@ -508,9 +510,17 @@ class Test_HinSAGELinkGenerator(object):
             for i in range(0, 2):
                 assert samples[i].shape == (this_batch_size, 1, feature_size)
             for i in range(2, 2 * (1 + edge_types)):
-                assert samples[i].shape == (this_batch_size, num_samples[0], feature_size)
+                assert samples[i].shape == (
+                    this_batch_size,
+                    num_samples[0],
+                    feature_size,
+                )
             for i in range(2 * (1 + edge_types), 2 * samples_per_head):
-                assert samples[i].shape == (this_batch_size, np.product(num_samples), feature_size)
+                assert samples[i].shape == (
+                    this_batch_size,
+                    np.product(num_samples),
+                    feature_size,
+                )
 
             assert labels is None
 

--- a/tests/mapper/test_link_mappers.py
+++ b/tests/mapper/test_link_mappers.py
@@ -483,6 +483,37 @@ class Test_HinSAGELinkGenerator(object):
                 head_node_types=["B", "B"],
             ).flow(links, link_labels)
 
+    def test_HinSAGELinkGenerator_homgeneous_inference(self):
+        feature_size = 4
+        edge_types = 3
+        batch_size = 2
+        num_samples = [5, 7]
+        G = example_graph_random(feature_size=feature_size, node_types=1, edge_types=edge_types)
+
+        # G is homogeneous so the head_node_types argument isn't required
+        mapper = HinSAGELinkGenerator(G, batch_size=batch_size, num_samples=num_samples)
+
+        assert mapper.head_node_types == ["n-0", "n-0"]
+
+        links = [(1, 4), (2, 3), (4, 1)]
+        seq = mapper.flow(links)
+        assert len(seq) == 2
+
+        samples_per_head = 1 + edge_types + edge_types * edge_types
+        for batch_idx, (samples, labels) in enumerate(seq):
+            this_batch_size = {0: batch_size, 1: 1}[batch_idx]
+
+            assert len(samples) == 2 * samples_per_head
+
+            for i in range(0, 2):
+                assert samples[i].shape == (this_batch_size, 1, feature_size)
+            for i in range(2, 2 * (1 + edge_types)):
+                assert samples[i].shape == (this_batch_size, num_samples[0], feature_size)
+            for i in range(2 * (1 + edge_types), 2 * samples_per_head):
+                assert samples[i].shape == (this_batch_size, np.product(num_samples), feature_size)
+
+            assert labels is None
+
     def test_HinSAGELinkGenerator_1(self):
         G = example_hin_1(self.n_feat)
         links = [(1, 4), (1, 5), (0, 4), (0, 5)]  # selected ('movie', 'user') links

--- a/tests/mapper/test_node_mappers.py
+++ b/tests/mapper/test_node_mappers.py
@@ -619,7 +619,9 @@ def test_hinsage_homogeneous_inference():
     edge_types = 3
     batch_size = 2
     num_samples = [5, 7]
-    G = example_graph_random(feature_size=feature_size, node_types=1, edge_types=edge_types)
+    G = example_graph_random(
+        feature_size=feature_size, node_types=1, edge_types=edge_types
+    )
 
     # G is homogeneous so the head_node_type argument isn't required
     mapper = HinSAGENodeGenerator(G, batch_size=batch_size, num_samples=num_samples)
@@ -640,9 +642,14 @@ def test_hinsage_homogeneous_inference():
         for i in range(1, 1 + edge_types):
             assert samples[i].shape == (this_batch_size, num_samples[0], feature_size)
         for i in range(1 + edge_types, samples_per_head):
-            assert samples[i].shape == (this_batch_size, np.product(num_samples), feature_size)
+            assert samples[i].shape == (
+                this_batch_size,
+                np.product(num_samples),
+                feature_size,
+            )
 
         assert labels is None
+
 
 def test_attri2vec_nodemapper_constructor_nx():
     """

--- a/tests/mapper/test_node_mappers.py
+++ b/tests/mapper/test_node_mappers.py
@@ -722,7 +722,10 @@ class Test_FullBatchNodeGenerator:
     def test_generator_constructor_hin(self):
         feature_sizes = {"t1": 1, "t2": 1}
         Ghin, nodes_type_1, nodes_type_2 = example_hin_3(feature_sizes)
-        with pytest.raises(TypeError):
+        with pytest.raises(
+            ValueError,
+            match="G: expected a graph with a single node type, found a graph with node types: 't1', 't2'",
+        ):
             generator = FullBatchNodeGenerator(Ghin)
 
     def generator_flow(

--- a/tests/mapper/test_node_mappers.py
+++ b/tests/mapper/test_node_mappers.py
@@ -614,6 +614,36 @@ def test_hinsage_corrupt_indices():
     assert {tensors[idx].shape[-1] for idx in groups[1]} == {7}
 
 
+def test_hinsage_homogeneous_inference():
+    feature_size = 4
+    edge_types = 3
+    batch_size = 2
+    num_samples = [5, 7]
+    G = example_graph_random(feature_size=feature_size, node_types=1, edge_types=edge_types)
+
+    # G is homogeneous so the head_node_type argument isn't required
+    mapper = HinSAGENodeGenerator(G, batch_size=batch_size, num_samples=num_samples)
+
+    assert mapper.head_node_types == ["n-0"]
+
+    nodes = [1, 4, 2]
+    seq = mapper.flow(nodes)
+    assert len(seq) == 2
+
+    samples_per_head = 1 + edge_types + edge_types * edge_types
+    for batch_idx, (samples, labels) in enumerate(seq):
+        this_batch_size = {0: batch_size, 1: 1}[batch_idx]
+
+        assert len(samples) == samples_per_head
+
+        assert samples[0].shape == (this_batch_size, 1, feature_size)
+        for i in range(1, 1 + edge_types):
+            assert samples[i].shape == (this_batch_size, num_samples[0], feature_size)
+        for i in range(1 + edge_types, samples_per_head):
+            assert samples[i].shape == (this_batch_size, np.product(num_samples), feature_size)
+
+        assert labels is None
+
 def test_attri2vec_nodemapper_constructor_nx():
     """
     Attri2VecNodeGenerator requires a StellarGraph object

--- a/tests/mapper/test_padded_graph_generator.py
+++ b/tests/mapper/test_padded_graph_generator.py
@@ -70,7 +70,7 @@ def test_generator_init_hin():
 
     with pytest.raises(
         ValueError,
-        match="graphs: node generator requires graphs with single node type.*found.*2",
+        match="graphs: expected only graphs with a single node type.*found.*'A', 'B'",
     ):
         generator = PaddedGraphGenerator(graphs=graphs_mixed)
 


### PR DESCRIPTION
This adds a `unique_node_type` method to `StellarGraph`. The API of this is slightly peculiar, as it either:

- returns the single node type in a graph with only one (a "homogeneous-node graph")
- throws a `ValueError` if it doesn't have exactly one node type, optionally using a custom error message

This API is what I think is the most reliable one, as it's not possible to accidentally forget to detect and fail on the case when there's not one node type. (An alternative API would be to return `None` in the failure case. This would make sense in some languages, but Python's non-static type system (and also the flexibility for what StellarGraph allows for node types) means that a caller could forget to detect this case, and so continue when they should really stop.)

This PR then uses this new functionality to:
- make `homogeneous_graph.node_features()` work
- make `HinSAGENodeGenerator(homogeneous_graph, batch_size=5, num_samples=[10, 5])` work, meaning it's now easier to use (#1023) and is a drop-in replacement for `GraphSAGE`
- simplify some error handling code in other generators, by calling `unique_node_type` instead of manual `if len(...) > 1` code

See: #1343