### PR TITLE
Use edge_type_column= in basics/ demos

### DIFF
--- a/demos/basics/loading-pandas.ipynb
+++ b/demos/basics/loading-pandas.ipynb
@@ -1208,7 +1208,7 @@
    "source": [
     "### Multiple edge types\n",
     "\n",
-    "Graphs with multiple edge types is simpler. Since we have no features on the edges, we can pass a DataFrame with an additional column for the type, specifying it via the `edge_type_column` parameter. (Multiple edge types can also be created in the same way as multiple node types, by passing with a dictionary of DataFrames, but this is not necessary.)\n",
+    "Graphs with multiple edge types are simpler. Since we have no features on the edges, we can pass a DataFrame with an additional column for the type, specifying it via the `edge_type_column` parameter. (Multiple edge types can also be created in the same way as multiple node types, by passing with a dictionary of DataFrames, but this is not necessary.)\n",
     "\n",
     "For example, suppose the edges in our square graph have types based on their orientation."
    ]
@@ -1288,7 +1288,7 @@
        "4      a      c    diagonal"
       ]
      },
-     "execution_count": 50,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1422,7 +1422,7 @@
        "4      a      c    diagonal    1.00"
       ]
      },
-     "execution_count": 52,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1526,7 +1526,7 @@
        "2      c      d"
       ]
      },
-     "execution_count": 44,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1643,7 +1643,7 @@
        "2      c      d    45.6"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1726,18 +1726,18 @@
       "    foo-diagonal->bar: [1]\n",
       "        Weights: all 1 (default)\n",
       "    bar-vertical->foo: [1]\n",
-      "        Weights: all 1 (default)\n",
+      "        Weights: all 5.67\n",
       "    bar-vertical->bar: [1]\n",
-      "        Weights: all 1 (default)\n",
+      "        Weights: all 0.2\n",
       "    bar-horizontal->bar: [1]\n",
-      "        Weights: all 1 (default)\n"
+      "        Weights: all 3.4\n"
      ]
     }
    ],
    "source": [
     "square_everything = StellarGraph(\n",
     "    {\"foo\": square_foo, \"bar\": square_bar},\n",
-    "    square_edges_types,\n",
+    "    square_edges_types_weighted,\n",
     "    edge_type_column=\"orientation\",\n",
     ")\n",
     "print(square_everything.info())"
@@ -1778,11 +1778,11 @@
       "    foo-diagonal->bar: [1]\n",
       "        Weights: all 1 (default)\n",
       "    bar-vertical->foo: [1]\n",
-      "        Weights: all 1 (default)\n",
+      "        Weights: all 5.67\n",
       "    bar-vertical->bar: [1]\n",
-      "        Weights: all 1 (default)\n",
+      "        Weights: all 0.2\n",
       "    bar-horizontal->bar: [1]\n",
-      "        Weights: all 1 (default)\n"
+      "        Weights: all 3.4\n"
      ]
     }
    ],
@@ -1791,7 +1791,7 @@
     "\n",
     "square_everything_directed = StellarDiGraph(\n",
     "    {\"foo\": square_foo, \"bar\": square_bar},\n",
-    "    square_edges_types,\n",
+    "    square_edges_types_weighted,\n",
     "    edge_type_column=\"orientation\",\n",
     ")\n",
     "print(square_everything_directed.info())"
@@ -1968,7 +1968,7 @@
        "[5429 rows x 2 columns]"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2339,7 +2339,7 @@
        "[2708 rows x 1435 columns]"
       ]
      },
-     "execution_count": 35,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2738,7 +2738,7 @@
        "[2708 rows x 1434 columns]"
       ]
      },
-     "execution_count": 36,
+     "execution_count": 38,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3141,7 +3141,7 @@
        "[2708 rows x 1433 columns]"
       ]
      },
-     "execution_count": 37,
+     "execution_count": 39,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3216,7 +3216,7 @@
        "Name: subject, Length: 2708, dtype: object"
       ]
      },
-     "execution_count": 39,
+     "execution_count": 41,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3256,7 +3256,7 @@
        "Name: subject, Length: 677, dtype: object"
       ]
      },
-     "execution_count": 40,
+     "execution_count": 42,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3293,7 +3293,7 @@
        "Name: subject, Length: 2031, dtype: object"
       ]
      },
-     "execution_count": 41,
+     "execution_count": 43,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3721,7 +3721,7 @@
        "[2708 rows x 1440 columns]"
       ]
      },
