### PR TITLE
Switch Binder and Colab links in notebooks to markdown block quote

### DIFF
--- a/demos/basics/loading-networkx.ipynb
+++ b/demos/basics/loading-networkx.ipynb
@@ -22,8 +22,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<!-- work around https://github.com/spatialaudio/nbsphinx/issues/450 -->\n",
-    "\n",
     "> This demo explains how to load data from NetworkX into a form that can be used by the StellarGraph library. [See all other demos](../README.md).\n",
     "\n",
     "[The StellarGraph library](https://github.com/stellargraph/stellargraph) supports loading graph information from NetworkX graphs. [NetworkX](https://networkx.github.io) is a library for working with graphs that provides many convenient I/O functions, graph algorithms and other tools. If your data is naturally a NetworkX graph, this is a great way to load it. If your data does not *need* to be a NetworkX graph, [loading via Pandas](loading-pandas.ipynb) is likely to be faster and potentially more convenient.\n",

--- a/demos/basics/loading-networkx.ipynb
+++ b/demos/basics/loading-networkx.ipynb
@@ -22,6 +22,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<!-- work around https://github.com/spatialaudio/nbsphinx/issues/450 -->\n",
+    "\n",
     "> This demo explains how to load data from NetworkX into a form that can be used by the StellarGraph library. [See all other demos](../README.md).\n",
     "\n",
     "[The StellarGraph library](https://github.com/stellargraph/stellargraph) supports loading graph information from NetworkX graphs. [NetworkX](https://networkx.github.io) is a library for working with graphs that provides many convenient I/O functions, graph algorithms and other tools. If your data is naturally a NetworkX graph, this is a great way to load it. If your data does not *need* to be a NetworkX graph, [loading via Pandas](loading-pandas.ipynb) is likely to be faster and potentially more convenient.\n",

--- a/demos/basics/loading-networkx.ipynb
+++ b/demos/basics/loading-networkx.ipynb
@@ -15,7 +15,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/basics/loading-networkx.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/basics/loading-networkx.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/basics/loading-networkx.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/basics/loading-networkx.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   },
   {
@@ -1048,7 +1052,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/basics/loading-networkx.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/basics/loading-networkx.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/basics/loading-networkx.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/basics/loading-networkx.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   }
  ],

--- a/demos/basics/loading-networkx.ipynb
+++ b/demos/basics/loading-networkx.ipynb
@@ -15,11 +15,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/basics/loading-networkx.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/basics/loading-networkx.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/basics/loading-networkx.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/basics/loading-networkx.ipynb)"
    ]
   },
   {
@@ -1052,11 +1048,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/basics/loading-networkx.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/basics/loading-networkx.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/basics/loading-networkx.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/basics/loading-networkx.ipynb)"
    ]
   }
  ],

--- a/demos/basics/loading-pandas.ipynb
+++ b/demos/basics/loading-pandas.ipynb
@@ -33,6 +33,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<!-- work around https://github.com/spatialaudio/nbsphinx/issues/450 -->\n",
+    "\n",
     "> This demo explains how to load data into a form that can be used by the StellarGraph library. [See all other demos](../README.md).\n",
     "\n",
     "[The StellarGraph library](https://github.com/stellargraph/stellargraph) supports many deep machine learning (ML) algorithms on [graphs](https://en.wikipedia.org/wiki/Graph_%28discrete_mathematics%29). A graph consists of a set of *nodes* connected by *edges*, potentially with information associated with each node and edge.\n",

--- a/demos/basics/loading-pandas.ipynb
+++ b/demos/basics/loading-pandas.ipynb
@@ -22,17 +22,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<div class=\"alert alert-info run-cell\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/basics/loading-pandas.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/basics/loading-pandas.ipynb)\n",
-    "    \n",
-    "</div>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "<!-- work around https://github.com/spatialaudio/nbsphinx/issues/450 -->\n",
     "\n",
     "> This demo explains how to load data into a form that can be used by the StellarGraph library. [See all other demos](../README.md).\n",

--- a/demos/basics/loading-pandas.ipynb
+++ b/demos/basics/loading-pandas.ipynb
@@ -15,11 +15,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/basics/loading-pandas.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/basics/loading-pandas.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/basics/loading-pandas.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/basics/loading-pandas.ipynb)"
    ]
   },
   {
@@ -3664,11 +3660,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/basics/loading-pandas.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/basics/loading-pandas.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/basics/loading-pandas.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/basics/loading-pandas.ipynb)"
    ]
   }
  ],

--- a/demos/basics/loading-pandas.ipynb
+++ b/demos/basics/loading-pandas.ipynb
@@ -15,7 +15,22 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/basics/loading-pandas.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/basics/loading-pandas.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/basics/loading-pandas.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/basics/loading-pandas.ipynb)\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-info run-cell\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/basics/loading-pandas.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/basics/loading-pandas.ipynb)\n",
+    "    \n",
+    "</div>"
    ]
   },
   {
@@ -3649,7 +3664,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/basics/loading-pandas.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/basics/loading-pandas.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/basics/loading-pandas.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/basics/loading-pandas.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   }
  ],

--- a/demos/basics/loading-pandas.ipynb
+++ b/demos/basics/loading-pandas.ipynb
@@ -22,8 +22,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<!-- work around https://github.com/spatialaudio/nbsphinx/issues/450 -->\n",
-    "\n",
     "> This demo explains how to load data into a form that can be used by the StellarGraph library. [See all other demos](../README.md).\n",
     "\n",
     "[The StellarGraph library](https://github.com/stellargraph/stellargraph) supports many deep machine learning (ML) algorithms on [graphs](https://en.wikipedia.org/wiki/Graph_%28discrete_mathematics%29). A graph consists of a set of *nodes* connected by *edges*, potentially with information associated with each node and edge.\n",

--- a/demos/basics/loading-saving-neo4j.ipynb
+++ b/demos/basics/loading-saving-neo4j.ipynb
@@ -15,11 +15,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/basics/loading-saving-neo4j.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/basics/loading-saving-neo4j.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/basics/loading-saving-neo4j.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/basics/loading-saving-neo4j.ipynb)"
    ]
   },
   {
@@ -2062,11 +2058,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/basics/loading-saving-neo4j.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/basics/loading-saving-neo4j.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/basics/loading-saving-neo4j.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/basics/loading-saving-neo4j.ipynb)"
    ]
   }
  ],

--- a/demos/basics/loading-saving-neo4j.ipynb
+++ b/demos/basics/loading-saving-neo4j.ipynb
@@ -22,6 +22,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<!-- work around https://github.com/spatialaudio/nbsphinx/issues/450 -->\n",
+    "\n",
     "> This demo explains how to load data from Neo4j into a form that can be used by the StellarGraph library, and how to save predictions back into the database. [See all other demos](../README.md).\n",
     "\n",
     "[The StellarGraph library](https://github.com/stellargraph/stellargraph) supports many deep machine learning (ML) algorithms on [graphs](https://en.wikipedia.org/wiki/Graph_%28discrete_mathematics%29).  This graph information can be loaded from the popular [Neo4j](https://neo4j.com) graph database. If your data is already in Neo4j, this is a great way to load it. If not, [loading via Pandas](loading-pandas.ipynb) or [via NetworkX](loading-networkx.ipynb) is likely to be faster and potentially more convenient.\n",

--- a/demos/basics/loading-saving-neo4j.ipynb
+++ b/demos/basics/loading-saving-neo4j.ipynb
@@ -15,7 +15,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/basics/loading-saving-neo4j.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/basics/loading-saving-neo4j.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/basics/loading-saving-neo4j.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/basics/loading-saving-neo4j.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   },
   {
@@ -2058,7 +2062,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/basics/loading-saving-neo4j.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/basics/loading-saving-neo4j.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/basics/loading-saving-neo4j.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/basics/loading-saving-neo4j.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   }
  ],

--- a/demos/basics/loading-saving-neo4j.ipynb
+++ b/demos/basics/loading-saving-neo4j.ipynb
@@ -22,8 +22,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<!-- work around https://github.com/spatialaudio/nbsphinx/issues/450 -->\n",
-    "\n",
     "> This demo explains how to load data from Neo4j into a form that can be used by the StellarGraph library, and how to save predictions back into the database. [See all other demos](../README.md).\n",
     "\n",
     "[The StellarGraph library](https://github.com/stellargraph/stellargraph) supports many deep machine learning (ML) algorithms on [graphs](https://en.wikipedia.org/wiki/Graph_%28discrete_mathematics%29).  This graph information can be loaded from the popular [Neo4j](https://neo4j.com) graph database. If your data is already in Neo4j, this is a great way to load it. If not, [loading via Pandas](loading-pandas.ipynb) or [via NetworkX](loading-networkx.ipynb) is likely to be faster and potentially more convenient.\n",

--- a/demos/calibration/calibration-pubmed-link-prediction.ipynb
+++ b/demos/calibration/calibration-pubmed-link-prediction.ipynb
@@ -15,11 +15,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/calibration/calibration-pubmed-link-prediction.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/calibration/calibration-pubmed-link-prediction.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/calibration/calibration-pubmed-link-prediction.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/calibration/calibration-pubmed-link-prediction.ipynb)"
    ]
   },
   {
@@ -1204,11 +1200,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/calibration/calibration-pubmed-link-prediction.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/calibration/calibration-pubmed-link-prediction.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/calibration/calibration-pubmed-link-prediction.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/calibration/calibration-pubmed-link-prediction.ipynb)"
    ]
   }
  ],

