### PR TITLE
Remove exhortation to skip sections from loading demo

### DIFF
--- a/demos/basics/loading-networkx.ipynb
+++ b/demos/basics/loading-networkx.ipynb
@@ -26,7 +26,7 @@
     "\n",
     "[The StellarGraph library](https://github.com/stellargraph/stellargraph) supports loading graph information from NetworkX graphs. [NetworkX](https://networkx.github.io) is a library for working with graphs that provides many convenient I/O functions, graph algorithms and other tools. If your data is naturally a NetworkX graph, this is a great way to load it. If your data does not *need* to be a NetworkX graph, [loading via Pandas](loading-pandas.ipynb) is likely to be faster and potentially more convenient.\n",
     "\n",
-    "This notebook walks through loading several kinds of graphs. Feel free to go through the whole notebook, or search for the following titles to jump to sections most relevant to you.\n",
+    "This notebook walks through loading several kinds of graphs.\n",
     "\n",
     "- homogeneous graph without features (a homogeneous graph is one with only one type of node and one type of edge)\n",
     "- homogeneous graph with features\n",

--- a/demos/basics/loading-pandas.ipynb
+++ b/demos/basics/loading-pandas.ipynb
@@ -34,7 +34,7 @@
     "\n",
     "All of these are optional, because they have sensible defaults if they're not relevant to the task at hand.\n",
     "\n",
-    "This notebook walks through loading several kinds of graphs. Feel free to go through the whole notebook, or search for the following titles to jump to sections most relevant to you.\n",
+    "This notebook walks through loading several kinds of graphs.\n",
     "\n",
     "- homogeneous graph without features (a homogeneous graph is one with only one type of node and one type of edge)\n",
     "- homogeneous graph with features\n",

--- a/demos/basics/loading-saving-neo4j.ipynb
+++ b/demos/basics/loading-saving-neo4j.ipynb
@@ -28,7 +28,7 @@
     "\n",
     "This notebook demonstrates one approach to connecting StellarGraph and Neo4j. It uses the SQL-like [Cypher language](https://neo4j.com/developer/cypher-query-language/) to read a graph or subgraph from Neo4j into [Pandas](https://pandas.pydata.org) DataFrames, and then uses these to construct a `StellarGraph` object (following the same techniques as in the [loading via Pandas](loading-pandas.ipynb) demo, which has more details about that aspect). This notebook assumes some familiarity with Cypher constructs like `MATCH`, `RETURN` and `WHERE`. This notebook uses the [py2neo](http://py2neo.org/) library to interact with a Neo4j instance.\n",
     "\n",
-    "This notebook walks through scenarios for loading and storing graphs. Feel free to go through the whole notebook, or search for the following titles to jump to sections most relevant to you.\n",
+    "This notebook walks through scenarios for loading and storing graphs.\n",
     "\n",
     "- homogeneous graph without features (a homogeneous graph is one with only one type of node and one type of edge)\n",
     "- homogeneous graph with features\n",


### PR DESCRIPTION
Some of the sections in these notebooks build on each other, and so a reader should at least skim the sections leading up to the one in which they are interested. Once they've skimmed it, they'll hopefully remember enough to jump around themselves, but we shouldn't be explicitly encouraging them to skip over potentially relevant things.

See: #1340