### PR TITLE
Disallow empty graphs in PaddedGraphGenerator

### DIFF
--- a/stellargraph/mapper/padded_graph_generator.py
+++ b/stellargraph/mapper/padded_graph_generator.py
@@ -46,6 +46,14 @@ class PaddedGraphGenerator(Generator):
                 raise TypeError(
                     f"graphs: expected every element to be a StellarGraph object, found {type(graph).__name__}."
                 )
+
+            if graph.number_of_nodes() == 0:
+                # an empty graph has no information at all and breaks things like mean pooling, so
+                # let's disallow them
+                raise ValueError(
+                    "graphs: expected every graph to be non-empty, found graph with no nodes"
+                )
+
             # Check that there is only a single node type for GAT or GCN
             node_type = graph.unique_node_type(
                 "graphs: expected only graphs with a single node type, found a graph with node types: %(found)s"

--- a/tests/mapper/test_padded_graph_generator.py
+++ b/tests/mapper/test_padded_graph_generator.py
@@ -75,6 +75,19 @@ def test_generator_init_hin():
         generator = PaddedGraphGenerator(graphs=graphs_mixed)
 
 
+def test_generator_init_empty():
+    graphs = [
+        example_graph_random(feature_size=2, n_nodes=4),
+        example_graph_random(feature_size=2, node_types=0, edge_types=0),
+    ]
+
+    with pytest.raises(
+        ValueError,
+        match="graphs: expected every graph to be non-empty, found graph with no nodes",
+    ):
+        generator = PaddedGraphGenerator(graphs=graphs)
+
+
 def test_generator_flow_invalid_batch_size():
     with pytest.raises(
         ValueError, match="expected batch_size.*strictly positive integer, found -1"


### PR DESCRIPTION
`PaddedGraphGenerator` is designed for graph classification, and an empty graphs is awkward and arguably meaningless to classify: 

- there's no input data at all, so nothing for a classification algorithm to work with
- all empty graphs are identical and all are classified the same
- mean pooling doesn't work (and having a mask of entirely `False`s is likely an edge case that other complicated pooling mechanisms don't explicitly consider/test for)

This PR thus resolves the problems `PaddedGraphGenerator` has with empty graphs by catching and disallowing them early. A user should then filter out any empty graphs before/while creating the generator.

This is future-proof: if it turns out to be useful to work with empty graphs here, we can always remove the restriction in future.

This is a simpler alternative to #1380. Is disallowing it like this PR the correct trade-off, instead of making it work like #1380 (which doesn't yet actually work)?

See: #1338