--- a/demos/calibration/calibration-pubmed-link-prediction.ipynb
+++ b/demos/calibration/calibration-pubmed-link-prediction.ipynb
@@ -15,7 +15,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/calibration/calibration-pubmed-link-prediction.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/calibration/calibration-pubmed-link-prediction.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/calibration/calibration-pubmed-link-prediction.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/calibration/calibration-pubmed-link-prediction.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   },
   {
@@ -1200,7 +1204,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/calibration/calibration-pubmed-link-prediction.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/calibration/calibration-pubmed-link-prediction.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/calibration/calibration-pubmed-link-prediction.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/calibration/calibration-pubmed-link-prediction.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   }
  ],

--- a/demos/calibration/calibration-pubmed-node-classification.ipynb
+++ b/demos/calibration/calibration-pubmed-node-classification.ipynb
@@ -15,11 +15,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/calibration/calibration-pubmed-node-classification.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/calibration/calibration-pubmed-node-classification.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/calibration/calibration-pubmed-node-classification.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/calibration/calibration-pubmed-node-classification.ipynb)"
    ]
   },
   {
@@ -1527,11 +1523,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/calibration/calibration-pubmed-node-classification.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/calibration/calibration-pubmed-node-classification.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/calibration/calibration-pubmed-node-classification.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/calibration/calibration-pubmed-node-classification.ipynb)"
    ]
   }
  ],

--- a/demos/calibration/calibration-pubmed-node-classification.ipynb
+++ b/demos/calibration/calibration-pubmed-node-classification.ipynb
@@ -15,7 +15,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/calibration/calibration-pubmed-node-classification.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/calibration/calibration-pubmed-node-classification.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/calibration/calibration-pubmed-node-classification.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/calibration/calibration-pubmed-node-classification.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   },
   {
@@ -1523,7 +1527,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/calibration/calibration-pubmed-node-classification.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/calibration/calibration-pubmed-node-classification.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/calibration/calibration-pubmed-node-classification.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/calibration/calibration-pubmed-node-classification.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   }
  ],

--- a/demos/community_detection/attacks_clustering_analysis.ipynb
+++ b/demos/community_detection/attacks_clustering_analysis.ipynb
@@ -15,7 +15,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/community_detection/attacks_clustering_analysis.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/community_detection/attacks_clustering_analysis.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/community_detection/attacks_clustering_analysis.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/community_detection/attacks_clustering_analysis.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   },
   {
@@ -3097,7 +3101,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/community_detection/attacks_clustering_analysis.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/community_detection/attacks_clustering_analysis.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/community_detection/attacks_clustering_analysis.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/community_detection/attacks_clustering_analysis.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   }
  ],

--- a/demos/community_detection/attacks_clustering_analysis.ipynb
+++ b/demos/community_detection/attacks_clustering_analysis.ipynb
@@ -15,11 +15,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/community_detection/attacks_clustering_analysis.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/community_detection/attacks_clustering_analysis.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/community_detection/attacks_clustering_analysis.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/community_detection/attacks_clustering_analysis.ipynb)"
    ]
   },
   {
@@ -3101,11 +3097,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/community_detection/attacks_clustering_analysis.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/community_detection/attacks_clustering_analysis.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/community_detection/attacks_clustering_analysis.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/community_detection/attacks_clustering_analysis.ipynb)"
    ]
   }
  ],

--- a/demos/connector/neo4j/directed-graphsage-on-cora-neo4j-example.ipynb
+++ b/demos/connector/neo4j/directed-graphsage-on-cora-neo4j-example.ipynb
@@ -15,7 +15,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/connector/neo4j/directed-graphsage-on-cora-neo4j-example.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/connector/neo4j/directed-graphsage-on-cora-neo4j-example.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/connector/neo4j/directed-graphsage-on-cora-neo4j-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/connector/neo4j/directed-graphsage-on-cora-neo4j-example.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   },
   {
@@ -956,7 +960,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/connector/neo4j/directed-graphsage-on-cora-neo4j-example.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/connector/neo4j/directed-graphsage-on-cora-neo4j-example.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/connector/neo4j/directed-graphsage-on-cora-neo4j-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/connector/neo4j/directed-graphsage-on-cora-neo4j-example.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   }
  ],

--- a/demos/connector/neo4j/directed-graphsage-on-cora-neo4j-example.ipynb
+++ b/demos/connector/neo4j/directed-graphsage-on-cora-neo4j-example.ipynb
@@ -15,11 +15,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/connector/neo4j/directed-graphsage-on-cora-neo4j-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/connector/neo4j/directed-graphsage-on-cora-neo4j-example.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/connector/neo4j/directed-graphsage-on-cora-neo4j-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/connector/neo4j/directed-graphsage-on-cora-neo4j-example.ipynb)"
    ]
   },
   {
@@ -960,11 +956,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/connector/neo4j/directed-graphsage-on-cora-neo4j-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/connector/neo4j/directed-graphsage-on-cora-neo4j-example.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/connector/neo4j/directed-graphsage-on-cora-neo4j-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/connector/neo4j/directed-graphsage-on-cora-neo4j-example.ipynb)"
    ]
   }
  ],

--- a/demos/connector/neo4j/load-cora-into-neo4j.ipynb
+++ b/demos/connector/neo4j/load-cora-into-neo4j.ipynb
@@ -15,7 +15,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/connector/neo4j/load-cora-into-neo4j.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/connector/neo4j/load-cora-into-neo4j.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/connector/neo4j/load-cora-into-neo4j.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/connector/neo4j/load-cora-into-neo4j.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   },
   {
@@ -469,7 +473,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/connector/neo4j/load-cora-into-neo4j.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/connector/neo4j/load-cora-into-neo4j.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/connector/neo4j/load-cora-into-neo4j.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/connector/neo4j/load-cora-into-neo4j.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   }
  ],

--- a/demos/connector/neo4j/load-cora-into-neo4j.ipynb
+++ b/demos/connector/neo4j/load-cora-into-neo4j.ipynb
@@ -15,11 +15,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/connector/neo4j/load-cora-into-neo4j.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/connector/neo4j/load-cora-into-neo4j.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/connector/neo4j/load-cora-into-neo4j.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/connector/neo4j/load-cora-into-neo4j.ipynb)"
    ]
   },
   {
@@ -473,11 +469,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/connector/neo4j/load-cora-into-neo4j.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/connector/neo4j/load-cora-into-neo4j.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/connector/neo4j/load-cora-into-neo4j.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/connector/neo4j/load-cora-into-neo4j.ipynb)"
    ]
   }
  ],

--- a/demos/connector/neo4j/undirected-graphsage-on-cora-neo4j-example.ipynb
+++ b/demos/connector/neo4j/undirected-graphsage-on-cora-neo4j-example.ipynb
@@ -15,7 +15,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/connector/neo4j/undirected-graphsage-on-cora-neo4j-example.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/connector/neo4j/undirected-graphsage-on-cora-neo4j-example.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/connector/neo4j/undirected-graphsage-on-cora-neo4j-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/connector/neo4j/undirected-graphsage-on-cora-neo4j-example.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   },
   {
@@ -792,7 +796,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/connector/neo4j/undirected-graphsage-on-cora-neo4j-example.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/connector/neo4j/undirected-graphsage-on-cora-neo4j-example.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/connector/neo4j/undirected-graphsage-on-cora-neo4j-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/connector/neo4j/undirected-graphsage-on-cora-neo4j-example.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   }
  ],

--- a/demos/connector/neo4j/undirected-graphsage-on-cora-neo4j-example.ipynb
+++ b/demos/connector/neo4j/undirected-graphsage-on-cora-neo4j-example.ipynb
@@ -15,11 +15,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/connector/neo4j/undirected-graphsage-on-cora-neo4j-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/connector/neo4j/undirected-graphsage-on-cora-neo4j-example.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/connector/neo4j/undirected-graphsage-on-cora-neo4j-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/connector/neo4j/undirected-graphsage-on-cora-neo4j-example.ipynb)"
    ]
   },
   {
@@ -796,11 +792,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/connector/neo4j/undirected-graphsage-on-cora-neo4j-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/connector/neo4j/undirected-graphsage-on-cora-neo4j-example.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/connector/neo4j/undirected-graphsage-on-cora-neo4j-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/connector/neo4j/undirected-graphsage-on-cora-neo4j-example.ipynb)"
    ]
   }
  ],

--- a/demos/embeddings/deep-graph-infomax-cora.ipynb
+++ b/demos/embeddings/deep-graph-infomax-cora.ipynb
@@ -15,11 +15,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/deep-graph-infomax-cora.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/deep-graph-infomax-cora.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/deep-graph-infomax-cora.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/deep-graph-infomax-cora.ipynb)"
    ]
   },
   {
@@ -599,11 +595,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/deep-graph-infomax-cora.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/deep-graph-infomax-cora.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/deep-graph-infomax-cora.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/deep-graph-infomax-cora.ipynb)"
    ]
   }
  ],

