### PR TITLE
Use type from homogeneous check for features in FullBatchGenerator

### DIFF
--- a/stellargraph/mapper/full_batch_generators.py
+++ b/stellargraph/mapper/full_batch_generators.py
@@ -82,7 +82,7 @@ class FullBatchGenerator(Generator):
         G.check_graph_for_ml()
 
         # Check that there is only a single node type for GAT or GCN
-        _ = G.unique_node_type(
+        node_type = G.unique_node_type(
             "G: expected a graph with a single node type, found a graph with node types: %(found)s"
         )
 
@@ -105,7 +105,7 @@ class FullBatchGenerator(Generator):
             self.use_sparse = sparse
 
         # Get the features for the nodes
-        self.features = G.node_features(node_type=node_types[0])
+        self.features = G.node_features(node_type=node_type)
 
         if transform is not None:
             if callable(transform):


### PR DESCRIPTION
Pull requests #1277 and #1375 were both modifying a similar area of the `FullBatchGenerator` code. #1277 merged before #1375, but #1375 didn't happen to have tests rerun before it merged. If it did, we would've noticed that #1375 needed updates due to #1277 changing how features were queried.

This PR does the appropriate update, reusing the node type computed with `unique_node_type` from #1375 to get the node features, rather than indexing the list of node types that was being created before #1277 merged.

See: #1388