-     "execution_count": 42,
+     "execution_count": 44,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/demos/basics/loading-pandas.ipynb
+++ b/demos/basics/loading-pandas.ipynb
@@ -214,7 +214,7 @@
        "4      a      c"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -391,7 +391,7 @@
        "4     a      c"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -507,7 +507,7 @@
        "d  4 -0.5"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -679,7 +679,7 @@
        "4      a      c    1.00"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -882,7 +882,7 @@
        "Index: [a]"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -949,7 +949,7 @@
        "d  0.9  300"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1053,7 +1053,7 @@
        "b -1"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1123,7 +1123,7 @@
        "foo-a -1"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1192,7 +1192,7 @@
        "bar-d  0.9  300"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1208,16 +1208,276 @@
    "source": [
     "### Multiple edge types\n",
     "\n",
-    "Graphs with multiple edge types are almost identical: instead of passing a single DataFrame or a dictionary with one element for the edges, pass a dictionary with multiple elements.\n",
+    "Graphs with multiple edge types is simpler. Since we have no features on the edges, we can pass a DataFrame with an additional column for the type, specifying it via the `edge_type_column` parameter. (Multiple edge types can also be created in the same way as multiple node types, by passing with a dictionary of DataFrames, but this is not necessary.)\n",
     "\n",
-    "For example, suppose the edges in our square graph have types based on their orientation. We'll need a separate dataframe for each edge.\n",
+    "For example, suppose the edges in our square graph have types based on their orientation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>source</th>\n",
+       "      <th>target</th>\n",
+       "      <th>orientation</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>a</td>\n",
+       "      <td>b</td>\n",
+       "      <td>horizontal</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>b</td>\n",
+       "      <td>c</td>\n",
+       "      <td>vertical</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>c</td>\n",
+       "      <td>d</td>\n",
+       "      <td>horizontal</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>d</td>\n",
+       "      <td>a</td>\n",
+       "      <td>vertical</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>a</td>\n",
+       "      <td>c</td>\n",
+       "      <td>diagonal</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  source target orientation\n",
+       "0      a      b  horizontal\n",
+       "1      b      c    vertical\n",
+       "2      c      d  horizontal\n",
+       "3      d      a    vertical\n",
+       "4      a      c    diagonal"
+      ]
+     },
+     "execution_count": 50,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "square_edges_types = square_edges.assign(\n",
+    "    orientation=[\"horizontal\", \"vertical\", \"horizontal\", \"vertical\", \"diagonal\"]\n",
+    ")\n",
+    "square_edges_types"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "StellarGraph: Undirected multigraph\n",
+      " Nodes: 4, Edges: 5\n",
+      "\n",
+      " Node types:\n",
+      "  default: [4]\n",
+      "    Features: none\n",
+      "    Edge types: default-diagonal->default, default-horizontal->default, default-vertical->default\n",
+      "\n",
+      " Edge types:\n",
+      "    default-vertical->default: [2]\n",
+      "        Weights: all 1 (default)\n",
+      "    default-horizontal->default: [2]\n",
+      "        Weights: all 1 (default)\n",
+      "    default-diagonal->default: [1]\n",
+      "        Weights: all 1 (default)\n"
+     ]
+    }
+   ],
+   "source": [
+    "square_orientation = StellarGraph(\n",
+    "    edges=square_edges_types, edge_type_column=\"orientation\"\n",
+    ")\n",
+    "print(square_orientation.info())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Edge weights are supported, in the same way as a homogeneous graph above, with a `weight` column:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>source</th>\n",
+       "      <th>target</th>\n",
+       "      <th>orientation</th>\n",
+       "      <th>weight</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>a</td>\n",
+       "      <td>b</td>\n",
+       "      <td>horizontal</td>\n",
+       "      <td>1.00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>b</td>\n",
+       "      <td>c</td>\n",
+       "      <td>vertical</td>\n",
+       "      <td>0.20</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>c</td>\n",
+       "      <td>d</td>\n",
+       "      <td>horizontal</td>\n",
+       "      <td>3.40</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>d</td>\n",
+       "      <td>a</td>\n",
+       "      <td>vertical</td>\n",
+       "      <td>5.67</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>a</td>\n",
+       "      <td>c</td>\n",
+       "      <td>diagonal</td>\n",
+       "      <td>1.00</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  source target orientation  weight\n",
+       "0      a      b  horizontal    1.00\n",
+       "1      b      c    vertical    0.20\n",
+       "2      c      d  horizontal    3.40\n",
+       "3      d      a    vertical    5.67\n",
+       "4      a      c    diagonal    1.00"
+      ]
+     },
+     "execution_count": 52,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "square_edges_types_weighted = square_edges_types.assign(weight=[1.0, 0.2, 3.4, 5.67, 1.0])\n",
+    "square_edges_types_weighted"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "StellarGraph: Undirected multigraph\n",
+      " Nodes: 4, Edges: 5\n",
+      "\n",
+      " Node types:\n",
+      "  default: [4]\n",
+      "    Features: none\n",
+      "    Edge types: default-diagonal->default, default-horizontal->default, default-vertical->default\n",
+      "\n",
+      " Edge types:\n",
+      "    default-vertical->default: [2]\n",
+      "        Weights: range=[0.2, 5.67], mean=2.935, std=3.86787\n",
+      "    default-horizontal->default: [2]\n",
+      "        Weights: range=[1, 3.4], mean=2.2, std=1.69706\n",
+      "    default-diagonal->default: [1]\n",
+      "        Weights: all 1 (default)\n"
+     ]
+    }
+   ],
+   "source": [
+    "square_orientation_weighted = StellarGraph(\n",
+    "    edges=square_edges_types_weighted, edge_type_column=\"orientation\"\n",
+    ")\n",
+    "print(square_orientation_weighted.info())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Multiple edge types can also be done in the same way as multiple node types: instead of passing a single DataFrame or a dictionary with one element for the edges, pass a dictionary with multiple elements.\n",
     "\n",
     "Note: Edges also have IDs (the DataFrame index, like nodes), and they need to be unique across all edge types."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {
@@ -1266,7 +1526,7 @@
        "2      c      d"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 44,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1275,130 +1535,18 @@
     "square_edges_horizontal = pd.DataFrame(\n",
     "    {\"source\": [\"a\", \"c\"], \"target\": [\"b\", \"d\"]}, index=[0, 2]\n",
     ")\n",
+    "square_edges_vertical = pd.DataFrame(\n",
+    "    {\"source\": [\"b\", \"d\"], \"target\": [\"c\", \"a\"]}, index=[1, 3]\n",
+    ")\n",
+    "square_edges_diagonal = pd.DataFrame({\"source\": [\"a\"], \"target\": [\"c\"]}, index=[4])\n",
+    "\n",
+    "# example:\n",
     "square_edges_horizontal"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>source</th>\n",
-       "      <th>target</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>b</td>\n",
-       "      <td>c</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>d</td>\n",
-       "      <td>a</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "  source target\n",
-       "1      b      c\n",
-       "3      d      a"
-      ]
-     },
-     "execution_count": 25,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "square_edges_vertical = pd.DataFrame(\n",
-    "    {\"source\": [\"b\", \"d\"], \"target\": [\"c\", \"a\"]}, index=[1, 3]\n",
-    ")\n",
-    "square_edges_vertical"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 27,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>source</th>\n",
-       "      <th>target</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>a</td>\n",
-       "      <td>c</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "  source target\n",
-       "4      a      c"
-      ]
-     },
-     "execution_count": 26,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "square_edges_diagonal = pd.DataFrame({\"source\": [\"a\"], \"target\": [\"c\"]}, index=[4])\n",
-    "square_edges_diagonal"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
@@ -1424,26 +1572,26 @@
     }
    ],
    "source": [
-    "square_orientation = StellarGraph(\n",
+    "square_orientation_separate = StellarGraph(\n",
     "    edges={\n",
     "        \"horizontal\": square_edges_horizontal,\n",
     "        \"vertical\": square_edges_vertical,\n",
     "        \"diagonal\": square_edges_diagonal,\n",
     "    },\n",
     ")\n",
-    "print(square_orientation.info())"
+    "print(square_orientation_separate.info())"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A heterogeneous graph can have weights just like a homogeneous graph. Any or all of the DataFrames for an edge type can contain a `weight` column."
+    "Edge weights can be specified with this multiple-DataFrames form too. Any or all of the DataFrames for an edge type can contain a `weight` column."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [
     {
@@ -1495,7 +1643,7 @@
        "2      c      d    45.6"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1507,7 +1655,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [
     {
@@ -1533,14 +1681,14 @@
     }
    ],
    "source": [
-    "square_orientation = StellarGraph(\n",
+    "square_orientation_separate_weighted = StellarGraph(\n",
     "    edges={\n",
     "        \"horizontal\": square_edges_horizontal_weighted,\n",
     "        \"vertical\": square_edges_vertical,\n",
     "        \"diagonal\": square_edges_diagonal,\n",
     "    },\n",
     ")\n",
-    "print(square_orientation.info())"
+    "print(square_orientation_separate_weighted.info())"
    ]
   },
   {
@@ -1549,12 +1697,12 @@
    "source": [
     "### Multiple everything\n",
     "\n",
-    "A graph can have multiple node types and multiple edge types, with features or without and with edge weights or without. We can put everything together from the previous sections to make a single complicated `StellarGraph`."
+    "A graph can have multiple node types and multiple edge types, with features or without, with edge weights or without and with `edge_type_column=...` (shown here) or with multiple DataFrames for edge types. We can put everything together from the previous sections to make a single complicated `StellarGraph`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [
     {
@@ -1574,7 +1722,7 @@
       "\n",
       " Edge types:\n",
       "    foo-horizontal->bar: [1]\n",
-      "        Weights: all 12.3\n",
+      "        Weights: all 1 (default)\n",
       "    foo-diagonal->bar: [1]\n",
       "        Weights: all 1 (default)\n",
       "    bar-vertical->foo: [1]\n",
@@ -1582,18 +1730,15 @@
       "    bar-vertical->bar: [1]\n",
       "        Weights: all 1 (default)\n",
       "    bar-horizontal->bar: [1]\n",
-      "        Weights: all 45.6\n"
+      "        Weights: all 1 (default)\n"
      ]
     }
    ],
    "source": [
     "square_everything = StellarGraph(\n",
     "    {\"foo\": square_foo, \"bar\": square_bar},\n",
-    "    {\n",
-    "        \"horizontal\": square_edges_horizontal_weighted,\n",
-    "        \"vertical\": square_edges_vertical,\n",
-    "        \"diagonal\": square_edges_diagonal,\n",
-    "    },\n",
+    "    square_edges_types,\n",
+    "    edge_type_column=\"orientation\",\n",
     ")\n",
     "print(square_everything.info())"
    ]
@@ -1609,7 +1754,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [
     {
@@ -1629,7 +1774,7 @@
       "\n",
       " Edge types:\n",
       "    foo-horizontal->bar: [1]\n",
-      "        Weights: all 12.3\n",
+      "        Weights: all 1 (default)\n",
       "    foo-diagonal->bar: [1]\n",
       "        Weights: all 1 (default)\n",
       "    bar-vertical->foo: [1]\n",
@@ -1637,7 +1782,7 @@
       "    bar-vertical->bar: [1]\n",
       "        Weights: all 1 (default)\n",
       "    bar-horizontal->bar: [1]\n",
-      "        Weights: all 45.6\n"
+      "        Weights: all 1 (default)\n"
      ]
     }
    ],
@@ -1646,11 +1791,8 @@
     "\n",
     "square_everything_directed = StellarDiGraph(\n",
     "    {\"foo\": square_foo, \"bar\": square_bar},\n",
-    "    {\n",
-    "        \"horizontal\": square_edges_horizontal_weighted,\n",
-    "        \"vertical\": square_edges_vertical,\n",
-    "        \"diagonal\": square_edges_diagonal,\n",
-    "    },\n",
+    "    square_edges_types,\n",
+    "    edge_type_column=\"orientation\",\n",
     ")\n",
     "print(square_everything_directed.info())"
    ]