--- a/demos/embeddings/deep-graph-infomax-cora.ipynb
+++ b/demos/embeddings/deep-graph-infomax-cora.ipynb
@@ -15,7 +15,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/deep-graph-infomax-cora.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/deep-graph-infomax-cora.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/deep-graph-infomax-cora.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/deep-graph-infomax-cora.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   },
   {
@@ -595,7 +599,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/deep-graph-infomax-cora.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/deep-graph-infomax-cora.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/deep-graph-infomax-cora.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/deep-graph-infomax-cora.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   }
  ],

--- a/demos/embeddings/embeddings-unsupervised-graphsage-cora.ipynb
+++ b/demos/embeddings/embeddings-unsupervised-graphsage-cora.ipynb
@@ -15,7 +15,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/embeddings-unsupervised-graphsage-cora.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/embeddings-unsupervised-graphsage-cora.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/embeddings-unsupervised-graphsage-cora.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/embeddings-unsupervised-graphsage-cora.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   },
   {
@@ -769,7 +773,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/embeddings-unsupervised-graphsage-cora.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/embeddings-unsupervised-graphsage-cora.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/embeddings-unsupervised-graphsage-cora.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/embeddings-unsupervised-graphsage-cora.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   }
  ],

--- a/demos/embeddings/embeddings-unsupervised-graphsage-cora.ipynb
+++ b/demos/embeddings/embeddings-unsupervised-graphsage-cora.ipynb
@@ -15,11 +15,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/embeddings-unsupervised-graphsage-cora.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/embeddings-unsupervised-graphsage-cora.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/embeddings-unsupervised-graphsage-cora.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/embeddings-unsupervised-graphsage-cora.ipynb)"
    ]
   },
   {
@@ -773,11 +769,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/embeddings-unsupervised-graphsage-cora.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/embeddings-unsupervised-graphsage-cora.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/embeddings-unsupervised-graphsage-cora.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/embeddings-unsupervised-graphsage-cora.ipynb)"
    ]
   }
  ],

--- a/demos/embeddings/graphwave-barbell.ipynb
+++ b/demos/embeddings/graphwave-barbell.ipynb
@@ -15,7 +15,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/graphwave-barbell.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/graphwave-barbell.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/graphwave-barbell.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/graphwave-barbell.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   },
   {
@@ -211,7 +215,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/graphwave-barbell.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/graphwave-barbell.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/graphwave-barbell.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/graphwave-barbell.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   }
  ],

--- a/demos/embeddings/graphwave-barbell.ipynb
+++ b/demos/embeddings/graphwave-barbell.ipynb
@@ -15,11 +15,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/graphwave-barbell.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/graphwave-barbell.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/graphwave-barbell.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/graphwave-barbell.ipynb)"
    ]
   },
   {
@@ -215,11 +211,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/graphwave-barbell.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/graphwave-barbell.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/graphwave-barbell.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/graphwave-barbell.ipynb)"
    ]
   }
  ],

--- a/demos/embeddings/stellargraph-attri2vec-citeseer.ipynb
+++ b/demos/embeddings/stellargraph-attri2vec-citeseer.ipynb
@@ -15,7 +15,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/stellargraph-attri2vec-citeseer.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/stellargraph-attri2vec-citeseer.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/stellargraph-attri2vec-citeseer.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/stellargraph-attri2vec-citeseer.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   },
   {
@@ -488,7 +492,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/stellargraph-attri2vec-citeseer.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/stellargraph-attri2vec-citeseer.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/stellargraph-attri2vec-citeseer.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/stellargraph-attri2vec-citeseer.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   }
  ],

--- a/demos/embeddings/stellargraph-attri2vec-citeseer.ipynb
+++ b/demos/embeddings/stellargraph-attri2vec-citeseer.ipynb
@@ -15,11 +15,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/stellargraph-attri2vec-citeseer.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/stellargraph-attri2vec-citeseer.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/stellargraph-attri2vec-citeseer.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/stellargraph-attri2vec-citeseer.ipynb)"
    ]
   },
   {
@@ -492,11 +488,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/stellargraph-attri2vec-citeseer.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/stellargraph-attri2vec-citeseer.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/stellargraph-attri2vec-citeseer.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/stellargraph-attri2vec-citeseer.ipynb)"
    ]
   }
  ],

--- a/demos/embeddings/stellargraph-metapath2vec.ipynb
+++ b/demos/embeddings/stellargraph-metapath2vec.ipynb
@@ -15,7 +15,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/stellargraph-metapath2vec.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/stellargraph-metapath2vec.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/stellargraph-metapath2vec.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/stellargraph-metapath2vec.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   },
   {
@@ -349,7 +353,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/stellargraph-metapath2vec.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/stellargraph-metapath2vec.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/stellargraph-metapath2vec.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/stellargraph-metapath2vec.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   }
  ],

--- a/demos/embeddings/stellargraph-metapath2vec.ipynb
+++ b/demos/embeddings/stellargraph-metapath2vec.ipynb
@@ -15,11 +15,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/stellargraph-metapath2vec.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/stellargraph-metapath2vec.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/stellargraph-metapath2vec.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/stellargraph-metapath2vec.ipynb)"
    ]
   },
   {
@@ -353,11 +349,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/stellargraph-metapath2vec.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/stellargraph-metapath2vec.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/stellargraph-metapath2vec.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/stellargraph-metapath2vec.ipynb)"
    ]
   }
  ],

--- a/demos/embeddings/stellargraph-node2vec.ipynb
+++ b/demos/embeddings/stellargraph-node2vec.ipynb
@@ -15,11 +15,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/stellargraph-node2vec.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/stellargraph-node2vec.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/stellargraph-node2vec.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/stellargraph-node2vec.ipynb)"
    ]
   },
   {
@@ -348,11 +344,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/stellargraph-node2vec.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/stellargraph-node2vec.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/stellargraph-node2vec.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/stellargraph-node2vec.ipynb)"
    ]
   }
  ],

--- a/demos/embeddings/stellargraph-node2vec.ipynb
+++ b/demos/embeddings/stellargraph-node2vec.ipynb
@@ -15,7 +15,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/stellargraph-node2vec.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/stellargraph-node2vec.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/stellargraph-node2vec.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/stellargraph-node2vec.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   },
   {
@@ -344,7 +348,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/stellargraph-node2vec.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/stellargraph-node2vec.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/stellargraph-node2vec.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/stellargraph-node2vec.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   }
  ],

--- a/demos/embeddings/watch-your-step-cora-demo.ipynb
+++ b/demos/embeddings/watch-your-step-cora-demo.ipynb
@@ -15,11 +15,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/watch-your-step-cora-demo.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/watch-your-step-cora-demo.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/watch-your-step-cora-demo.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/watch-your-step-cora-demo.ipynb)"
    ]
   },
   {
@@ -598,11 +594,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/watch-your-step-cora-demo.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/watch-your-step-cora-demo.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/watch-your-step-cora-demo.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/watch-your-step-cora-demo.ipynb)"
    ]
   }
  ],

--- a/demos/embeddings/watch-your-step-cora-demo.ipynb
+++ b/demos/embeddings/watch-your-step-cora-demo.ipynb
@@ -15,7 +15,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/watch-your-step-cora-demo.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/watch-your-step-cora-demo.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/watch-your-step-cora-demo.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/watch-your-step-cora-demo.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   },
   {
@@ -594,7 +598,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/watch-your-step-cora-demo.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/watch-your-step-cora-demo.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/embeddings/watch-your-step-cora-demo.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/embeddings/watch-your-step-cora-demo.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   }
  ],

--- a/demos/ensembles/ensemble-link-prediction-example.ipynb
+++ b/demos/ensembles/ensemble-link-prediction-example.ipynb
@@ -15,7 +15,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/ensembles/ensemble-link-prediction-example.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/ensembles/ensemble-link-prediction-example.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/ensembles/ensemble-link-prediction-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/ensembles/ensemble-link-prediction-example.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   },
   {
@@ -1154,7 +1158,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/ensembles/ensemble-link-prediction-example.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/ensembles/ensemble-link-prediction-example.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/ensembles/ensemble-link-prediction-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/ensembles/ensemble-link-prediction-example.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   }
  ],

--- a/demos/ensembles/ensemble-link-prediction-example.ipynb
+++ b/demos/ensembles/ensemble-link-prediction-example.ipynb
@@ -15,11 +15,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/ensembles/ensemble-link-prediction-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/ensembles/ensemble-link-prediction-example.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/ensembles/ensemble-link-prediction-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/ensembles/ensemble-link-prediction-example.ipynb)"
    ]
   },
   {
@@ -1158,11 +1154,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/ensembles/ensemble-link-prediction-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/ensembles/ensemble-link-prediction-example.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/ensembles/ensemble-link-prediction-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/ensembles/ensemble-link-prediction-example.ipynb)"
    ]
   }
  ],

--- a/demos/ensembles/ensemble-node-classification-example.ipynb
+++ b/demos/ensembles/ensemble-node-classification-example.ipynb
@@ -15,7 +15,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/ensembles/ensemble-node-classification-example.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/ensembles/ensemble-node-classification-example.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/ensembles/ensemble-node-classification-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/ensembles/ensemble-node-classification-example.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   },
   {
@@ -1241,7 +1245,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/ensembles/ensemble-node-classification-example.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/ensembles/ensemble-node-classification-example.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/ensembles/ensemble-node-classification-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/ensembles/ensemble-node-classification-example.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   }
  ],

