### PR TITLE
Rewrite doc links to StellarGraph's Read the Docs to be internal

### DIFF
--- a/demos/basics/loading-networkx.ipynb
+++ b/demos/basics/loading-networkx.ipynb
@@ -39,7 +39,7 @@
     "\n",
     "> StellarGraph supports loading data from many sources with all sorts of data preprocessing, via [Pandas](https://pandas.pydata.org) DataFrames, [NumPy](https://www.numpy.org) arrays, [Neo4j](https://neo4j.com) and [NetworkX](https://networkx.github.io) graphs. See [all loading demos](README.md) for more details.\n",
     "\n",
-    "The [documentation](https://stellargraph.readthedocs.io/en/latest/api.html#stellargraph.StellarGraph.from_networkx) for the `StellarGraph.from_networkx` static method includes a compressed reminder of everything discussed in this file, as well as explanations of all of the parameters.\n",
+    "The [documentation](https://stellargraph.readthedocs.io/en/stable/api.html#stellargraph.StellarGraph.from_networkx) for the `StellarGraph.from_networkx` static method includes a compressed reminder of everything discussed in this file, as well as explanations of all of the parameters.\n",
     "\n",
     "The `StellarGraph` class is available at the top level of the `stellargraph` library:"
    ]
@@ -1038,7 +1038,7 @@
     "\n",
     "You hopefully now know more about building a `StellarGraph` in various configurations via NetworkX.\n",
     "\n",
-    "Revisit this document to use as a reminder, or [documentation](https://stellargraph.readthedocs.io/en/latest/api.html#stellargraph.StellarGraph.from_networkx) for the `StellarGraph.from_networkx` static method.\n",
+    "Revisit this document to use as a reminder, or [documentation](https://stellargraph.readthedocs.io/en/stable/api.html#stellargraph.StellarGraph.from_networkx) for the `StellarGraph.from_networkx` static method.\n",
     "\n",
     "Once you've loaded your data, you can start doing machine learning: a good place to start is the [demo of the GCN algorithm on the Cora dataset for node classification](../node-classification/gcn-node-classification.ipynb). Additionally, StellarGraph includes [many other demos of other algorithms, solving other tasks](../README.md)."
    ]

--- a/demos/node-classification/gcn-node-classification.ipynb
+++ b/demos/node-classification/gcn-node-classification.ipynb
@@ -125,7 +125,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can retrieve a `StellarGraph` graph object holding this Cora dataset using the `Cora` loader ([docs](https://stellargraph.readthedocs.io/en/stable/api.html#stellargraph.datasets.datasets.Cora)) from the `datasets` submodule ([docs](https://stellargraph.readthedocs.io/en/stable/api.html#module-stellargraph.datasets.datasets)). It also provides us with the ground-truth node subject classes. This function is implemented using Pandas, see [the \"Loading data into StellarGraph from Pandas\" notebook](../basics/loading-pandas.ipynb) for details.\n",
+    "We can retrieve a `StellarGraph` graph object holding this Cora dataset using the `Cora` loader ([docs](https://stellargraph.readthedocs.io/en/stable/api.html#stellargraph.datasets.Cora)) from the `datasets` submodule ([docs](https://stellargraph.readthedocs.io/en/stable/api.html#module-stellargraph.datasets)). It also provides us with the ground-truth node subject classes. This function is implemented using Pandas, see [the \"Loading data into StellarGraph from Pandas\" notebook](../basics/loading-pandas.ipynb) for details.\n",
     "\n",
     "(Note: Cora is a citation network, which is a directed graph, but, like most users of this graph, we ignore the edge direction and treat it as undirected.)"
    ]
@@ -464,7 +464,7 @@
     "- the layers themselves, such as graph convolution, [dropout](https://www.tensorflow.org/api_docs/python/tf/keras/layers/Dropout) and even [conventional dense layers](https://www.tensorflow.org/api_docs/python/tf/keras/layers/Dense)\n",
     "- a data generator to convert the core graph structure and node features into a format that can be fed into the Keras model for training or prediction\n",
     "\n",
-    "GCN is a full-batch model and we're doing node classification here, which means the `FullBatchNodeGenerator` class ([docs](https://stellargraph.readthedocs.io/en/latest/api.html#stellargraph.mapper.FullBatchNodeGenerator)) is the appropriate generator for our task. StellarGraph has many generators in order to support all [its many models and tasks](../README.md).\n",
+    "GCN is a full-batch model and we're doing node classification here, which means the `FullBatchNodeGenerator` class ([docs](https://stellargraph.readthedocs.io/en/stable/api.html#stellargraph.mapper.FullBatchNodeGenerator)) is the appropriate generator for our task. StellarGraph has many generators in order to support all [its many models and tasks](../README.md).\n",
     "\n",
     "Specifying the `method='gcn'` argument to the `FullBatchNodeGenerator` means it will yield data appropriate for the GCN algorithm specifically, by using the [normalized graph Laplacian matrix](https://en.wikipedia.org/wiki/Laplacian_matrix#Symmetric_normalized_Laplacian) to capture the graph structure."
    ]