@@ -1694,7 +1836,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1720,7 +1862,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [
     {
@@ -1826,7 +1968,7 @@
        "[5429 rows x 2 columns]"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 34,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1850,7 +1992,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [
     {
@@ -2197,7 +2339,7 @@
        "[2708 rows x 1435 columns]"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 35,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2223,7 +2365,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [
     {
@@ -2596,7 +2738,7 @@
        "[2708 rows x 1434 columns]"
       ]
      },
-     "execution_count": 35,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2626,7 +2768,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [
     {
@@ -2999,7 +3141,7 @@
        "[2708 rows x 1433 columns]"
       ]
      },
-     "execution_count": 36,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3018,7 +3160,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [
     {
@@ -3053,7 +3195,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [
     {
@@ -3074,7 +3216,7 @@
        "Name: subject, Length: 2708, dtype: object"
       ]
      },
-     "execution_count": 38,
+     "execution_count": 39,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3093,7 +3235,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [
     {
@@ -3114,7 +3256,7 @@
        "Name: subject, Length: 677, dtype: object"
       ]
      },
-     "execution_count": 39,
+     "execution_count": 40,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3130,7 +3272,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [
     {
@@ -3151,7 +3293,7 @@
        "Name: subject, Length: 2031, dtype: object"
       ]
      },
-     "execution_count": 40,
+     "execution_count": 41,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3178,7 +3320,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [
     {
@@ -3579,7 +3721,7 @@
        "[2708 rows x 1440 columns]"
       ]
      },
-     "execution_count": 41,
+     "execution_count": 42,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3600,7 +3742,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [
     {
@@ -3669,7 +3811,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5"
+   "version": "3.6.9"
   }
  },
  "nbformat": 4,

--- a/demos/basics/loading-saving-neo4j.ipynb
+++ b/demos/basics/loading-saving-neo4j.ipynb
@@ -1063,10 +1063,7 @@
    "source": [
     "### Multiple edge types\n",
     "\n",
-    "FIXME https://github.com/stellargraph/stellargraph/issues/1183\n",
-    "\n",
-    "\n",
-    "Graphs with multiple edge types are almost identical: instead of passing a single DataFrame or a dictionary with one element for the edges, pass a dictionary with multiple elements.\n",
+    "Graphs with multiple edge types is simpler. Since we have no features on the edges, we can pass a DataFrame with an additional column for the type, specifying it via the `edge_type_column` parameter. (Multiple edge types can also be created in the same way as multiple node types, by passing with a dictionary of DataFrames, but this is not necessary.)\n",
     "\n",
     "For example, our square graph has labelled each edge with its orientation. We can retrieve this using [the `type` function](https://neo4j.com/docs/cypher-manual/current/functions/scalar/#functions-type) to get a DataFrame with a label column too."
    ]
@@ -1166,48 +1163,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We need to convert this to a dictionary for each type, by grouping on that column."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 23,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'diagonal':   source target\n",
-       " 3      a      c,\n",
-       " 'horizontal':   source target\n",
-       " 1      a      b\n",
-       " 4      c      d,\n",
-       " 'vertical':   source target\n",
-       " 0      d      a\n",
-       " 2      b      c}"
-      ]
-     },
-     "execution_count": 22,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# FIXME https://github.com/stellargraph/stellargraph/issues/1183\n",
-    "grouped = {name: df.drop(columns=\"label\") for name, df in labelled_edges.groupby(\"label\")}\n",
-    "grouped"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "We now have a dictionary of the edges, so we can create a graph with one node type, but multiple edge types. Notice how `info()` shows 3 edge types."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -1233,7 +1194,7 @@
     }
    ],
    "source": [
-    "hetereogeneous_edges = StellarGraph(edges=grouped)\n",
+    "hetereogeneous_edges = StellarGraph(edges=labelled_edges, edge_type_column=\"label\")\n",
     "print(hetereogeneous_edges.info())"
    ]
   },
@@ -1248,7 +1209,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
@@ -1281,7 +1242,9 @@
     }
    ],
    "source": [
-    "hetereogeneous_everything = StellarGraph({\"foo\": foo_nodes, \"bar\": bar_nodes}, grouped)\n",
+    "hetereogeneous_everything = StellarGraph(\n",
+    "    {\"foo\": foo_nodes, \"bar\": bar_nodes}, labelled_edges, edge_type_column=\"label\"\n",
+    ")\n",
     "print(hetereogeneous_everything.info())"
    ]
   },