--- a/demos/ensembles/ensemble-node-classification-example.ipynb
+++ b/demos/ensembles/ensemble-node-classification-example.ipynb
@@ -15,11 +15,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/ensembles/ensemble-node-classification-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/ensembles/ensemble-node-classification-example.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/ensembles/ensemble-node-classification-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/ensembles/ensemble-node-classification-example.ipynb)"
    ]
   },
   {
@@ -1245,11 +1241,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/ensembles/ensemble-node-classification-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/ensembles/ensemble-node-classification-example.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/ensembles/ensemble-node-classification-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/ensembles/ensemble-node-classification-example.ipynb)"
    ]
   }
  ],

--- a/demos/graph-classification/supervised-graph-classification.ipynb
+++ b/demos/graph-classification/supervised-graph-classification.ipynb
@@ -15,11 +15,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/graph-classification/supervised-graph-classification.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/graph-classification/supervised-graph-classification.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/graph-classification/supervised-graph-classification.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/graph-classification/supervised-graph-classification.ipynb)"
    ]
   },
   {
@@ -553,11 +549,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/graph-classification/supervised-graph-classification.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/graph-classification/supervised-graph-classification.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/graph-classification/supervised-graph-classification.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/graph-classification/supervised-graph-classification.ipynb)"
    ]
   }
  ],

--- a/demos/graph-classification/supervised-graph-classification.ipynb
+++ b/demos/graph-classification/supervised-graph-classification.ipynb
@@ -15,7 +15,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/graph-classification/supervised-graph-classification.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/graph-classification/supervised-graph-classification.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/graph-classification/supervised-graph-classification.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/graph-classification/supervised-graph-classification.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   },
   {
@@ -549,7 +553,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/graph-classification/supervised-graph-classification.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/graph-classification/supervised-graph-classification.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/graph-classification/supervised-graph-classification.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/graph-classification/supervised-graph-classification.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   }
  ],

--- a/demos/interpretability/gat/node-link-importance-demo-gat.ipynb
+++ b/demos/interpretability/gat/node-link-importance-demo-gat.ipynb
@@ -15,7 +15,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/interpretability/gat/node-link-importance-demo-gat.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/interpretability/gat/node-link-importance-demo-gat.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/interpretability/gat/node-link-importance-demo-gat.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/interpretability/gat/node-link-importance-demo-gat.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   },
   {
@@ -1059,7 +1063,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/interpretability/gat/node-link-importance-demo-gat.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/interpretability/gat/node-link-importance-demo-gat.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/interpretability/gat/node-link-importance-demo-gat.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/interpretability/gat/node-link-importance-demo-gat.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   }
  ],

--- a/demos/interpretability/gat/node-link-importance-demo-gat.ipynb
+++ b/demos/interpretability/gat/node-link-importance-demo-gat.ipynb
@@ -15,11 +15,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/interpretability/gat/node-link-importance-demo-gat.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/interpretability/gat/node-link-importance-demo-gat.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/interpretability/gat/node-link-importance-demo-gat.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/interpretability/gat/node-link-importance-demo-gat.ipynb)"
    ]
   },
   {
@@ -1063,11 +1059,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/interpretability/gat/node-link-importance-demo-gat.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/interpretability/gat/node-link-importance-demo-gat.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/interpretability/gat/node-link-importance-demo-gat.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/interpretability/gat/node-link-importance-demo-gat.ipynb)"
    ]
   }
  ],

--- a/demos/interpretability/gcn/hateful-twitters-interpretability.ipynb
+++ b/demos/interpretability/gcn/hateful-twitters-interpretability.ipynb
@@ -15,11 +15,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/interpretability/gcn/hateful-twitters-interpretability.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/interpretability/gcn/hateful-twitters-interpretability.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/interpretability/gcn/hateful-twitters-interpretability.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/interpretability/gcn/hateful-twitters-interpretability.ipynb)"
    ]
   },
   {
@@ -2165,11 +2161,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/interpretability/gcn/hateful-twitters-interpretability.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/interpretability/gcn/hateful-twitters-interpretability.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/interpretability/gcn/hateful-twitters-interpretability.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/interpretability/gcn/hateful-twitters-interpretability.ipynb)"
    ]
   }
  ],

--- a/demos/interpretability/gcn/hateful-twitters-interpretability.ipynb
+++ b/demos/interpretability/gcn/hateful-twitters-interpretability.ipynb
@@ -15,7 +15,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/interpretability/gcn/hateful-twitters-interpretability.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/interpretability/gcn/hateful-twitters-interpretability.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/interpretability/gcn/hateful-twitters-interpretability.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/interpretability/gcn/hateful-twitters-interpretability.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   },
   {
@@ -2161,7 +2165,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/interpretability/gcn/hateful-twitters-interpretability.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/interpretability/gcn/hateful-twitters-interpretability.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/interpretability/gcn/hateful-twitters-interpretability.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/interpretability/gcn/hateful-twitters-interpretability.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   }
  ],

--- a/demos/interpretability/gcn/node-link-importance-demo-gcn-sparse.ipynb
+++ b/demos/interpretability/gcn/node-link-importance-demo-gcn-sparse.ipynb
@@ -15,7 +15,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/interpretability/gcn/node-link-importance-demo-gcn-sparse.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/interpretability/gcn/node-link-importance-demo-gcn-sparse.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/interpretability/gcn/node-link-importance-demo-gcn-sparse.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/interpretability/gcn/node-link-importance-demo-gcn-sparse.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   },
   {
@@ -1059,7 +1063,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/interpretability/gcn/node-link-importance-demo-gcn-sparse.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/interpretability/gcn/node-link-importance-demo-gcn-sparse.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/interpretability/gcn/node-link-importance-demo-gcn-sparse.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/interpretability/gcn/node-link-importance-demo-gcn-sparse.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   }
  ],

--- a/demos/interpretability/gcn/node-link-importance-demo-gcn-sparse.ipynb
+++ b/demos/interpretability/gcn/node-link-importance-demo-gcn-sparse.ipynb
@@ -15,11 +15,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/interpretability/gcn/node-link-importance-demo-gcn-sparse.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/interpretability/gcn/node-link-importance-demo-gcn-sparse.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/interpretability/gcn/node-link-importance-demo-gcn-sparse.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/interpretability/gcn/node-link-importance-demo-gcn-sparse.ipynb)"
    ]
   },
   {
@@ -1063,11 +1059,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/interpretability/gcn/node-link-importance-demo-gcn-sparse.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/interpretability/gcn/node-link-importance-demo-gcn-sparse.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/interpretability/gcn/node-link-importance-demo-gcn-sparse.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/interpretability/gcn/node-link-importance-demo-gcn-sparse.ipynb)"
    ]
   }
  ],

--- a/demos/interpretability/gcn/node-link-importance-demo-gcn.ipynb
+++ b/demos/interpretability/gcn/node-link-importance-demo-gcn.ipynb
@@ -15,7 +15,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/interpretability/gcn/node-link-importance-demo-gcn.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/interpretability/gcn/node-link-importance-demo-gcn.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/interpretability/gcn/node-link-importance-demo-gcn.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/interpretability/gcn/node-link-importance-demo-gcn.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   },
   {
@@ -1085,7 +1089,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/interpretability/gcn/node-link-importance-demo-gcn.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/interpretability/gcn/node-link-importance-demo-gcn.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/interpretability/gcn/node-link-importance-demo-gcn.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/interpretability/gcn/node-link-importance-demo-gcn.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   }
  ],

--- a/demos/interpretability/gcn/node-link-importance-demo-gcn.ipynb
+++ b/demos/interpretability/gcn/node-link-importance-demo-gcn.ipynb
@@ -15,11 +15,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/interpretability/gcn/node-link-importance-demo-gcn.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/interpretability/gcn/node-link-importance-demo-gcn.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/interpretability/gcn/node-link-importance-demo-gcn.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/interpretability/gcn/node-link-importance-demo-gcn.ipynb)"
    ]
   },
   {
@@ -1089,11 +1085,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/interpretability/gcn/node-link-importance-demo-gcn.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/interpretability/gcn/node-link-importance-demo-gcn.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/interpretability/gcn/node-link-importance-demo-gcn.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/interpretability/gcn/node-link-importance-demo-gcn.ipynb)"
    ]
   }
  ],

--- a/demos/link-prediction/attri2vec/stellargraph-attri2vec-DBLP.ipynb
+++ b/demos/link-prediction/attri2vec/stellargraph-attri2vec-DBLP.ipynb
@@ -15,7 +15,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/attri2vec/stellargraph-attri2vec-DBLP.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/attri2vec/stellargraph-attri2vec-DBLP.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/attri2vec/stellargraph-attri2vec-DBLP.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/attri2vec/stellargraph-attri2vec-DBLP.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   },
   {
@@ -965,7 +969,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/attri2vec/stellargraph-attri2vec-DBLP.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/attri2vec/stellargraph-attri2vec-DBLP.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/attri2vec/stellargraph-attri2vec-DBLP.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/attri2vec/stellargraph-attri2vec-DBLP.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   }
  ],

