### PR TITLE
Update readme with instructions for downloading demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ StellarGraph is built on [TensorFlow 2](https://tensorflow.org/) and its [Keras 
 
 You can start working with the examples immediately in Google Colab or Binder by clicking the ![](https://colab.research.google.com/assets/colab-badge.svg) and ![](https://mybinder.org/badge_logo.svg) badges within each Jupyter notebook.
 
-Alternatively, you can run download a local copy of the demos and run them using `jupyter`. The demos can be downloaded by cloning the `master` branch of this repo, or by using the [`svn` command-line tool](https://subversion.apache.org/) to download the specific directory:
+Alternatively, you can run download a local copy of the demos and run them using `jupyter`. The demos can be downloaded by cloning the `master` branch of this repo, or by using the `curl` command below:
 ```bash
-svn export https://github.com/stellargraph/stellargraph/branches/master/demos
+curl https://codeload.github.com/stellargraph/stellargraph/tar.gz/master | tar -xz --strip=1 stellargraph-master/demos
 ```
 
 All dependencies required to run our demo notebooks locally can be installed using one of the following:

--- a/README.md
+++ b/README.md
@@ -80,7 +80,12 @@ StellarGraph is built on [TensorFlow 2](https://tensorflow.org/) and its [Keras 
 
 You can start working with the examples immediately in Google Colab or Binder by clicking the ![](https://colab.research.google.com/assets/colab-badge.svg) and ![](https://mybinder.org/badge_logo.svg) badges within each Jupyter notebook.
 
-Alternatively, you can run them locally by cloning this repo and starting a `jupyter` instance from the `demos` directory. All dependencies required to run our demo notebooks locally can be installed using one of the following:
+Alternatively, you can run download a local copy of the demos and run them using `jupyter`. The demos can be downloaded by cloning the `master` branch of this repo, or by using the [`svn` command-line tool](https://subversion.apache.org/) to download the specific directory:
+```bash
+svn export https://github.com/stellargraph/stellargraph/branches/master/demos
+```
+
+All dependencies required to run our demo notebooks locally can be installed using one of the following:
 
 - Using pip: `pip install stellargraph[demos]`
 - Using conda: `conda install -c stellargraph stellargraph`

--- a/README.md
+++ b/README.md
@@ -78,7 +78,9 @@ StellarGraph is built on [TensorFlow 2](https://tensorflow.org/) and its [Keras 
 
 [The numerous detailed and narrated examples](https://github.com/stellargraph/stellargraph/tree/master/demos/) are a good way to get started with StellarGraph. There is likely to be one that is similar to your data or your problem (if not, [let us know](#getting-help)).
 
-You can start working with the examples immediately in Google Colab or Binder by clicking the ![](https://colab.research.google.com/assets/colab-badge.svg) and ![](https://mybinder.org/badge_logo.svg) badges within each Jupyter notebook. You can also run them locally, after installing StellarGraph. One of the following might be appropriate:
+You can start working with the examples immediately in Google Colab or Binder by clicking the ![](https://colab.research.google.com/assets/colab-badge.svg) and ![](https://mybinder.org/badge_logo.svg) badges within each Jupyter notebook.
+
+Alternatively, you can run them locally by cloning this repo and starting a `jupyter` instance from the `demos` directory. All dependencies required to run our demo notebooks locally can be installed using one of the following:
 
 - Using pip: `pip install stellargraph[demos]`
 - Using conda: `conda install -c stellargraph stellargraph`


### PR DESCRIPTION
This adds some instructions in the top-level README for downloading our demos to run them locally.

See #1202 