### PR TITLE
Hide generated notebook cells from Sphinx output

### DIFF
--- a/demos/basics/loading-networkx.ipynb
+++ b/demos/basics/loading-networkx.ipynb
@@ -45,6 +45,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "CloudRunner"
     ]
@@ -61,6 +62,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "VersionCheck"
     ]

--- a/demos/basics/loading-pandas.ipynb
+++ b/demos/basics/loading-pandas.ipynb
@@ -54,6 +54,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "CloudRunner"
     ]
@@ -70,6 +71,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "VersionCheck"
     ]

--- a/demos/basics/loading-saving-neo4j.ipynb
+++ b/demos/basics/loading-saving-neo4j.ipynb
@@ -45,6 +45,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "CloudRunner"
     ]
@@ -61,6 +62,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "VersionCheck"
     ]

--- a/demos/calibration/calibration-pubmed-link-prediction.ipynb
+++ b/demos/calibration/calibration-pubmed-link-prediction.ipynb
@@ -48,6 +48,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "CloudRunner"
     ]
@@ -64,6 +65,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "VersionCheck"
     ]

--- a/demos/calibration/calibration-pubmed-node-classification.ipynb
+++ b/demos/calibration/calibration-pubmed-node-classification.ipynb
@@ -42,6 +42,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "CloudRunner"
     ]
@@ -58,6 +59,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "VersionCheck"
     ]

--- a/demos/community_detection/attacks_clustering_analysis.ipynb
+++ b/demos/community_detection/attacks_clustering_analysis.ipynb
@@ -84,6 +84,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "CloudRunner"
     ]
@@ -100,6 +101,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "VersionCheck"
     ]

--- a/demos/connector/neo4j/directed-graphsage-on-cora-neo4j-example.ipynb
+++ b/demos/connector/neo4j/directed-graphsage-on-cora-neo4j-example.ipynb
@@ -26,6 +26,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "CloudRunner"
     ]
@@ -42,6 +43,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "VersionCheck"
     ]

--- a/demos/connector/neo4j/load-cora-into-neo4j.ipynb
+++ b/demos/connector/neo4j/load-cora-into-neo4j.ipynb
@@ -24,6 +24,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "CloudRunner"
     ]
@@ -40,6 +41,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "VersionCheck"
     ]

--- a/demos/connector/neo4j/undirected-graphsage-on-cora-neo4j-example.ipynb
+++ b/demos/connector/neo4j/undirected-graphsage-on-cora-neo4j-example.ipynb
@@ -22,6 +22,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "CloudRunner"
     ]
@@ -38,6 +39,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "VersionCheck"
     ]

--- a/demos/embeddings/deep-graph-infomax-cora.ipynb
+++ b/demos/embeddings/deep-graph-infomax-cora.ipynb
@@ -26,6 +26,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "CloudRunner"
     ]
@@ -42,6 +43,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "VersionCheck"
     ]

--- a/demos/embeddings/embeddings-unsupervised-graphsage-cora.ipynb
+++ b/demos/embeddings/embeddings-unsupervised-graphsage-cora.ipynb
@@ -49,6 +49,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "CloudRunner"
     ]
@@ -65,6 +66,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "VersionCheck"
     ]

--- a/demos/embeddings/graphwave-barbell.ipynb
+++ b/demos/embeddings/graphwave-barbell.ipynb
@@ -31,6 +31,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "CloudRunner"
     ]
@@ -47,6 +48,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "VersionCheck"
     ]

--- a/demos/embeddings/stellargraph-attri2vec-citeseer.ipynb
+++ b/demos/embeddings/stellargraph-attri2vec-citeseer.ipynb
@@ -40,6 +40,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "CloudRunner"
     ]
@@ -56,6 +57,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "VersionCheck"
     ]

--- a/demos/embeddings/stellargraph-metapath2vec.ipynb
+++ b/demos/embeddings/stellargraph-metapath2vec.ipynb
@@ -34,6 +34,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "CloudRunner"
     ]