--- a/demos/link-prediction/attri2vec/stellargraph-attri2vec-DBLP.ipynb
+++ b/demos/link-prediction/attri2vec/stellargraph-attri2vec-DBLP.ipynb
@@ -15,11 +15,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/attri2vec/stellargraph-attri2vec-DBLP.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/attri2vec/stellargraph-attri2vec-DBLP.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/attri2vec/stellargraph-attri2vec-DBLP.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/attri2vec/stellargraph-attri2vec-DBLP.ipynb)"
    ]
   },
   {
@@ -969,11 +965,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/attri2vec/stellargraph-attri2vec-DBLP.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/attri2vec/stellargraph-attri2vec-DBLP.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/attri2vec/stellargraph-attri2vec-DBLP.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/attri2vec/stellargraph-attri2vec-DBLP.ipynb)"
    ]
   }
  ],

--- a/demos/link-prediction/gcn/cora-gcn-links-example.ipynb
+++ b/demos/link-prediction/gcn/cora-gcn-links-example.ipynb
@@ -15,11 +15,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/gcn/cora-gcn-links-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/gcn/cora-gcn-links-example.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/gcn/cora-gcn-links-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/gcn/cora-gcn-links-example.ipynb)"
    ]
   },
   {
@@ -649,11 +645,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/gcn/cora-gcn-links-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/gcn/cora-gcn-links-example.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/gcn/cora-gcn-links-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/gcn/cora-gcn-links-example.ipynb)"
    ]
   }
  ],

--- a/demos/link-prediction/gcn/cora-gcn-links-example.ipynb
+++ b/demos/link-prediction/gcn/cora-gcn-links-example.ipynb
@@ -15,7 +15,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/gcn/cora-gcn-links-example.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/gcn/cora-gcn-links-example.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/gcn/cora-gcn-links-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/gcn/cora-gcn-links-example.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   },
   {
@@ -645,7 +649,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/gcn/cora-gcn-links-example.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/gcn/cora-gcn-links-example.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/gcn/cora-gcn-links-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/gcn/cora-gcn-links-example.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   }
  ],

--- a/demos/link-prediction/graphsage/cora-links-example.ipynb
+++ b/demos/link-prediction/graphsage/cora-links-example.ipynb
@@ -15,11 +15,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/graphsage/cora-links-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/graphsage/cora-links-example.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/graphsage/cora-links-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/graphsage/cora-links-example.ipynb)"
    ]
   },
   {
@@ -628,11 +624,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/graphsage/cora-links-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/graphsage/cora-links-example.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/graphsage/cora-links-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/graphsage/cora-links-example.ipynb)"
    ]
   }
  ],

--- a/demos/link-prediction/graphsage/cora-links-example.ipynb
+++ b/demos/link-prediction/graphsage/cora-links-example.ipynb
@@ -15,7 +15,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/graphsage/cora-links-example.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/graphsage/cora-links-example.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/graphsage/cora-links-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/graphsage/cora-links-example.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   },
   {
@@ -624,7 +628,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/graphsage/cora-links-example.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/graphsage/cora-links-example.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/graphsage/cora-links-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/graphsage/cora-links-example.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   }
  ],

--- a/demos/link-prediction/hinsage/movielens-recommender.ipynb
+++ b/demos/link-prediction/hinsage/movielens-recommender.ipynb
@@ -15,7 +15,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/hinsage/movielens-recommender.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/hinsage/movielens-recommender.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/hinsage/movielens-recommender.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/hinsage/movielens-recommender.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   },
   {
@@ -780,7 +784,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/hinsage/movielens-recommender.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/hinsage/movielens-recommender.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/hinsage/movielens-recommender.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/hinsage/movielens-recommender.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   }
  ],

--- a/demos/link-prediction/hinsage/movielens-recommender.ipynb
+++ b/demos/link-prediction/hinsage/movielens-recommender.ipynb
@@ -15,11 +15,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/hinsage/movielens-recommender.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/hinsage/movielens-recommender.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/hinsage/movielens-recommender.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/hinsage/movielens-recommender.ipynb)"
    ]
   },
   {
@@ -784,11 +780,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/hinsage/movielens-recommender.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/hinsage/movielens-recommender.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/hinsage/movielens-recommender.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/hinsage/movielens-recommender.ipynb)"
    ]
   }
  ],

--- a/demos/link-prediction/knowledge-graphs/complex.ipynb
+++ b/demos/link-prediction/knowledge-graphs/complex.ipynb
@@ -15,7 +15,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/knowledge-graphs/complex.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/knowledge-graphs/complex.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/knowledge-graphs/complex.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/knowledge-graphs/complex.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   },
   {
@@ -1001,7 +1005,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/knowledge-graphs/complex.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/knowledge-graphs/complex.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/knowledge-graphs/complex.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/knowledge-graphs/complex.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   }
  ],

--- a/demos/link-prediction/knowledge-graphs/complex.ipynb
+++ b/demos/link-prediction/knowledge-graphs/complex.ipynb
@@ -15,11 +15,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/knowledge-graphs/complex.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/knowledge-graphs/complex.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/knowledge-graphs/complex.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/knowledge-graphs/complex.ipynb)"
    ]
   },
   {
@@ -1005,11 +1001,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/knowledge-graphs/complex.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/knowledge-graphs/complex.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/knowledge-graphs/complex.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/knowledge-graphs/complex.ipynb)"
    ]
   }
  ],

--- a/demos/link-prediction/knowledge-graphs/distmult.ipynb
+++ b/demos/link-prediction/knowledge-graphs/distmult.ipynb
@@ -15,7 +15,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/knowledge-graphs/distmult.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/knowledge-graphs/distmult.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/knowledge-graphs/distmult.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/knowledge-graphs/distmult.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   },
   {
@@ -778,7 +782,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/knowledge-graphs/distmult.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/knowledge-graphs/distmult.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/knowledge-graphs/distmult.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/knowledge-graphs/distmult.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   }
  ],

--- a/demos/link-prediction/knowledge-graphs/distmult.ipynb
+++ b/demos/link-prediction/knowledge-graphs/distmult.ipynb
@@ -15,11 +15,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/knowledge-graphs/distmult.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/knowledge-graphs/distmult.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/knowledge-graphs/distmult.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/knowledge-graphs/distmult.ipynb)"
    ]
   },
   {
@@ -782,11 +778,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/knowledge-graphs/distmult.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/knowledge-graphs/distmult.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/knowledge-graphs/distmult.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/knowledge-graphs/distmult.ipynb)"
    ]
   }
  ],

--- a/demos/link-prediction/random-walks/cora-lp-demo.ipynb
+++ b/demos/link-prediction/random-walks/cora-lp-demo.ipynb
@@ -15,11 +15,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/random-walks/cora-lp-demo.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/random-walks/cora-lp-demo.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/random-walks/cora-lp-demo.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/random-walks/cora-lp-demo.ipynb)"
    ]
   },
   {
@@ -826,11 +822,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/random-walks/cora-lp-demo.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/random-walks/cora-lp-demo.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/random-walks/cora-lp-demo.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/random-walks/cora-lp-demo.ipynb)"
    ]
   }
  ],

--- a/demos/link-prediction/random-walks/cora-lp-demo.ipynb
+++ b/demos/link-prediction/random-walks/cora-lp-demo.ipynb
@@ -15,7 +15,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/random-walks/cora-lp-demo.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/random-walks/cora-lp-demo.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/random-walks/cora-lp-demo.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/random-walks/cora-lp-demo.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   },
   {
@@ -822,7 +826,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/random-walks/cora-lp-demo.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/random-walks/cora-lp-demo.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/random-walks/cora-lp-demo.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/random-walks/cora-lp-demo.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   }
  ],

--- a/demos/link-prediction/random-walks/ctdne-link-prediction.ipynb
+++ b/demos/link-prediction/random-walks/ctdne-link-prediction.ipynb
@@ -15,11 +15,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/random-walks/ctdne-link-prediction.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/random-walks/ctdne-link-prediction.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/random-walks/ctdne-link-prediction.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/random-walks/ctdne-link-prediction.ipynb)"
    ]
   },
   {
@@ -731,11 +727,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/random-walks/ctdne-link-prediction.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/random-walks/ctdne-link-prediction.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/random-walks/ctdne-link-prediction.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/random-walks/ctdne-link-prediction.ipynb)"
    ]
   }
  ],

--- a/demos/link-prediction/random-walks/ctdne-link-prediction.ipynb
+++ b/demos/link-prediction/random-walks/ctdne-link-prediction.ipynb
@@ -15,7 +15,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/random-walks/ctdne-link-prediction.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/random-walks/ctdne-link-prediction.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/random-walks/ctdne-link-prediction.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/random-walks/ctdne-link-prediction.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   },
   {
@@ -727,7 +731,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/random-walks/ctdne-link-prediction.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/random-walks/ctdne-link-prediction.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/link-prediction/random-walks/ctdne-link-prediction.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/link-prediction/random-walks/ctdne-link-prediction.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   }
  ],

