### PR TITLE
Simplify "ready for machine learning" out of documentation

### DIFF
--- a/demos/node-classification/hinsage/yelp-example.py
+++ b/demos/node-classification/hinsage/yelp-example.py
@@ -76,7 +76,7 @@ def train(
     Train a HinSAGE model on the specified graph G with given parameters.
 
     Args:
-        G: A StellarGraph object ready for machine learning
+        G: A StellarGraph object
         layer_size: A list of number of hidden nodes in each layer
         num_samples: Number of neighbours to sample at each layer
         batch_size: Size of batch for inference

--- a/stellargraph/connector/neo4j/mapper.py
+++ b/stellargraph/connector/neo4j/mapper.py
@@ -39,9 +39,7 @@ class Neo4JBatchedNodeGenerator(BatchedNodeGenerator):
     """
     Abstract base class for graph data generators from Neo4J.
 
-    The supplied graph should be a StellarGraph object that is ready for
-    machine learning. Currently the model requires node features for all
-    nodes in the graph.
+    The supplied graph should be a StellarGraph object with node features.
 
     Do not use this base class: use a subclass specific to the method.
 
@@ -81,9 +79,7 @@ class Neo4JGraphSAGENodeGenerator(Neo4JBatchedNodeGenerator):
     At minimum, supply the StellarGraph, the batch size, and the number of
     node samples for each layer of the GraphSAGE model.
 
-    The supplied graph should be a StellarGraph object that is ready for
-    machine learning. Currently the model requires node features for all
-    nodes in the graph.
+    The supplied graph should be a StellarGraph object with node features.
 
     Use the :meth:`flow` method supplying the nodes and (optionally) targets
     to get an object that can be used as a Keras data generator.
@@ -168,9 +164,7 @@ class Neo4JDirectedGraphSAGENodeGenerator(Neo4JBatchedNodeGenerator):
     node samples (separately for in-nodes and out-nodes)
     for each layer of the GraphSAGE model.
 
-    The supplied graph should be a StellarDiGraph object that is ready for
-    machine learning. Currently the model requires node features for all
-    nodes in the graph.
+    The supplied graph should be a StellarDiGraph object with node features.
 
     Use the :meth:`flow` method supplying the nodes and (optionally) targets
     to get an object that can be used as a Keras data generator.

--- a/stellargraph/mapper/full_batch_generators.py
+++ b/stellargraph/mapper/full_batch_generators.py
@@ -200,9 +200,7 @@ class FullBatchNodeGenerator(FullBatchGenerator):
     """
     A data generator for use with full-batch models on homogeneous graphs,
     e.g., GCN, GAT, SGC.
-    The supplied graph G should be a StellarGraph object that is ready for
-    machine learning. Currently the model requires node features to be available for all
-    nodes in the graph.
+    The supplied graph G should be a StellarGraph object with node features.
 
     Use the :meth:`flow` method supplying the nodes and (optionally) targets
     to get an object that can be used as a Keras data generator.
@@ -288,9 +286,7 @@ class FullBatchLinkGenerator(FullBatchGenerator):
     """
     A data generator for use with full-batch models on homogeneous graphs,
     e.g., GCN, GAT, SGC.
-    The supplied graph G should be a StellarGraph object that is ready for
-    machine learning. Currently the model requires node features to be available for all
-    nodes in the graph.
+    The supplied graph G should be a StellarGraph object with node features.
 
     Use the :meth:`flow` method supplying the links as a list of (src, dst) tuples
     of node IDs and (optionally) targets.
@@ -373,9 +369,7 @@ class RelationalFullBatchNodeGenerator(Generator):
     """
     A data generator for use with full-batch models on relational graphs e.g. RGCN.
 
-    The supplied graph G should be a StellarGraph or StellarDiGraph object that is ready for
-    machine learning. Currently the model requires node features to be available for all
-    nodes in the graph.
+    The supplied graph G should be a StellarGraph or StellarDiGraph object with node features.
     Use the :meth:`flow` method supplying the nodes and (optionally) targets
     to get an object that can be used as a Keras data generator.
 

--- a/stellargraph/mapper/mini_batch_node_generators.py
+++ b/stellargraph/mapper/mini_batch_node_generators.py
@@ -36,9 +36,7 @@ class ClusterNodeGenerator(Generator):
     """
     A data generator for use with ClusterGCN models on homogeneous graphs, [1].
 
-    The supplied graph G should be a StellarGraph object that is ready for
-    machine learning. Currently the model requires node features to be available for all
-    nodes in the graph.
+    The supplied graph G should be a StellarGraph object with node features.
     Use the :meth:`flow` method supplying the nodes and (optionally) targets
     to get an object that can be used as a Keras data generator.
 

--- a/stellargraph/mapper/padded_graph_generator.py
+++ b/stellargraph/mapper/padded_graph_generator.py
@@ -23,8 +23,7 @@ class PaddedGraphGenerator(Generator):
     """
     A data generator for use with graph classification algorithms.
 
-    The supplied graphs should be :class:`StellarGraph` objects ready for machine learning. The generator
-    requires node features to be available for all nodes in the graph.
+    The supplied graphs should be :class:`StellarGraph` objects with node features.
     Use the :meth:`flow` method supplying the graph indexes and (optionally) targets
     to get an object that can be used as a Keras data generator.
 
@@ -34,7 +33,7 @@ class PaddedGraphGenerator(Generator):
     valid and which are padding.
 
     Args:
-        graphs (list): a collection of ready for machine-learning StellarGraph-type objects
+        graphs (list): a collection of StellarGraph objects
         name (str): an optional name of the generator
     """
 

--- a/stellargraph/mapper/sampled_link_generators.py
+++ b/stellargraph/mapper/sampled_link_generators.py
@@ -201,9 +201,7 @@ class GraphSAGELinkGenerator(BatchedLinkGenerator):
     At minimum, supply the StellarGraph, the batch size, and the number of
     node samples for each layer of the GraphSAGE model.
 
-    The supplied graph should be a StellarGraph object that is ready for
-    machine learning. Currently the model requires node features for all
-    nodes in the graph.
+    The supplied graph should be a StellarGraph object with node features.
 
     Use the :meth:`.flow` method supplying the nodes and (optionally) targets,
     or an UnsupervisedSampler instance that generates node samples on demand,
@@ -314,9 +312,7 @@ class HinSAGELinkGenerator(BatchedLinkGenerator):
     At minimum, supply the StellarGraph, the batch size, and the number of
     node samples for each layer of the GraphSAGE model.
 
-    The supplied graph should be a StellarGraph object that is ready for
-    machine learning. Currently the model requires node features for all
-    nodes in the graph.
+    The supplied graph should be a StellarGraph object with node features for all node types.
 
     Use the :meth:`flow` method supplying the nodes and (optionally) targets
     to get an object that can be used as a Keras data generator.
@@ -458,9 +454,7 @@ class Attri2VecLinkGenerator(BatchedLinkGenerator):
 
     At minimum, supply the StellarGraph and the batch size.
 
-    The supplied graph should be a StellarGraph object that is ready for
-    machine learning. Currently the model requires node features for all
-    nodes in the graph.
+    The supplied graph should be a StellarGraph object with node features.
 
     Use the :meth:`.flow` method supplying the nodes and targets,
     or an UnsupervisedSampler instance that generates node samples on demand,
@@ -512,9 +506,7 @@ class DirectedGraphSAGELinkGenerator(BatchedLinkGenerator):
     At minimum, supply the StellarDiGraph, the batch size, and the number of
     node samples (separately for in-nodes and out-nodes) for each layer of the GraphSAGE model.
 
-    The supplied graph should be a StellarDiGraph object that is ready for
-    machine learning. Currently the model requires node features for all
-    nodes in the graph.
+    The supplied graph should be a StellarDiGraph object with node features.
 
     Use the :meth:`.flow` method supplying the nodes and (optionally) targets,
     or an UnsupervisedSampler instance that generates node samples on demand,

--- a/stellargraph/mapper/sampled_node_generators.py
+++ b/stellargraph/mapper/sampled_node_generators.py
@@ -54,9 +54,7 @@ class BatchedNodeGenerator(Generator):
     """
     Abstract base class for graph data generators.
 
-    The supplied graph should be a StellarGraph object that is ready for
-    machine learning. Currently the model requires node features for all
-    nodes in the graph.
+    The supplied graph should be a StellarGraph object with node features.
 
     Do not use this base class: use a subclass specific to the method.
 
@@ -184,9 +182,7 @@ class GraphSAGENodeGenerator(BatchedNodeGenerator):
     At minimum, supply the StellarGraph, the batch size, and the number of
     node samples for each layer of the GraphSAGE model.
 
-    The supplied graph should be a StellarGraph object that is ready for
-    machine learning. Currently the model requires node features for all
-    nodes in the graph.
+    The supplied graph should be a StellarGraph object with node features.
 
     Use the :meth:`flow` method supplying the nodes and (optionally) targets
     to get an object that can be used as a Keras data generator.
@@ -289,9 +285,7 @@ class DirectedGraphSAGENodeGenerator(BatchedNodeGenerator):
     node samples (separately for in-nodes and out-nodes)
     for each layer of the GraphSAGE model.
 
-    The supplied graph should be a StellarDiGraph object that is ready for
-    machine learning. Currently the model requires node features for all
-    nodes in the graph.
+    The supplied graph should be a StellarDiGraph object with node features.
 
     Use the :meth:`flow` method supplying the nodes and (optionally) targets
     to get an object that can be used as a Keras data generator.
@@ -388,9 +382,7 @@ class HinSAGENodeGenerator(BatchedNodeGenerator):
     At minimum, supply the StellarGraph, the batch size, and the number of
     node samples for each layer of the HinSAGE model.
 
-    The supplied graph should be a StellarGraph object that is ready for
-    machine learning. Currently the model requires node features for all
-    nodes in the graph.
+    The supplied graph should be a StellarGraph object with node features for all node types.
 
     Use the :meth:`flow` method supplying the nodes and (optionally) targets
     to get an object that can be used as a Keras data generator.
@@ -514,9 +506,7 @@ class Attri2VecNodeGenerator(BatchedNodeGenerator):
 
     At minimum, supply the StellarGraph and the batch size.
 
-    The supplied graph should be a StellarGraph object that is ready for
-    machine learning. Currently the model requires node features for all
-    nodes in the graph.
+    The supplied graph should be a StellarGraph object with node features.
 
     Use the :meth:`flow` method supplying the nodes to get an object
     that can be used as a Keras data generator.


### PR DESCRIPTION
The "ready for machine learning" phrase is referring to the old "attribute spec" system for mutating an (old) `StellarGraph` object to insert node features. This system no longer exists (it was removed in 759b01a), and so this phrase is no longer relevant. (See #1334 for more specifics.)

We can remove this phrase and simplify our docs in the process for the current StellarGraph class, where a `StellarGraph` is always ready for machine learning.

The only thing required for some algorithms is features for the nodes. That is, feature dimension > 0 for each node type. I've phrased this requirement as "with node features" for brevity, but potentially it would be better to say something like "with non-empty node features" or "with node features with dimension > 0" or something along those lines?

See: #1334