### PR TITLE
Make metapath walk faster by grouping adjacency lists by node type

### DIFF
--- a/stellargraph/core/convert.py
+++ b/stellargraph/core/convert.py
@@ -22,7 +22,7 @@ import warnings
 import numpy as np
 import pandas as pd
 
-from ..globalvar import SOURCE, TARGET, WEIGHT, TYPE_ATTR_NAME
+from ..globalvar import SOURCE, TARGET, WEIGHT, TYPE_ATTR_NAME, NODE_TYPE_DEFAULT
 from .element_data import NodeData, EdgeData
 from .validation import comma_sep, require_dataframe_has_columns
 
@@ -216,8 +216,8 @@ def convert_edges(
     target_column,
     weight_column,
     type_column,
-    node_data,
-    node_default_type,
+    node_data=None,
+    node_default_type=NODE_TYPE_DEFAULT,
 ):
     selected = {
         source_column: SOURCE,

--- a/stellargraph/core/convert.py
+++ b/stellargraph/core/convert.py
@@ -216,6 +216,8 @@ def convert_edges(
     target_column,
     weight_column,
     type_column,
+    node_data,
+    node_default_type,
 ):
     selected = {
         source_column: SOURCE,
@@ -245,7 +247,7 @@ def convert_edges(
             f"{converter.name()}: expected weight column {weight_column!r} to be numeric, found dtype '{weight_col.dtype}'"
         )
 
-    return EdgeData(edges, type_starts)
+    return EdgeData(edges, type_starts, node_data, node_default_type)
 
 
 SingleTypeNodeIdsAndFeatures = namedtuple(

--- a/stellargraph/core/element_data.py
+++ b/stellargraph/core/element_data.py
@@ -20,7 +20,7 @@ import numpy as np
 import pandas as pd
 import scipy.sparse as sps
 
-from ..globalvar import SOURCE, TARGET, WEIGHT, TYPE_ATTR_NAME
+from ..globalvar import SOURCE, TARGET, WEIGHT, TYPE_ATTR_NAME, NODE_TYPE_DEFAULT
 from .validation import require_dataframe_has_columns, comma_sep
 from .utils import is_real_iterable
 
@@ -316,7 +316,9 @@ class EdgeData(ElementData):
 
     _SHARED_REQUIRED_COLUMNS = [SOURCE, TARGET, WEIGHT]
 
-    def __init__(self, shared, type_starts, node_data, node_default_type):
+    def __init__(
+        self, shared, type_starts, node_data=None, node_default_type=NODE_TYPE_DEFAULT
+    ):
         super().__init__(shared, type_starts)
 
         # cache these columns to avoid having to do more method and dict look-ups

--- a/stellargraph/core/element_data.py
+++ b/stellargraph/core/element_data.py
@@ -311,7 +311,9 @@ class EdgeData(ElementData):
     Args:
         shared (pandas DataFrame): information for the edges
         type_starts (list of tuple of type name, int): the starting iloc of the edges of each type within ``shared``
-        node_data (NodeData): node data
+        node_data (NodeData, optional): node data containing node types and IDs. If not provided, all nodes are assumed
+            to be of default type.
+        node_default_type (string, optional): default node type to use when there's no node data provided
     """
 
     _SHARED_REQUIRED_COLUMNS = [SOURCE, TARGET, WEIGHT]
@@ -327,6 +329,8 @@ class EdgeData(ElementData):
         self.weights = self._column(WEIGHT)
 
         if node_data is not None:
+            # if node_data is provided, we should validate all the node IDs that occur in the edge data, and use the
+            # node types when building the adjacency lists grouped by type
             try:
                 source_ilocs = node_data.ids.to_iloc(
                     self.sources, smaller_type=False, strict=True
@@ -347,6 +351,7 @@ class EdgeData(ElementData):
             self.source_types = node_data.type_of_iloc(source_ilocs)
             self.target_types = node_data.type_of_iloc(target_ilocs)
         else:
+            # use default node type
             self.source_types = (node_default_type for _ in range(len(self.sources)))
             self.target_types = (node_default_type for _ in range(len(self.sources)))
 

--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -590,6 +590,7 @@ class StellarGraph:
                 output is a named tuple with fields `node` (the node ID) and `weight` (the edge weight)
             edge_types (list of hashable, optional): If provided, only traverse the graph
                 via the provided edge types when collecting neighbours.
+            other_node_type (hashable, optional): If provided, only return neighbors of a specific node type
 
         Returns:
             iterable: The neighbouring nodes.
@@ -605,7 +606,11 @@ class StellarGraph:
         )
 
     def in_nodes(
-        self, node: Any, include_edge_weight=False, edge_types=None
+        self,
+        node: Any,
+        include_edge_weight=False,
+        edge_types=None,
+        other_node_type=None,
     ) -> Iterable[Any]:
         """
         Obtains the collection of neighbouring nodes with edges
@@ -618,6 +623,7 @@ class StellarGraph:
                 output is a named tuple with fields `node` (the node ID) and `weight` (the edge weight)
             edge_types (list of hashable, optional): If provided, only traverse the graph
                 via the provided edge types when collecting neighbours.
+            other_node_type (hashable, optional): If provided, only return neighbors of a specific node type
 
         Returns:
             iterable: The neighbouring in-nodes.
@@ -625,15 +631,24 @@ class StellarGraph:
         if not self.is_directed():
             # all edges are both incoming and outgoing for undirected graphs
             return self.neighbors(
-                node, include_edge_weight=include_edge_weight, edge_types=edge_types
+                node,
+                include_edge_weight=include_edge_weight,
+                edge_types=edge_types,
+                other_node_type=other_node_type,
             )
 
-        ilocs = self._edges.edge_ilocs(node, ins=True, outs=False)
+        ilocs = self._edges.edge_ilocs(
+            node, ins=True, outs=False, other_node_type=other_node_type
+        )
         source = self._edges.sources[ilocs]
         return self._transform_edges(source, ilocs, include_edge_weight, edge_types)
 
     def out_nodes(
-        self, node: Any, include_edge_weight=False, edge_types=None
+        self,
+        node: Any,
+        include_edge_weight=False,
+        edge_types=None,
+        other_node_type=None,
     ) -> Iterable[Any]:
         """
         Obtains the collection of neighbouring nodes with edges
@@ -646,6 +661,7 @@ class StellarGraph:
                 output is a named tuple with fields `node` (the node ID) and `weight` (the edge weight)
             edge_types (list of hashable, optional): If provided, only traverse the graph
                 via the provided edge types when collecting neighbours.
+            other_node_type (hashable, optional): If provided, only return neighbors of a specific node type
 
         Returns:
             iterable: The neighbouring out-nodes.
@@ -653,10 +669,15 @@ class StellarGraph:
         if not self.is_directed():
             # all edges are both incoming and outgoing for undirected graphs
             return self.neighbors(
-                node, include_edge_weight=include_edge_weight, edge_types=edge_types
+                node,
+                include_edge_weight=include_edge_weight,
+                edge_types=edge_types,
+                other_node_type=other_node_type,
             )
 
-        ilocs = self._edges.edge_ilocs(node, ins=False, outs=True)
+        ilocs = self._edges.edge_ilocs(
+            node, ins=False, outs=True, other_node_type=other_node_type
+        )
         target = self._edges.targets[ilocs]
         return self._transform_edges(target, ilocs, include_edge_weight, edge_types)
 

--- a/stellargraph/data/explorer.py
+++ b/stellargraph/data/explorer.py
@@ -536,50 +536,44 @@ class UniformRandomMetaPathWalk(RandomWalk):
         rs = self._get_random_state(seed)
 
         walks = []
+        metapaths_for_node_type = self._augment_and_group_metapaths(metapaths, length)
 
         for node in nodes:
             # retrieve node type
-            label = self.graph.node_type(node)
-            filtered_metapaths = [
-                metapath
-                for metapath in metapaths
-                if len(metapath) > 0 and metapath[0] == label
-            ]
+            node_type = self.graph.node_type(node)
+            filtered_metapaths = metapaths_for_node_type[node_type]
 
             for metapath in filtered_metapaths:
-                # augment metapath to be length long
-                # if (
-                #     len(metapath) == 1
-                # ):  # special case for random walks like in a homogeneous graphs
-                #     metapath = metapath * length
-                # else:
-                metapath = metapath[1:] * ((length // (len(metapath) - 1)) + 1)
                 for _ in range(n):
-                    walk = (
-                        []
-                    )  # holds the walk data for this walk; first node is the starting node
+                    # holds the walk data for this walk; first node is the starting node
+                    walk = []
                     current_node = node
-                    for d in range(length):
+                    for target_node_type in metapath:
                         walk.append(current_node)
-                        # d+1 can also be used to index metapath to retrieve the node type for the next step in the walk
-                        neighbours = self.graph.neighbors(current_node)
-                        # filter these by node type
-                        neighbours = [
-                            n_node
-                            for n_node in neighbours
-                            if self.graph.node_type(n_node) == metapath[d]
-                        ]
+                        neighbours = self.graph.neighbors(
+                            current_node, other_node_type=target_node_type
+                        )
+
+                        # if no neighbours of the required type as dictated by the metapath exist, then stop.
                         if len(neighbours) == 0:
-                            # if no neighbours of the required type as dictated by the metapath exist, then stop.
                             break
+
                         # select one of the neighbours uniformly at random
-                        current_node = rs.choice(
-                            neighbours
-                        )  # the next node in the walk
+                        current_node = rs.choice(neighbours)
 
                     walks.append(walk)  # store the walk
 
         return walks
+
+    def _augment_and_group_metapaths(self, metapaths, walk_length):
+        def augment_metapath(m):
+            return m[1:] * ((walk_length // (len(m) - 1)) + 1)
+
+        metapaths_for_node_type = defaultdict(list)
+        for metapath in metapaths:
+            metapaths_for_node_type[metapath[0]].append(augment_metapath(metapath))
+
+        return metapaths_for_node_type
 
     def _check_metapath_values(self, metapaths):
         """

--- a/stellargraph/data/explorer.py
+++ b/stellargraph/data/explorer.py
@@ -546,10 +546,9 @@ class UniformRandomMetaPathWalk(RandomWalk):
             for metapath in filtered_metapaths:
                 for _ in range(n):
                     # holds the walk data for this walk; first node is the starting node
-                    walk = []
                     current_node = node
+                    walk = [current_node]
                     for target_node_type in metapath:
-                        walk.append(current_node)
                         neighbours = self.graph.neighbors(
                             current_node, other_node_type=target_node_type
                         )
@@ -560,6 +559,7 @@ class UniformRandomMetaPathWalk(RandomWalk):
 
                         # select one of the neighbours uniformly at random
                         current_node = rs.choice(neighbours)
+                        walk.append(current_node)
 
                     walks.append(walk)  # store the walk
 
@@ -567,7 +567,7 @@ class UniformRandomMetaPathWalk(RandomWalk):
 
     def _augment_and_group_metapaths(self, metapaths, walk_length):
         def augment_metapath(m):
-            return m[1:] * ((walk_length // (len(m) - 1)) + 1)
+            return np.resize(m[1:], walk_length - 1)
 
         metapaths_for_node_type = defaultdict(list)
         for metapath in metapaths:

--- a/tests/core/test_graph.py
+++ b/tests/core/test_graph.py
@@ -821,6 +821,24 @@ def test_in_nodes_unweighted_hom():
     )
 
 
+@pytest.mark.parametrize("other_node_type,expected", [("A", [0, 0]), ("B", [2, 3])])
+def test_neighbors_other_node_type(other_node_type, expected):
+    graph = example_weighted_hin()
+    assert_items_equal(graph.neighbors(1, other_node_type=other_node_type), expected)
+
+
+@pytest.mark.parametrize("other_node_type,expected", [("A", [0, 0]), ("B", [])])
+def test_in_nodes_other_node_type(other_node_type, expected):
+    graph = example_weighted_hin()
+    assert_items_equal(graph.in_nodes(1, other_node_type=other_node_type), expected)
+
+
+@pytest.mark.parametrize("other_node_type,expected", [("A", []), ("B", [2, 3])])
+def test_out_nodes_other_node_type(other_node_type, expected):
+    graph = example_weighted_hin()
+    assert_items_equal(graph.out_nodes(1, other_node_type=other_node_type), expected)
+
+
 def test_out_nodes_weighted_hin():
     graph = example_weighted_hin()
     assert_items_equal(graph.out_nodes(1), [2, 3])


### PR DESCRIPTION
This mainly updates `EdgeData` to store an inner set of dicts within each adjacency list, so that we group adjacency elements by their node type. This could probably be useful for other heterogeneous algorithms that want to traverse the graph either for random walks or SAGE-type sampling - currently it's just been used for Metapath2Vec specifically. At its current state in this PR, the speedup for Metapath2vec looks pretty great, but `graph.neighbours` becomes quite a bit slower for homogeneous graphs

Benchmark against `develop` for metapath walk:
```
----------------------------------------------------------------------------------------------------------------- benchmark: 2 tests -----------------------------------------------------------------------------------------------------------------
Name (time in us)                                                   Min                    Max                   Mean                StdDev                 Median                   IQR            Outliers         OPS            Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_benchmark_uniformrandommetapathwalk (NOW)                 409.0180 (1.0)       1,415.0450 (1.0)         508.5108 (1.0)         89.4222 (1.0)         480.2570 (1.0)         38.4945 (1.0)       126;171  1,966.5264 (1.0)        1349           1
test_benchmark_uniformrandommetapathwalk (0007_1cca6b6)     11,785.8720 (28.82)    20,027.5200 (14.15)    15,493.4845 (30.47)    1,442.1304 (16.13)    15,570.4430 (32.42)    1,697.6358 (44.10)        15;3     64.5433 (0.03)         61           1
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

Things do get a bit slower for just getting neighbours without caring about types, and constructing the stellargraph object
```
---------------------------------------------------------------------------------------- benchmark 'StellarGraph neighbours': 2 tests ----------------------------------------------------------------------------------------
Name (time in us)                                     Min                   Max                  Mean              StdDev              Median                IQR            Outliers         OPS            Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_benchmark_get_neighbours (0009_1cca6b6)     673.0350 (1.0)      1,753.2520 (1.0)        772.2845 (1.0)      112.2834 (1.0)      738.3375 (1.0)      46.6965 (1.0)       120;151  1,294.8595 (1.0)        1244           1
test_benchmark_get_neighbours (NOW)              874.3200 (1.30)     1,957.4830 (1.12)     1,030.1057 (1.33)     156.3577 (1.39)     985.7585 (1.34)     78.7610 (1.69)       96;114    970.7742 (0.75)        920           1
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```
```
------------------------------------------------------------------------------------- benchmark 'StellarGraph creation (time)': 12 tests ------------------------------------------------------------------------------------
Name (time in ms)                                              Min                 Max               Mean             StdDev             Median               IQR            Outliers       OPS            Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_benchmark_creation[None-0-0] (0011_1cca6b6)            7.0827 (1.0)       10.4290 (1.0)       7.7464 (1.0)       0.5459 (1.01)      7.5999 (1.0)      0.3738 (1.0)         15;10  129.0918 (1.0)         123           1
test_benchmark_creation[None-0-0] (NOW)                     7.2598 (1.03)      11.9819 (1.15)      7.8674 (1.02)      0.5400 (1.0)       7.7635 (1.02)     0.4122 (1.10)         11;5  127.1069 (0.98)        114           1
test_benchmark_creation[None-100-200] (0011_1cca6b6)        7.7215 (1.09)      11.0146 (1.06)      8.6099 (1.11)      0.5706 (1.06)      8.4670 (1.11)     0.4709 (1.26)         18;5  116.1448 (0.90)         95           1
test_benchmark_creation[None-100-200] (NOW)                 8.2406 (1.16)      80.2710 (7.70)      9.9185 (1.28)      7.0318 (13.02)     8.9742 (1.18)     0.4729 (1.26)         1;12  100.8218 (0.78)        104           1
test_benchmark_creation[100-0-0] (0011_1cca6b6)             9.9753 (1.41)      16.8219 (1.61)     10.9606 (1.41)      0.8742 (1.62)     10.7575 (1.42)     0.8113 (2.17)         12;4   91.2356 (0.71)         91           1
test_benchmark_creation[100-0-0] (NOW)                     10.0131 (1.41)      14.2590 (1.37)     10.8740 (1.40)      0.8288 (1.53)     10.5627 (1.39)     0.7808 (2.09)          9;7   91.9623 (0.71)         91           1
test_benchmark_creation[100-100-200] (0011_1cca6b6)        10.3021 (1.45)      14.3739 (1.38)     11.7725 (1.52)      0.8119 (1.50)     11.6448 (1.53)     1.1646 (3.12)         18;2   84.9437 (0.66)         79           1
test_benchmark_creation[100-100-200] (NOW)                 11.6161 (1.64)      27.1939 (2.61)     14.2690 (1.84)      3.7345 (6.92)     12.6178 (1.66)     2.2522 (6.02)        10;10   70.0822 (0.54)         78           1
test_benchmark_creation[None-1000-5000] (0011_1cca6b6)     18.3149 (2.59)     100.4675 (9.63)     21.3902 (2.76)     11.4734 (21.25)    19.6913 (2.59)     1.2455 (3.33)          1;4   46.7505 (0.36)         50           1
test_benchmark_creation[100-1000-5000] (0011_1cca6b6)      20.9809 (2.96)      25.4421 (2.44)     22.9116 (2.96)      1.2696 (2.35)     22.8039 (3.00)     2.0631 (5.52)         16;0   43.6460 (0.34)         37           1
test_benchmark_creation[None-1000-5000] (NOW)              30.8860 (4.36)     114.9587 (11.02)    45.6015 (5.89)     29.9989 (55.56)    32.7245 (4.31)     5.6656 (15.16)         4;4   21.9291 (0.17)         26           1
test_benchmark_creation[100-1000-5000] (NOW)               34.9050 (4.93)     148.0317 (14.19)    56.4356 (7.29)     38.1269 (70.61)    37.4651 (4.93)     8.3243 (22.27)         4;4   17.7193 (0.14)         21           1
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```