@@ -490,7 +490,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A generator just encodes the information required to produce the model inputs. Calling the `flow` method ([docs](https://stellargraph.readthedocs.io/en/latest/api.html#stellargraph.mapper.FullBatchNodeGenerator.flow)) with a set of nodes and their true labels produces an object that can be used to train the model, on those nodes and labels that were specified. We created a training set above, so that's what we're going to use here."
+    "A generator just encodes the information required to produce the model inputs. Calling the `flow` method ([docs](https://stellargraph.readthedocs.io/en/stable/api.html#stellargraph.mapper.FullBatchNodeGenerator.flow)) with a set of nodes and their true labels produces an object that can be used to train the model, on those nodes and labels that were specified. We created a training set above, so that's what we're going to use here."
    ]
   },
   {
@@ -506,7 +506,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we can specify our machine learning model by building a stack of layers. We can use StellarGraph's `GCN` class ([docs](https://stellargraph.readthedocs.io/en/latest/api.html#stellargraph.layer.gcn.GCN)), which packages up the creation of this stack of [graph convolution](https://stellargraph.readthedocs.io/en/latest/api.html#stellargraph.layer.gcn.GraphConvolution) and [dropout](https://www.tensorflow.org/api_docs/python/tf/keras/layers/Dropout) layers. We can specify a few parameters to control this:\n",
+    "Now we can specify our machine learning model by building a stack of layers. We can use StellarGraph's `GCN` class ([docs](https://stellargraph.readthedocs.io/en/stable/api.html#stellargraph.layer.GCN)), which packages up the creation of this stack of [graph convolution](https://stellargraph.readthedocs.io/en/stable/api.html#stellargraph.layer.GraphConvolution) and [dropout](https://www.tensorflow.org/api_docs/python/tf/keras/layers/Dropout) layers. We can specify a few parameters to control this:\n",
     "\n",
     " * `layer_sizes`: the number of hidden GCN layers and their sizes. In this case, two GCN layers with 16 units each.\n",
     " * `activations`: the activation to apply to each GCN layer's output. In this case, [RelU](https://en.wikipedia.org/wiki/Rectifier_\\(neural_networks\\)) for both layers.\n",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -247,6 +247,7 @@ class RewriteLinks(docutils.transforms.Transform):
             refuri = node.get("refuri")
             parsed = urllib.parse.urlparse(refuri)
 
+            new_components = None
             if parsed.netloc == "" and parsed.path.endswith("README.md"):
                 # the notebooks include links to READMEs so that the links work locally and on
                 # GitHub, but on Read the Docs, the equivalent files are 'index', not 'README'.
@@ -259,7 +260,28 @@ class RewriteLinks(docutils.transforms.Transform):
                     parsed.query,
                     parsed.fragment,
                 )
+            elif parsed.netloc == "stellargraph.readthedocs.io":
+                # rewrite deep links to the Read the Docs documentation to
+                components = parsed.path.split("/", 3)
+                if len(components) == 4:
+                    empty, en, version, rest = components
+                    assert empty == ""
+                    assert en == "en"
 
