### PR TITLE
Handle and test empty graphs in PaddedGraphGenerator

### DIFF
--- a/stellargraph/core/utils.py
+++ b/stellargraph/core/utils.py
@@ -45,7 +45,7 @@ def normalize_adj(adj, symmetric=True, add_self_loops=False):
         Return a sparse normalized adjacency matrix.
     """
 
-    if add_self_loops:
+    if add_self_loops and adj.shape[0] > 0:
         adj = adj + sp.diags(np.ones(adj.shape[0]) - adj.diagonal())
 
     if symmetric:

--- a/stellargraph/mapper/padded_graph_generator.py
+++ b/stellargraph/mapper/padded_graph_generator.py
@@ -47,8 +47,14 @@ class PaddedGraphGenerator(Generator):
                 )
             # Check that there is only a single node type for GAT or GCN
             node_type = graph.unique_node_type(
-                "graphs: expected only graphs with a single node type, found a graph with node types: %(found)s"
+                "graphs: expected only graphs with a single node type, found a graph with node types: %(found)s",
+                allow_no_types=True
             )
+
+            if node_type is None:
+                # empty graph
+                assert graph.number_of_nodes() == 0
+                continue
 
             graph.check_graph_for_ml()
 

--- a/stellargraph/mapper/sequences.py
+++ b/stellargraph/mapper/sequences.py
@@ -624,7 +624,7 @@ class PaddedGraphSequence(Sequence):
         # pad adjacency and feature matrices to equal the size of those from the largest graph
         features = [
             np.pad(
-                graph.node_features(graph.nodes()),
+                graph.node_features(),
                 pad_width=((0, max_nodes - graph.number_of_nodes()), (0, 0)),
             )
             for graph in graphs

--- a/tests/core/test_graph.py
+++ b/tests/core/test_graph.py
@@ -325,6 +325,11 @@ def test_node_features_node_type_inference():
     # short-cut inference of the node type for a subset of the nodes with a homogenous graph
     np.testing.assert_array_equal(one_type.node_features([1]), [[1] * 4])
 
+    no_types = StellarGraph({}, {})
+    # make sure this testing the right case
+    assert no_types.node_types == set()
+    assert no_types.node_features().shape == (0, 0)
+
     # inference doesn't work for a heterogeneous graph:
     feature_sizes = {"A": 4, "B": 6}
     many_types = example_hin_1(feature_sizes=feature_sizes)


### PR DESCRIPTION
This adds various special cases to handle completely empty graphs in `PaddedGraphGenerator`.

(It relies on #1381.)

See also #1395 that just disallows empty graphs like this.

See: #1338