### PR TITLE
Allow empty graph or 'nodes' in undirected to_adjacency_matrix

### DIFF
--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -1104,9 +1104,12 @@ class StellarGraph:
         n = len(index)
 
         adj = sps.csr_matrix((weights, (src_idx, tgt_idx)), shape=(n, n))
-        if not self.is_directed():
+        if not self.is_directed() and n > 0:
             # in an undirected graph, the adjacency matrix should be symmetric: which means counting
-            # weights from either "incoming" or "outgoing" edges, but not double-counting self loops
+            # weights from either "incoming" or "outgoing" edges, but not double-counting self loops.
+
+            # FIXME https://github.com/scipy/scipy/issues/11949: these operations, particularly the
+            # diagonal, don't work for an empty matrix (n == 0)
             backward = adj.transpose(copy=True)
             # this is setdiag(0), but faster, since it doesn't change the sparsity structure of the
             # matrix (https://github.com/scipy/scipy/issues/11600)

--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -1106,7 +1106,7 @@ class StellarGraph:
         adj = sps.csr_matrix((weights, (src_idx, tgt_idx)), shape=(n, n))
         if not self.is_directed() and n > 0:
             # in an undirected graph, the adjacency matrix should be symmetric: which means counting
-            # weights from either "incoming" or "outgoing" edges, but not double-counting self loops.
+            # weights from either "incoming" or "outgoing" edges, but not double-counting self loops
 
             # FIXME https://github.com/scipy/scipy/issues/11949: these operations, particularly the
             # diagonal, don't work for an empty matrix (n == 0)

--- a/tests/core/test_graph.py
+++ b/tests/core/test_graph.py
@@ -1389,6 +1389,16 @@ def test_to_adjacency_matrix_edge_type_subgraph():
     np.testing.assert_array_equal(matrix_f, actual_f)
 
 
+@pytest.mark.parametrize("is_directed", [False, True])
+def test_to_adjacency_matrix_empty(is_directed):
+    cls = StellarDiGraph if is_directed else StellarGraph
+    g = cls()
+    assert g.to_adjacency_matrix().shape == (0, 0)
+
+    g = example_hin_1(is_directed=is_directed, self_loop=True)
+    assert g.to_adjacency_matrix(nodes=[]).shape == (0, 0)
+
+
 @pytest.mark.benchmark(group="StellarGraph to_adjacency_matrix")
 @pytest.mark.parametrize("is_directed", [False, True])
 def test_benchmark_to_adjacency_matrix(is_directed, benchmark):


### PR DESCRIPTION
This works around the failure of `sparse.diagonal()` when `sparse` is a square sparse matrix with shape `(0, 0)` (https://github.com/scipy/scipy/issues/11949). This is a major part of the cause of `PaddedGraphGenerator` not handling empty graphs, but is more generally applicable.

See: #1338