+                    new_path = "/" + rest
+                else:
+                    new_path = "/"
+
+                new_components = (
+                    "", # scheme
+                    "", # netloc
+                    new_path,
+                    parsed.params,
+                    parsed.query,
+                    parsed.fragment,
+                )
+
+            if new_components is not None:
                 node["refuri"] = urllib.parse.urlunparse(new_components)
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -297,7 +297,7 @@ class RewriteLinks(docutils.transforms.Transform):
             html_suffix = ".html"
             new_domain = "std"
             new_type = "doc"
-            new_target = "/" + rest[:-len(html_suffix)]
+            new_target = "/" + rest[: -len(html_suffix)]
 
         xref = sphinx.addnodes.pending_xref(
             refdomain=new_domain,


### PR DESCRIPTION
This extends our Sphinx link rewriting to also rewrite links to the published RTD docs `https://stellargraph.readthedocs.io/en/stable/...` to be relative internal links.

This rewriting allows us to use external links in documentation that might be viewed outside of RTD (doc strings, notebooks), but still have the benefits of internal links:

- more consistent experience with less "version jumping"
- checking for validity

This PR also does some validation of these URLs: that they always point to `https://stellargraph.readthedocs.io/en/stable/...`, not other versions or languages like `https://stellargraph.readthedocs.io/en/latest/...`.

Examples:

- `ClusterNodeGenerator` has a link to the Cluster-GCN demo as a full URL: https://github.com/stellargraph/stellargraph/blob/61b17d9ff7ec589273b545b58d4529192eeecad5/stellargraph/mapper/mini_batch_node_generators.py#L49 
  Being a full URL means that that's it's clickable (and loads a nicely rendered form) when someone does `help(ClusterNodeGenerator)`  (or `?ClusterNodeGenerator` in a Jupyter cell), whereas the internal/Sphinx form ``:doc:`/demos/node-classification/cluster-gcn-node-classification` `` would not be. The URL means that one can change versions unexpectedly, e.g. clicking on the link in [the develop (`.../latest/...`) docs](https://stellargraph.readthedocs.io/en/latest/api.html#stellargraph.mapper.ClusterNodeGenerator) will switch to the stable docs, and similarly for looking at any other version (such as a specific version like `.../1.0.0/...` or a PR build).
  
  With this PR, the link is rewritten inside Sphinx to be an internal reference, and so the link stays within a single version: e.g. https://stellargraph--1404.org.readthedocs.build/en/1404/api.html#stellargraph.mapper.ClusterNodeGenerator goes to  https://stellargraph--1404.org.readthedocs.build/en/1404/demos/node-classification/cluster-gcn-node-classification.html
- The GCN node classification demo links to various API elements, like the Cora datasets: https://github.com/stellargraph/stellargraph/blob/61b17d9ff7ec589273b545b58d4529192eeecad5/demos/node-classification/gcn-node-classification.ipynb#L128
   As with `ClusterNodeGenerator`, having full URLs are good for someone viewing the notebook outside of the Sphinx rendering on RTD (e.g. editing it), but is unfortunate when on RTD. Current stable: https://stellargraph.readthedocs.io/en/stable/demos/node-classification/gcn-node-classification.html#2.-Creating-the-GCN-layers ("We can use StellarGraph’s GCN class (docs), which packages up the creation of this stack of graph convolution ...") Note that these actually switch from `.../stable/...` to `.../latest/...`.

   This PR also rewrites these links to the corresponding Sphinx form, like ``:py:mod:`...` `` for modules (which have `module-` in their URL fragment) or ``:py:any:`...` `` for other elements (which aren't distinguished in the URL fragment): https://stellargraph--1404.org.readthedocs.build/en/1404/demos/node-classification/gcn-node-classification.html#2.-Creating-the-GCN-layers 

   This actually also catches two invalid links, where we rewrote the documentation paths from `stellargraph.layer.gcn.GCN` to `stellargraph.layer.GCN` (in #1157).
- The README has a link to the GCN node classification demo and the demo indexing: ['its extended narrated notebook' & 'many more algorithms ...'](https://github.com/stellargraph/stellargraph#training-and-evaluation). Both of these rewritten in the corresponding part of the README on RTD: https://stellargraph--1404.org.readthedocs.build/en/1404/README.html#training-and-evaluation

See: #1402