@@ -50,6 +51,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "VersionCheck"
     ]

--- a/demos/embeddings/stellargraph-node2vec.ipynb
+++ b/demos/embeddings/stellargraph-node2vec.ipynb
@@ -33,6 +33,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "CloudRunner"
     ]
@@ -49,6 +50,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "VersionCheck"
     ]

--- a/demos/embeddings/watch-your-step-cora-demo.ipynb
+++ b/demos/embeddings/watch-your-step-cora-demo.ipynb
@@ -15,6 +15,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "CloudRunner"
     ]
@@ -31,6 +32,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "VersionCheck"
     ]

--- a/demos/ensembles/ensemble-link-prediction-example.ipynb
+++ b/demos/ensembles/ensemble-link-prediction-example.ipynb
@@ -40,6 +40,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "CloudRunner"
     ]
@@ -56,6 +57,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "VersionCheck"
     ]

--- a/demos/ensembles/ensemble-node-classification-example.ipynb
+++ b/demos/ensembles/ensemble-node-classification-example.ipynb
@@ -37,6 +37,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "CloudRunner"
     ]
@@ -53,6 +54,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "VersionCheck"
     ]

--- a/demos/graph-classification/supervised-graph-classification.ipynb
+++ b/demos/graph-classification/supervised-graph-classification.ipynb
@@ -36,6 +36,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "CloudRunner"
     ]
@@ -52,6 +53,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "VersionCheck"
     ]

--- a/demos/interpretability/gat/node-link-importance-demo-gat.ipynb
+++ b/demos/interpretability/gat/node-link-importance-demo-gat.ipynb
@@ -28,6 +28,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "CloudRunner"
     ]
@@ -44,6 +45,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "VersionCheck"
     ]

--- a/demos/interpretability/gcn/hateful-twitters-interpretability.ipynb
+++ b/demos/interpretability/gcn/hateful-twitters-interpretability.ipynb
@@ -39,6 +39,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "CloudRunner"
     ]
@@ -55,6 +56,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "VersionCheck"
     ]

--- a/demos/interpretability/gcn/node-link-importance-demo-gcn-sparse.ipynb
+++ b/demos/interpretability/gcn/node-link-importance-demo-gcn-sparse.ipynb
@@ -34,6 +34,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "CloudRunner"
     ]
@@ -50,6 +51,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "VersionCheck"
     ]

--- a/demos/interpretability/gcn/node-link-importance-demo-gcn.ipynb
+++ b/demos/interpretability/gcn/node-link-importance-demo-gcn.ipynb
@@ -34,6 +34,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "CloudRunner"
     ]
@@ -50,6 +51,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "VersionCheck"
     ]

--- a/demos/link-prediction/attri2vec/stellargraph-attri2vec-DBLP.ipynb
+++ b/demos/link-prediction/attri2vec/stellargraph-attri2vec-DBLP.ipynb
@@ -41,6 +41,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "CloudRunner"
     ]
@@ -57,6 +58,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "VersionCheck"
     ]

--- a/demos/link-prediction/gcn/cora-gcn-links-example.ipynb
+++ b/demos/link-prediction/gcn/cora-gcn-links-example.ipynb
@@ -31,6 +31,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "CloudRunner"
     ]
@@ -47,6 +48,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "VersionCheck"
     ]

--- a/demos/link-prediction/graphsage/cora-links-example.ipynb
+++ b/demos/link-prediction/graphsage/cora-links-example.ipynb
@@ -31,6 +31,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "CloudRunner"
     ]
@@ -47,6 +48,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "VersionCheck"
     ]

--- a/demos/link-prediction/hinsage/movielens-recommender.ipynb
+++ b/demos/link-prediction/hinsage/movielens-recommender.ipynb
@@ -31,6 +31,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "CloudRunner"
     ]
@@ -47,6 +48,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "VersionCheck"
     ]

