### PR TITLE
Specify language for highlighting notebook code cells

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -192,3 +192,8 @@ texinfo_documents = [
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
+
+# -- Options for nbsphinx ----------------------------------------------------
+
+# Explicitly specify what language our code cells are
+nbsphinx_codecell_lexer = "python3"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -192,8 +192,3 @@ texinfo_documents = [
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
-
-# -- Options for nbsphinx ----------------------------------------------------
-
-# Explicitly specify what language our code cells are
-nbsphinx_codecell_lexer = "python3"

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,5 @@ recommonmark==0.6.0
 sphinx-markdown-tables==0.0.12
 nbsphinx==0.6.1
 nbsphinx-link==1.3.0
+# needed for Pygments highlighting in notebooks
+ipython==7.13.0


### PR DESCRIPTION
Notebooks have their language specified as `ipython3`, which Read the Docs/Sphinx/Pygments doesn't know about by default. Installing the `ipython` library is enough to enable this.

Our builds on Read the Docs previously had many warnings about an unknown lexer (see below). These are now silenced and the code is syntax highlighted.

```
.../docs/demos/basics/loading-networkx.nblink: WARNING: Pygments lexer name 'ipython3' is not known
.../docs/demos/basics/loading-networkx.nblink: WARNING: Pygments lexer name 'ipython3' is not known
...
.../docs/demos/basics/loading-pandas.nblink: WARNING: Pygments lexer name 'ipython3' is not known
...
```

(From the last step of https://readthedocs.org/projects/stellargraph/builds/10923097/)

Demo: https://stellargraph--1385.org.readthedocs.build/en/1385/demos/basics/loading-networkx.html

![image](https://user-images.githubusercontent.com/1203825/80439734-8fb7e400-894a-11ea-9dbf-0c53d6917003.png)

See: #1383