--- a/demos/node-classification/attri2vec/attri2vec-citeseer-node-classification-example.ipynb
+++ b/demos/node-classification/attri2vec/attri2vec-citeseer-node-classification-example.ipynb
@@ -15,7 +15,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/attri2vec/attri2vec-citeseer-node-classification-example.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/attri2vec/attri2vec-citeseer-node-classification-example.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/attri2vec/attri2vec-citeseer-node-classification-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/attri2vec/attri2vec-citeseer-node-classification-example.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   },
   {
@@ -620,7 +624,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/attri2vec/attri2vec-citeseer-node-classification-example.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/attri2vec/attri2vec-citeseer-node-classification-example.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/attri2vec/attri2vec-citeseer-node-classification-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/attri2vec/attri2vec-citeseer-node-classification-example.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   }
  ],

--- a/demos/node-classification/attri2vec/attri2vec-citeseer-node-classification-example.ipynb
+++ b/demos/node-classification/attri2vec/attri2vec-citeseer-node-classification-example.ipynb
@@ -15,11 +15,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/attri2vec/attri2vec-citeseer-node-classification-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/attri2vec/attri2vec-citeseer-node-classification-example.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/attri2vec/attri2vec-citeseer-node-classification-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/attri2vec/attri2vec-citeseer-node-classification-example.ipynb)"
    ]
   },
   {
@@ -624,11 +620,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/attri2vec/attri2vec-citeseer-node-classification-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/attri2vec/attri2vec-citeseer-node-classification-example.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/attri2vec/attri2vec-citeseer-node-classification-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/attri2vec/attri2vec-citeseer-node-classification-example.ipynb)"
    ]
   }
  ],

--- a/demos/node-classification/cluster-gcn/cluster-gcn-node-classification.ipynb
+++ b/demos/node-classification/cluster-gcn/cluster-gcn-node-classification.ipynb
@@ -15,7 +15,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/cluster-gcn/cluster-gcn-node-classification.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/cluster-gcn/cluster-gcn-node-classification.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/cluster-gcn/cluster-gcn-node-classification.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/cluster-gcn/cluster-gcn-node-classification.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   },
   {
@@ -1175,7 +1179,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/cluster-gcn/cluster-gcn-node-classification.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/cluster-gcn/cluster-gcn-node-classification.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/cluster-gcn/cluster-gcn-node-classification.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/cluster-gcn/cluster-gcn-node-classification.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   }
  ],

--- a/demos/node-classification/cluster-gcn/cluster-gcn-node-classification.ipynb
+++ b/demos/node-classification/cluster-gcn/cluster-gcn-node-classification.ipynb
@@ -15,11 +15,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/cluster-gcn/cluster-gcn-node-classification.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/cluster-gcn/cluster-gcn-node-classification.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/cluster-gcn/cluster-gcn-node-classification.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/cluster-gcn/cluster-gcn-node-classification.ipynb)"
    ]
   },
   {
@@ -1179,11 +1175,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/cluster-gcn/cluster-gcn-node-classification.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/cluster-gcn/cluster-gcn-node-classification.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/cluster-gcn/cluster-gcn-node-classification.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/cluster-gcn/cluster-gcn-node-classification.ipynb)"
    ]
   }
  ],

--- a/demos/node-classification/gat/gat-cora-node-classification-example.ipynb
+++ b/demos/node-classification/gat/gat-cora-node-classification-example.ipynb
@@ -15,7 +15,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/gat/gat-cora-node-classification-example.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/gat/gat-cora-node-classification-example.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/gat/gat-cora-node-classification-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/gat/gat-cora-node-classification-example.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   },
   {
@@ -1042,7 +1046,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/gat/gat-cora-node-classification-example.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/gat/gat-cora-node-classification-example.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/gat/gat-cora-node-classification-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/gat/gat-cora-node-classification-example.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   }
  ],

--- a/demos/node-classification/gat/gat-cora-node-classification-example.ipynb
+++ b/demos/node-classification/gat/gat-cora-node-classification-example.ipynb
@@ -15,11 +15,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/gat/gat-cora-node-classification-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/gat/gat-cora-node-classification-example.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/gat/gat-cora-node-classification-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/gat/gat-cora-node-classification-example.ipynb)"
    ]
   },
   {
@@ -1046,11 +1042,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/gat/gat-cora-node-classification-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/gat/gat-cora-node-classification-example.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/gat/gat-cora-node-classification-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/gat/gat-cora-node-classification-example.ipynb)"
    ]
   }
  ],

--- a/demos/node-classification/gcn/gcn-cora-node-classification-example.ipynb
+++ b/demos/node-classification/gcn/gcn-cora-node-classification-example.ipynb
@@ -22,8 +22,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<!-- work around https://github.com/spatialaudio/nbsphinx/issues/450 -->\n",
-    "\n",
     "> This demo explains how to do node classification using the StellarGraph library. [See all other demos](../../README.md).\n",
     "\n",
     "[The StellarGraph library](https://github.com/stellargraph/stellargraph) supports many state-of-the-art machine learning (ML) algorithms on [graphs](https://en.wikipedia.org/wiki/Graph_%28discrete_mathematics%29). In this notebook, we'll be training a model to predict the class or label of a node, commonly known as node classification. We will also use the resulting model to compute vector embeddings for each node.\n",

--- a/demos/node-classification/gcn/gcn-cora-node-classification-example.ipynb
+++ b/demos/node-classification/gcn/gcn-cora-node-classification-example.ipynb
@@ -22,6 +22,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<!-- work around https://github.com/spatialaudio/nbsphinx/issues/450 -->\n",
+    "\n",
     "> This demo explains how to do node classification using the StellarGraph library. [See all other demos](../../README.md).\n",
     "\n",
     "[The StellarGraph library](https://github.com/stellargraph/stellargraph) supports many state-of-the-art machine learning (ML) algorithms on [graphs](https://en.wikipedia.org/wiki/Graph_%28discrete_mathematics%29). In this notebook, we'll be training a model to predict the class or label of a node, commonly known as node classification. We will also use the resulting model to compute vector embeddings for each node.\n",

--- a/demos/node-classification/gcn/gcn-cora-node-classification-example.ipynb
+++ b/demos/node-classification/gcn/gcn-cora-node-classification-example.ipynb
@@ -15,7 +15,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/gcn/gcn-cora-node-classification-example.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/gcn/gcn-cora-node-classification-example.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/gcn/gcn-cora-node-classification-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/gcn/gcn-cora-node-classification-example.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   },
   {
@@ -1328,7 +1332,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/gcn/gcn-cora-node-classification-example.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/gcn/gcn-cora-node-classification-example.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/gcn/gcn-cora-node-classification-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/gcn/gcn-cora-node-classification-example.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   }
  ],

--- a/demos/node-classification/gcn/gcn-cora-node-classification-example.ipynb
+++ b/demos/node-classification/gcn/gcn-cora-node-classification-example.ipynb
@@ -15,11 +15,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/gcn/gcn-cora-node-classification-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/gcn/gcn-cora-node-classification-example.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/gcn/gcn-cora-node-classification-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/gcn/gcn-cora-node-classification-example.ipynb)"
    ]
   },
   {
@@ -1332,11 +1328,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/gcn/gcn-cora-node-classification-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/gcn/gcn-cora-node-classification-example.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/gcn/gcn-cora-node-classification-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/gcn/gcn-cora-node-classification-example.ipynb)"
    ]
   }
  ],

--- a/demos/node-classification/graphsage/directed-graphsage-on-cora-example.ipynb
+++ b/demos/node-classification/graphsage/directed-graphsage-on-cora-example.ipynb
@@ -15,11 +15,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/graphsage/directed-graphsage-on-cora-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/graphsage/directed-graphsage-on-cora-example.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/graphsage/directed-graphsage-on-cora-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/graphsage/directed-graphsage-on-cora-example.ipynb)"
    ]
   },
   {
@@ -914,11 +910,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/graphsage/directed-graphsage-on-cora-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/graphsage/directed-graphsage-on-cora-example.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/graphsage/directed-graphsage-on-cora-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/graphsage/directed-graphsage-on-cora-example.ipynb)"
    ]
   }
  ],

--- a/demos/node-classification/graphsage/directed-graphsage-on-cora-example.ipynb
+++ b/demos/node-classification/graphsage/directed-graphsage-on-cora-example.ipynb
@@ -15,7 +15,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/graphsage/directed-graphsage-on-cora-example.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/graphsage/directed-graphsage-on-cora-example.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/graphsage/directed-graphsage-on-cora-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/graphsage/directed-graphsage-on-cora-example.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   },
   {
@@ -910,7 +914,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/graphsage/directed-graphsage-on-cora-example.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/graphsage/directed-graphsage-on-cora-example.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/graphsage/directed-graphsage-on-cora-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/graphsage/directed-graphsage-on-cora-example.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   }
  ],

--- a/demos/node-classification/graphsage/graphsage-cora-node-classification-example.ipynb
+++ b/demos/node-classification/graphsage/graphsage-cora-node-classification-example.ipynb
@@ -15,7 +15,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/graphsage/graphsage-cora-node-classification-example.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/graphsage/graphsage-cora-node-classification-example.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/graphsage/graphsage-cora-node-classification-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/graphsage/graphsage-cora-node-classification-example.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   },
   {
@@ -889,7 +893,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/graphsage/graphsage-cora-node-classification-example.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/graphsage/graphsage-cora-node-classification-example.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/graphsage/graphsage-cora-node-classification-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/graphsage/graphsage-cora-node-classification-example.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   }
  ],