--- a/demos/link-prediction/knowledge-graphs/complex.ipynb
+++ b/demos/link-prediction/knowledge-graphs/complex.ipynb
@@ -26,6 +26,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "CloudRunner"
     ]
@@ -42,6 +43,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "VersionCheck"
     ]

--- a/demos/link-prediction/knowledge-graphs/distmult.ipynb
+++ b/demos/link-prediction/knowledge-graphs/distmult.ipynb
@@ -31,6 +31,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "CloudRunner"
     ]
@@ -47,6 +48,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "VersionCheck"
     ]

--- a/demos/link-prediction/random-walks/cora-lp-demo.ipynb
+++ b/demos/link-prediction/random-walks/cora-lp-demo.ipynb
@@ -43,6 +43,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "CloudRunner"
     ]
@@ -59,6 +60,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "VersionCheck"
     ]

--- a/demos/link-prediction/random-walks/ctdne-link-prediction.ipynb
+++ b/demos/link-prediction/random-walks/ctdne-link-prediction.ipynb
@@ -28,6 +28,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "CloudRunner"
     ]
@@ -44,6 +45,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "VersionCheck"
     ]

--- a/demos/node-classification/attri2vec/attri2vec-citeseer-node-classification-example.ipynb
+++ b/demos/node-classification/attri2vec/attri2vec-citeseer-node-classification-example.ipynb
@@ -40,6 +40,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "CloudRunner"
     ]
@@ -56,6 +57,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "VersionCheck"
     ]

--- a/demos/node-classification/cluster-gcn/cluster-gcn-node-classification.ipynb
+++ b/demos/node-classification/cluster-gcn/cluster-gcn-node-classification.ipynb
@@ -49,6 +49,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "CloudRunner"
     ]
@@ -65,6 +66,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "VersionCheck"
     ]

--- a/demos/node-classification/gat/gat-cora-node-classification-example.ipynb
+++ b/demos/node-classification/gat/gat-cora-node-classification-example.ipynb
@@ -29,6 +29,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "CloudRunner"
     ]
@@ -45,6 +46,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "VersionCheck"
     ]

--- a/demos/node-classification/gcn/gcn-cora-node-classification-example.ipynb
+++ b/demos/node-classification/gcn/gcn-cora-node-classification-example.ipynb
@@ -56,6 +56,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "CloudRunner"
     ]
@@ -72,6 +73,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "VersionCheck"
     ]

--- a/demos/node-classification/graphsage/directed-graphsage-on-cora-example.ipynb
+++ b/demos/node-classification/graphsage/directed-graphsage-on-cora-example.ipynb
@@ -31,6 +31,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "CloudRunner"
     ]
@@ -47,6 +48,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "VersionCheck"
     ]

--- a/demos/node-classification/graphsage/graphsage-cora-node-classification-example.ipynb
+++ b/demos/node-classification/graphsage/graphsage-cora-node-classification-example.ipynb
@@ -29,6 +29,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "CloudRunner"
     ]
@@ -45,6 +46,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "VersionCheck"
     ]

--- a/demos/node-classification/graphsage/graphsage-pubmed-inductive-node-classification-example.ipynb
+++ b/demos/node-classification/graphsage/graphsage-pubmed-inductive-node-classification-example.ipynb
@@ -34,6 +34,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "CloudRunner"
     ]
@@ -50,6 +51,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "VersionCheck"
     ]

--- a/demos/node-classification/node2vec/stellargraph-node2vec-node-classification.ipynb
+++ b/demos/node-classification/node2vec/stellargraph-node2vec-node-classification.ipynb
@@ -37,6 +37,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "CloudRunner"
     ]
@@ -53,6 +54,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "VersionCheck"
     ]

--- a/demos/node-classification/node2vec/stellargraph-node2vec-weighted-random-walks.ipynb
+++ b/demos/node-classification/node2vec/stellargraph-node2vec-weighted-random-walks.ipynb
@@ -53,6 +53,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "CloudRunner"
     ]
