### PR TITLE
Optimise feature lookup in PaddedGraphSequence (2.7× faster)

### DIFF
--- a/stellargraph/mapper/sequences.py
+++ b/stellargraph/mapper/sequences.py
@@ -624,7 +624,7 @@ class PaddedGraphSequence(Sequence):
         # pad adjacency and feature matrices to equal the size of those from the largest graph
         features = [
             np.pad(
-                graph.node_features(graph.nodes()),
+                graph.node_features(),
                 pad_width=((0, max_nodes - graph.number_of_nodes()), (0, 0)),
             )
             for graph in graphs


### PR DESCRIPTION
The `StellarGraph.node_features()` method can now (as of #1274 and #1375) return the features for all nodes of a type (that is, for a homogeneous graph, all nodes) at once. Using this new functionality is an improvement over the old form `graph.node_features(graph.nodes())` in a few ways, mainly:

- more convenient and cleaner code
- less time overhead from ID<->iloc conversion (particularly important for complicated indices, like `MultiIndex`s, #1346), because it's entirely avoided with the new form
- less time overhead from node type inference when `node_type=...` isn't passed, because that is also entirely avoided with the new form (although it's also minimised with #1375)
- less time and memory overhead caused by copying features, because the new form can return the underlying NumPy array directly

These theoretical benefits translates into benefits in practice. I benchmarked this in a few ways:

- "microbenchmark": timing how long it takes to construct a whole epoch of the generator

  ```python
  import stellargraph as sg
  graphs, _ = sg.datasets.MUTAG().load()
  gen = sg.mapper.PaddedGraphGenerator(graphs)
  seq = gen.flow(range(len(graphs)))
  %timeit -n 10 list(seq)
  ```

- "per restart": the time per inner restart loop in the Supervised Graph Classification notebook (that is, the time to create the model, call `fit` on the train data, and `evaluate` on the test data)
- "epoch step": the time "XX ms/step" time reported by TensorFlow in `model.fit(train_gen, epochs=30, verbose=1)`, where `train_gen` is taken from the first split of the Supervised Graph Classification notebook

| code | microbenchmark (ms) | per restart (s) | epoch step (ms) |
|---|---|---|---|
| develop | 53.5 ± 1.5 | 11 | 11 |
| this PR | 19.5 ± 1.44 | 7.2 | 6 |
| speedup | 2.7× | 1.5× | 1.8× |

I'm not sure how measure potential memory improvements.

(Without any verification or investigation, this _may_ translate into even more improvements with the end-to-end TensorFlow pipeline, because the feature arrays are more obviously constant, and so more able to be optimised (potentially) although this may require #1228 to fully realise.)