### PR TITLE
Fix from_networkx for an empty graph with DataFrame of features

### DIFF
--- a/stellargraph/core/convert.py
+++ b/stellargraph/core/convert.py
@@ -298,7 +298,7 @@ def _features_from_attributes(node_type, ids, values, dtype):
     return matrix
 
 
-def _features_from_node_data(nodes, data, dtype):
+def _features_from_node_data(nodes, node_type_default, data, dtype):
     if isinstance(data, dict):
 
         def single(node_type):
@@ -348,8 +348,8 @@ def _features_from_node_data(nodes, data, dtype):
                 "When there is more than one node type, pass node features as a dictionary."
             )
 
-        node_type = next(iter(nodes))
-        return _features_from_node_data(nodes, {node_type: data}, dtype)
+        node_type = next(iter(nodes), node_type_default)
+        return _features_from_node_data(nodes, node_type_default, {node_type: data}, dtype)
     elif isinstance(data, (Iterable, list)):
         id_to_data = dict(data)
         return {
@@ -402,7 +402,7 @@ def from_networkx(
             for node_type, node_info in nodes.items()
         }
     else:
-        node_frames = _features_from_node_data(nodes, node_features, dtype)
+        node_frames = _features_from_node_data(nodes, node_type_default, node_features, dtype)
 
     edges = nx.to_pandas_edgelist(graph, source=SOURCE, target=TARGET)
     _fill_or_assign(edges, edge_type_attr, edge_type_default)

--- a/stellargraph/core/convert.py
+++ b/stellargraph/core/convert.py
@@ -349,7 +349,9 @@ def _features_from_node_data(nodes, node_type_default, data, dtype):
             )
 
         node_type = next(iter(nodes), node_type_default)
-        return _features_from_node_data(nodes, node_type_default, {node_type: data}, dtype)
+        return _features_from_node_data(
+            nodes, node_type_default, {node_type: data}, dtype
+        )
     elif isinstance(data, (Iterable, list)):
         id_to_data = dict(data)
         return {
@@ -402,7 +404,9 @@ def from_networkx(
             for node_type, node_info in nodes.items()
         }
     else:
-        node_frames = _features_from_node_data(nodes, node_type_default, node_features, dtype)
+        node_frames = _features_from_node_data(
+            nodes, node_type_default, node_features, dtype
+        )
 
     edges = nx.to_pandas_edgelist(graph, source=SOURCE, target=TARGET)
     _fill_or_assign(edges, edge_type_attr, edge_type_default)

--- a/tests/core/test_convert.py
+++ b/tests/core/test_convert.py
@@ -441,6 +441,29 @@ def test_from_networkx_default_features():
     assert edges == {}
 
 
+def test_from_networkx_empty():
+    g = nx.Graph()
+    # no features, means no types
+    nodes, edges = from_networkx_for_testing(g)
+    assert nodes == {}
+    assert edges == {}
+
+    # various forms of features:
+    nodes, edges = from_networkx_for_testing(g, node_features={})
+    assert nodes == {}
+    assert edges == {}
+
+    features = pd.DataFrame(columns=range(10))
+
+    nodes, edges = from_networkx_for_testing(g, node_features=features)
+    assert nodes == {}
+    assert edges == {}
+
+    nodes, edges = from_networkx_for_testing(g, node_features={"b": features})
+    assert nodes == {}
+    assert edges == {}
+
+
 def test_from_networkx_errors():
     het = nx.MultiDiGraph()
     het.add_nodes_from([(0, {"n": "a"}), (1, {"n": "b"})])

--- a/tests/core/test_graph.py
+++ b/tests/core/test_graph.py
@@ -1431,11 +1431,18 @@ def test_node_type():
 def test_from_networkx_empty():
     empty = StellarGraph.from_networkx(nx.Graph())
     assert not empty.is_directed()
+    assert empty.node_types == set()
     assert isinstance(empty, StellarGraph)
 
     empty = StellarGraph.from_networkx(nx.DiGraph())
     assert empty.is_directed()
+    assert empty.node_types == set()
     assert isinstance(empty, StellarDiGraph)
+
+    # https://github.com/stellargraph/stellargraph/issues/1339
+    features = pd.DataFrame(columns=range(10))
+    empty_with_features = StellarGraph.from_networkx(nx.Graph(), node_features=features)
+    assert empty_with_features.node_types == set()
 
 
 def test_from_networkx_smoke():


### PR DESCRIPTION
`from_networkx(g, node_features=features)` would fail if specifically:

- `g` is empty (i.e. no nodes)
- `features` is a `DataFrame`, not a `{type_name: df}` dict or any of the other supported values for the `node_features` parameter

This was because it had to find the unique node type that take their features from the `features` DataFrame. However, without nodes and thus without any node types, this is impossible.

The approach here is a bit fuzzy and should potentially be reconsidered. For instance, maybe we should guarantee that there's always at least one type of nodes and of edges (the default node or edge type) in any `StellarGraph`?

See: #1339