@@ -69,6 +70,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "VersionCheck"
     ]

--- a/demos/node-classification/ppnp/ppnp-cora-node-classification-example.ipynb
+++ b/demos/node-classification/ppnp/ppnp-cora-node-classification-example.ipynb
@@ -29,6 +29,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "CloudRunner"
     ]
@@ -45,6 +46,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "VersionCheck"
     ]

--- a/demos/node-classification/rgcn/rgcn-aifb-node-classification-example.ipynb
+++ b/demos/node-classification/rgcn/rgcn-aifb-node-classification-example.ipynb
@@ -33,6 +33,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "CloudRunner"
     ]
@@ -49,6 +50,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "VersionCheck"
     ]

--- a/demos/node-classification/sgc/sgc-node-classification-example.ipynb
+++ b/demos/node-classification/sgc/sgc-node-classification-example.ipynb
@@ -50,6 +50,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "CloudRunner"
     ]
@@ -66,6 +67,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "VersionCheck"
     ]

--- a/demos/spatio-temporal/gcn-lstm-LA.ipynb
+++ b/demos/spatio-temporal/gcn-lstm-LA.ipynb
@@ -40,6 +40,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "CloudRunner"
     ]
@@ -56,6 +57,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "VersionCheck"
     ]

--- a/demos/use-cases/hateful-twitters.ipynb
+++ b/demos/use-cases/hateful-twitters.ipynb
@@ -42,6 +42,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "CloudRunner"
     ]
@@ -58,6 +59,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
+    "nbsphinx": "hidden",
     "tags": [
      "VersionCheck"
     ]

--- a/scripts/format_notebooks.py
+++ b/scripts/format_notebooks.py
@@ -130,6 +130,15 @@ class FormatCodeCellPreprocessor(preprocessors.Preprocessor):
         return cell, resources
 
 
+def hide_cell_from_docs(cell):
+    """
+    Add metadata so that the cell is removed from the Sphinx output.
+
+    https://nbsphinx.readthedocs.io/en/0.6.1/hidden-cells.html
+    """
+    cell["metadata"]["nbsphinx"] = "hidden"
+
+
 class InsertTaggedCellsPreprocessor(preprocessors.Preprocessor):
     # abstract class working with tagged notebook cells
     metadata_tag = ""  # tag for added cells so that we can find them easily; needs to be set in derived class
@@ -194,6 +203,7 @@ if 'google.colab' in sys.modules:
         )
         import_cell = nbformat.v4.new_code_cell(self.colab_import_code)
         self.tag_cell(import_cell)
+        hide_cell_from_docs(import_cell)
         nb.cells.insert(first_code_cell_id, import_cell)
 
         nb.cells.append(badge_cell)  # add a badge to the bottom of notebook
@@ -223,6 +233,7 @@ except AttributeError:
         )
         version_cell = nbformat.v4.new_code_cell(self.version_check_code)
         self.tag_cell(version_cell)
+        hide_cell_from_docs(version_cell)
         nb.cells.insert(first_code_cell_id, version_cell)
         return nb, resources
 


### PR DESCRIPTION
We currently insert two notebook cells that are just execution-management code:

- installing StellarGraph on Google Colab
- checking the versions

These aren't relevant to someone reading the notebooks as documentation, so we can hide them in Sphinx, such as on Read the Docs.

Demo: https://stellargraph--1386.org.readthedocs.build/en/1386/demos/basics/loading-saving-neo4j.html

![image](https://user-images.githubusercontent.com/1203825/80438676-17e8ba00-8948-11ea-8075-0d432fac30b9.png)

The old form: https://stellargraph.readthedocs.io/en/v1.0.0rc1/demos/basics/loading-saving-neo4j.html

![image](https://user-images.githubusercontent.com/1203825/80438705-246d1280-8948-11ea-8712-a78bfdeb8633.png)


See: #1384