@@ -1308,7 +1271,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
@@ -1403,7 +1366,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
@@ -1478,7 +1441,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
@@ -1513,7 +1476,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [
     {
@@ -1587,7 +1550,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {
@@ -1641,7 +1604,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
@@ -1733,7 +1696,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [
     {
@@ -1808,7 +1771,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [
     {
@@ -1861,7 +1824,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1881,7 +1844,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [
     {
@@ -1913,7 +1876,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1937,7 +1900,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [
     {
@@ -2042,7 +2005,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/demos/basics/loading-saving-neo4j.ipynb
+++ b/demos/basics/loading-saving-neo4j.ipynb
@@ -1063,7 +1063,7 @@
    "source": [
     "### Multiple edge types\n",
     "\n",
-    "Graphs with multiple edge types is simpler. Since we have no features on the edges, we can pass a DataFrame with an additional column for the type, specifying it via the `edge_type_column` parameter. (Multiple edge types can also be created in the same way as multiple node types, by passing with a dictionary of DataFrames, but this is not necessary.)\n",
+    "Graphs with multiple edge types are simpler. Since we have no features on the edges, we can pass a DataFrame with an additional column for the type, specifying it via the `edge_type_column` parameter. (Multiple edge types can also be created in the same way as multiple node types, by passing with a dictionary of DataFrames, but this is not necessary.)\n",
     "\n",
     "For example, our square graph has labelled each edge with its orientation. We can retrieve this using [the `type` function](https://neo4j.com/docs/cypher-manual/current/functions/scalar/#functions-type) to get a DataFrame with a label column too."
    ]


### PR DESCRIPTION
This updates the `basics/` demos to use the simpler multiple-edge-type construction from #1183/#1284. This construction uses a single DataFrame with a type column, along with passing `edge_type_column=...` with the name of that type column.

This in particular makes the Neo4j demo simpler, since it's easy to get a DataFrame of source, target and type in a single query.

See: #1301