--- a/demos/node-classification/graphsage/graphsage-cora-node-classification-example.ipynb
+++ b/demos/node-classification/graphsage/graphsage-cora-node-classification-example.ipynb
@@ -15,11 +15,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/graphsage/graphsage-cora-node-classification-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/graphsage/graphsage-cora-node-classification-example.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/graphsage/graphsage-cora-node-classification-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/graphsage/graphsage-cora-node-classification-example.ipynb)"
    ]
   },
   {
@@ -893,11 +889,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/graphsage/graphsage-cora-node-classification-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/graphsage/graphsage-cora-node-classification-example.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/graphsage/graphsage-cora-node-classification-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/graphsage/graphsage-cora-node-classification-example.ipynb)"
    ]
   }
  ],

--- a/demos/node-classification/graphsage/graphsage-pubmed-inductive-node-classification-example.ipynb
+++ b/demos/node-classification/graphsage/graphsage-pubmed-inductive-node-classification-example.ipynb
@@ -15,11 +15,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/graphsage/graphsage-pubmed-inductive-node-classification-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/graphsage/graphsage-pubmed-inductive-node-classification-example.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/graphsage/graphsage-pubmed-inductive-node-classification-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/graphsage/graphsage-pubmed-inductive-node-classification-example.ipynb)"
    ]
   },
   {
@@ -1057,11 +1053,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/graphsage/graphsage-pubmed-inductive-node-classification-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/graphsage/graphsage-pubmed-inductive-node-classification-example.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/graphsage/graphsage-pubmed-inductive-node-classification-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/graphsage/graphsage-pubmed-inductive-node-classification-example.ipynb)"
    ]
   }
  ],

--- a/demos/node-classification/graphsage/graphsage-pubmed-inductive-node-classification-example.ipynb
+++ b/demos/node-classification/graphsage/graphsage-pubmed-inductive-node-classification-example.ipynb
@@ -15,7 +15,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/graphsage/graphsage-pubmed-inductive-node-classification-example.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/graphsage/graphsage-pubmed-inductive-node-classification-example.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/graphsage/graphsage-pubmed-inductive-node-classification-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/graphsage/graphsage-pubmed-inductive-node-classification-example.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   },
   {
@@ -1053,7 +1057,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/graphsage/graphsage-pubmed-inductive-node-classification-example.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/graphsage/graphsage-pubmed-inductive-node-classification-example.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/graphsage/graphsage-pubmed-inductive-node-classification-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/graphsage/graphsage-pubmed-inductive-node-classification-example.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   }
  ],

--- a/demos/node-classification/node2vec/stellargraph-node2vec-node-classification.ipynb
+++ b/demos/node-classification/node2vec/stellargraph-node2vec-node-classification.ipynb
@@ -15,11 +15,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/node2vec/stellargraph-node2vec-node-classification.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/node2vec/stellargraph-node2vec-node-classification.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/node2vec/stellargraph-node2vec-node-classification.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/node2vec/stellargraph-node2vec-node-classification.ipynb)"
    ]
   },
   {
@@ -494,11 +490,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/node2vec/stellargraph-node2vec-node-classification.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/node2vec/stellargraph-node2vec-node-classification.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/node2vec/stellargraph-node2vec-node-classification.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/node2vec/stellargraph-node2vec-node-classification.ipynb)"
    ]
   }
  ],

--- a/demos/node-classification/node2vec/stellargraph-node2vec-node-classification.ipynb
+++ b/demos/node-classification/node2vec/stellargraph-node2vec-node-classification.ipynb
@@ -15,7 +15,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/node2vec/stellargraph-node2vec-node-classification.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/node2vec/stellargraph-node2vec-node-classification.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/node2vec/stellargraph-node2vec-node-classification.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/node2vec/stellargraph-node2vec-node-classification.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   },
   {
@@ -490,7 +494,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/node2vec/stellargraph-node2vec-node-classification.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/node2vec/stellargraph-node2vec-node-classification.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/node2vec/stellargraph-node2vec-node-classification.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/node2vec/stellargraph-node2vec-node-classification.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   }
  ],

--- a/demos/node-classification/node2vec/stellargraph-node2vec-weighted-random-walks.ipynb
+++ b/demos/node-classification/node2vec/stellargraph-node2vec-weighted-random-walks.ipynb
@@ -15,11 +15,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/node2vec/stellargraph-node2vec-weighted-random-walks.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/node2vec/stellargraph-node2vec-weighted-random-walks.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/node2vec/stellargraph-node2vec-weighted-random-walks.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/node2vec/stellargraph-node2vec-weighted-random-walks.ipynb)"
    ]
   },
   {
@@ -1179,11 +1175,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/node2vec/stellargraph-node2vec-weighted-random-walks.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/node2vec/stellargraph-node2vec-weighted-random-walks.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/node2vec/stellargraph-node2vec-weighted-random-walks.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/node2vec/stellargraph-node2vec-weighted-random-walks.ipynb)"
    ]
   }
  ],

--- a/demos/node-classification/node2vec/stellargraph-node2vec-weighted-random-walks.ipynb
+++ b/demos/node-classification/node2vec/stellargraph-node2vec-weighted-random-walks.ipynb
@@ -15,7 +15,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/node2vec/stellargraph-node2vec-weighted-random-walks.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/node2vec/stellargraph-node2vec-weighted-random-walks.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/node2vec/stellargraph-node2vec-weighted-random-walks.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/node2vec/stellargraph-node2vec-weighted-random-walks.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   },
   {
@@ -1175,7 +1179,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/node2vec/stellargraph-node2vec-weighted-random-walks.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/node2vec/stellargraph-node2vec-weighted-random-walks.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/node2vec/stellargraph-node2vec-weighted-random-walks.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/node2vec/stellargraph-node2vec-weighted-random-walks.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   }
  ],

--- a/demos/node-classification/ppnp/ppnp-cora-node-classification-example.ipynb
+++ b/demos/node-classification/ppnp/ppnp-cora-node-classification-example.ipynb
@@ -15,11 +15,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/ppnp/ppnp-cora-node-classification-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/ppnp/ppnp-cora-node-classification-example.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/ppnp/ppnp-cora-node-classification-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/ppnp/ppnp-cora-node-classification-example.ipynb)"
    ]
   },
   {
@@ -2033,11 +2029,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/ppnp/ppnp-cora-node-classification-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/ppnp/ppnp-cora-node-classification-example.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/ppnp/ppnp-cora-node-classification-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/ppnp/ppnp-cora-node-classification-example.ipynb)"
    ]
   }
  ],

--- a/demos/node-classification/ppnp/ppnp-cora-node-classification-example.ipynb
+++ b/demos/node-classification/ppnp/ppnp-cora-node-classification-example.ipynb
@@ -15,7 +15,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/ppnp/ppnp-cora-node-classification-example.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/ppnp/ppnp-cora-node-classification-example.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/ppnp/ppnp-cora-node-classification-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/ppnp/ppnp-cora-node-classification-example.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   },
   {
@@ -2029,7 +2033,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/ppnp/ppnp-cora-node-classification-example.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/ppnp/ppnp-cora-node-classification-example.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/ppnp/ppnp-cora-node-classification-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/ppnp/ppnp-cora-node-classification-example.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   }
  ],

--- a/demos/node-classification/rgcn/rgcn-aifb-node-classification-example.ipynb
+++ b/demos/node-classification/rgcn/rgcn-aifb-node-classification-example.ipynb
@@ -15,7 +15,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/rgcn/rgcn-aifb-node-classification-example.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/rgcn/rgcn-aifb-node-classification-example.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/rgcn/rgcn-aifb-node-classification-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/rgcn/rgcn-aifb-node-classification-example.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   },
   {
@@ -473,7 +477,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/rgcn/rgcn-aifb-node-classification-example.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/rgcn/rgcn-aifb-node-classification-example.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/rgcn/rgcn-aifb-node-classification-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/rgcn/rgcn-aifb-node-classification-example.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   }
  ],

--- a/demos/node-classification/rgcn/rgcn-aifb-node-classification-example.ipynb
+++ b/demos/node-classification/rgcn/rgcn-aifb-node-classification-example.ipynb
@@ -15,11 +15,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/rgcn/rgcn-aifb-node-classification-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/rgcn/rgcn-aifb-node-classification-example.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/rgcn/rgcn-aifb-node-classification-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/rgcn/rgcn-aifb-node-classification-example.ipynb)"
    ]
   },
   {
@@ -477,11 +473,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/rgcn/rgcn-aifb-node-classification-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/rgcn/rgcn-aifb-node-classification-example.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/rgcn/rgcn-aifb-node-classification-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/rgcn/rgcn-aifb-node-classification-example.ipynb)"
    ]
   }
  ],

--- a/demos/node-classification/sgc/sgc-node-classification-example.ipynb
+++ b/demos/node-classification/sgc/sgc-node-classification-example.ipynb
@@ -15,7 +15,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/sgc/sgc-node-classification-example.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/sgc/sgc-node-classification-example.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/sgc/sgc-node-classification-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/sgc/sgc-node-classification-example.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   },
   {
@@ -907,7 +911,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/sgc/sgc-node-classification-example.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/sgc/sgc-node-classification-example.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/sgc/sgc-node-classification-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/sgc/sgc-node-classification-example.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   }
  ],

--- a/demos/node-classification/sgc/sgc-node-classification-example.ipynb
+++ b/demos/node-classification/sgc/sgc-node-classification-example.ipynb
@@ -15,11 +15,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/sgc/sgc-node-classification-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/sgc/sgc-node-classification-example.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/sgc/sgc-node-classification-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/sgc/sgc-node-classification-example.ipynb)"
    ]
   },
   {
@@ -911,11 +907,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/sgc/sgc-node-classification-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/sgc/sgc-node-classification-example.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/node-classification/sgc/sgc-node-classification-example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/node-classification/sgc/sgc-node-classification-example.ipynb)"
    ]
   }
  ],

--- a/demos/spatio-temporal/gcn-lstm-LA.ipynb
+++ b/demos/spatio-temporal/gcn-lstm-LA.ipynb
@@ -15,7 +15,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/spatio-temporal/gcn-lstm-LA.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/spatio-temporal/gcn-lstm-LA.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/spatio-temporal/gcn-lstm-LA.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/spatio-temporal/gcn-lstm-LA.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   },
   {
@@ -645,7 +649,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/spatio-temporal/gcn-lstm-LA.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/spatio-temporal/gcn-lstm-LA.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/spatio-temporal/gcn-lstm-LA.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/spatio-temporal/gcn-lstm-LA.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   }
  ],

--- a/demos/spatio-temporal/gcn-lstm-LA.ipynb
+++ b/demos/spatio-temporal/gcn-lstm-LA.ipynb
@@ -15,11 +15,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/spatio-temporal/gcn-lstm-LA.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/spatio-temporal/gcn-lstm-LA.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/spatio-temporal/gcn-lstm-LA.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/spatio-temporal/gcn-lstm-LA.ipynb)"
    ]
   },
   {
@@ -649,11 +645,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/spatio-temporal/gcn-lstm-LA.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/spatio-temporal/gcn-lstm-LA.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/spatio-temporal/gcn-lstm-LA.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/spatio-temporal/gcn-lstm-LA.ipynb)"
    ]
   }
  ],

--- a/demos/use-cases/hateful-twitters.ipynb
+++ b/demos/use-cases/hateful-twitters.ipynb
@@ -15,7 +15,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/use-cases/hateful-twitters.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/use-cases/hateful-twitters.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/use-cases/hateful-twitters.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/use-cases/hateful-twitters.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   },
   {
@@ -2868,7 +2872,11 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/use-cases/hateful-twitters.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/use-cases/hateful-twitters.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/use-cases/hateful-twitters.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/use-cases/hateful-twitters.ipynb)\n",
+    "\n",
+    "</div>"
    ]
   }
  ],

--- a/demos/use-cases/hateful-twitters.ipynb
+++ b/demos/use-cases/hateful-twitters.ipynb
@@ -15,11 +15,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/use-cases/hateful-twitters.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/use-cases/hateful-twitters.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/use-cases/hateful-twitters.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/use-cases/hateful-twitters.ipynb)"
    ]
   },
   {
@@ -2872,11 +2868,7 @@
     ]
    },
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/use-cases/hateful-twitters.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/use-cases/hateful-twitters.ipynb)\n",
-    "\n",
-    "</div>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/use-cases/hateful-twitters.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/use-cases/hateful-twitters.ipynb)"
    ]
   }
  ],

--- a/scripts/format_notebooks.py
+++ b/scripts/format_notebooks.py
@@ -182,13 +182,7 @@ if 'google.colab' in sys.modules:
         return f"[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)]({self._colab_url(notebook_path)})"
 
     def _badge_markdown(self, notebook_path):
-        # GitHub and nbsphinx (and so on) have special support for these alert classes
-        return f"""\
-<div class="alert alert-info">
-
-Run the master version of this notebook: {self._binder_badge(notebook_path)} {self._colab_badge(notebook_path)}
-
-</div>"""
+        return f"> Run the master version of this notebook: {self._binder_badge(notebook_path)} {self._colab_badge(notebook_path)}"
 
     def preprocess(self, nb, resources):
         notebook_path = resources[self.path_resource_name]

--- a/scripts/format_notebooks.py
+++ b/scripts/format_notebooks.py
@@ -176,10 +176,19 @@ if 'google.colab' in sys.modules:
         return f"https://colab.research.google.com/github/stellargraph/stellargraph/blob/{self.git_branch}/{notebook_path}"
 
     def _binder_badge(self, notebook_path):
-        return f'<a href="{self._binder_url(notebook_path)}" alt="Open In Binder" target="_parent"><img src="https://mybinder.org/badge_logo.svg"/></a>'
+        return f"[![Open In Binder](https://mybinder.org/badge_logo.svg)]({self._binder_url(notebook_path)})"
 
     def _colab_badge(self, notebook_path):
-        return f'<a href="{self._colab_url(notebook_path)}" alt="Open In Colab" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg"/></a>'
+        return f"[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)]({self._colab_url(notebook_path)})"
+
+    def _badge_markdown(self, notebook_path):
+        # GitHub and nbsphinx (and so on) have special support for these alert classes
+        return f"""\
+<div class="alert alert-info">
+
+Run the master version of this notebook: {self._binder_badge(notebook_path)} {self._colab_badge(notebook_path)}
+
+</div>"""
 
     def preprocess(self, nb, resources):
         notebook_path = resources[self.path_resource_name]
@@ -188,9 +197,7 @@ if 'google.colab' in sys.modules:
                 f"WARNING: Notebook file path of {notebook_path} didn't start with {self.demos_path_prefix}, and may result in bad links to cloud runners."
             )
         self.remove_tagged_cells_from_notebook(nb)
-        # due to limited HTML-in-markdown support in Jupyter, place badges in an html table (paragraph doesn't work)
-        badge_markdown = f"<table><tr><td>Run the master version of this notebook:</td><td>{self._binder_badge(notebook_path)}</td><td>{self._colab_badge(notebook_path)}</td></tr></table>"
-        badge_cell = nbformat.v4.new_markdown_cell(badge_markdown)
+        badge_cell = nbformat.v4.new_markdown_cell(self._badge_markdown(notebook_path))
         self.tag_cell(badge_cell)
         # the badges go after the first cell, unless the first cell is code
         if nb.cells[0].cell_type == "code":


### PR DESCRIPTION
The raw HTML table was not converting to reStructuredText through `nbsphinx` (which, I think, uses `jupyter nbconvert --to=rst`, which uses pandoc). The output lost the links + images (see more details about `pandoc` directly at the end of this PR).

This PR updates the links to be normal markdown links + images, which ensures they do get converted correctly. To distinguish these links from normal body text, these are formatted as a block-quote (`> ...`). This gives acceptable (not great) formatting on each of the major platforms one might be using to look at this:

- Jupyter locally:  ![image](https://user-images.githubusercontent.com/1203825/80667021-5a91ca00-8ae1-11ea-94b2-da2403712163.png)
- [Github](https://github.com/stellargraph/stellargraph/blob/2972637ec3b75c7ab7bc6a7a96697489b03f62fd/demos/basics/loading-networkx.ipynb) ![image](https://user-images.githubusercontent.com/1203825/80666975-42ba4600-8ae1-11ea-9aeb-d2f501aa41a9.png)
- [nbviewer](https://nbviewer.jupyter.org/github/stellargraph/stellargraph/blob/2972637ec3b75c7ab7bc6a7a96697489b03f62fd/demos/basics/loading-networkx.ipynb) ![image](https://user-images.githubusercontent.com/1203825/80666998-4cdc4480-8ae1-11ea-8cc5-bac0ad70cd59.png)
- [Read the Docs](https://stellargraph--1398.org.readthedocs.build/en/1398/demos/basics/loading-networkx.html)
![image](https://user-images.githubusercontent.com/1203825/80666964-3635ed80-8ae1-11ea-9fe0-5b6af0905c5a.png)


Note that both Github and nbviewer have CSS that forces images to be formatted as block elements, and so they're positioned separately (instead of inline elements as is the default).

We can potentially improve the Read the Docs formatting with custom CSS or some post-processing (similar to #1401).

See: #1293

<details><summary>Reproducing pandoc's behaviour</summary>

```shell
echo '<a href="https://example.com">Y</a> <img src="example.com" />' \
  | pandoc --from=markdown --to=rst
```

The output is just `Y` by itself, the link and image both completely disappear.

From [their docs](https://pandoc.org/MANUAL.html#raw-html)

> The raw HTML is passed through unchanged in HTML, S5, Slidy, Slideous, DZSlides, EPUB, Markdown, CommonMark, Emacs Org mode, and Textile output, and suppressed in other formats.

That doesn't include reStructuredText.

Strangely enough (and in contradiction), it does seem to pass through the various `<table>` tags. The converted rST for the original table is contains the text and the table-related tags, but nothing else:

```rst
.. raw:: html

   <table>

.. raw:: html

   <tr>

.. raw:: html

   <td>

Run the master version of this notebook:

.. raw:: html

   </td>

.. raw:: html

   <td>

.. raw:: html

   </td>

.. raw:: html

   <td>

.. raw:: html

   </td>

.. raw:: html

   </tr>

.. raw:: html

   </table>
```

</details>