### PR TITLE
Set the right permissions in stellargraph docker image

### DIFF
--- a/docker/stellargraph/Dockerfile
+++ b/docker/stellargraph/Dockerfile
@@ -1,14 +1,16 @@
 FROM python:3.6-slim
 
 RUN adduser --disabled-password --gecos '' stellar
+# If WORKDIR creates the directory, it's owned by root, but it needs to be owned by stellar
+RUN mkdir /build && chown stellar:stellar /build
 USER stellar
 ENV PATH=${PATH}:/home/stellar/.local/bin
 
 WORKDIR /build
 # Copy requirements first to install dependencies without having to recompute when the source code
 # changes
-COPY --chown=stellar setup.py /build/setup.py
-COPY --chown=stellar stellargraph/version.py /build/stellargraph/version.py
+COPY --chown=stellar:stellar setup.py /build/setup.py
+COPY --chown=stellar:stellar stellargraph/version.py /build/stellargraph/version.py
 # hadolint ignore=DL3013
 RUN echo "+++ installing dependencies" \
     # install stellargraph without any source code to install its dependencies, and then immediately
@@ -19,7 +21,7 @@ RUN echo "+++ installing dependencies" \
     && pip uninstall -y stellargraph
 
 # Now copy the code in, to install stellargraph itself
-COPY --chown=stellar . /build/
+COPY --chown=stellar:stellar . /build
 # hadolint ignore=DL3013
 RUN echo "+++ installing stellargraph" && pip install --no-cache-dir /build/ --user
 WORKDIR /home/stellar

--- a/docker/stellargraph/Dockerfile
+++ b/docker/stellargraph/Dockerfile
@@ -21,7 +21,7 @@ RUN echo "+++ installing dependencies" \
     && pip uninstall -y stellargraph
 
 # Now copy the code in, to install stellargraph itself
-COPY --chown=stellar:stellar . /build
+COPY --chown=stellar:stellar . /build/
 # hadolint ignore=DL3013
 RUN echo "+++ installing stellargraph" && pip install --no-cache-dir /build/ --user
 WORKDIR /home/stellar

--- a/docker/stellargraph/Dockerfile
+++ b/docker/stellargraph/Dockerfile
@@ -7,8 +7,8 @@ ENV PATH=${PATH}:/home/stellar/.local/bin
 WORKDIR /build
 # Copy requirements first to install dependencies without having to recompute when the source code
 # changes
-COPY setup.py /build/setup.py
-COPY stellargraph/version.py /build/stellargraph/version.py
+COPY --chown=stellar setup.py /build/setup.py
+COPY --chown=stellar stellargraph/version.py /build/stellargraph/version.py
 # hadolint ignore=DL3013
 RUN echo "+++ installing dependencies" \
     # install stellargraph without any source code to install its dependencies, and then immediately
@@ -19,7 +19,7 @@ RUN echo "+++ installing dependencies" \
     && pip uninstall -y stellargraph
 
 # Now copy the code in, to install stellargraph itself
-COPY . /build/
+COPY --chown=stellar . /build/
 # hadolint ignore=DL3013
 RUN echo "+++ installing stellargraph" && pip install --no-cache-dir /build/ --user
 WORKDIR /home/stellar


### PR DESCRIPTION
A new release of the `python:3.6-slim` docker image was released (https://github.com/docker-library/python/commit/bbb44b3ab29fb1d60dbe59c5a7ea4af868657ff2), which included an update to pip 20.1. Per https://pip.pypa.io/en/stable/news:

> Building of local directories is now done in place, instead of a temporary location containing a copy of the directory tree. (https://github.com/pypa/pip/issues/7555)

This causes our docker build to break, because the `/build` directory was being created by `WORKDIR`, which means it is owned by `root` (despite being run under the `stellar` user at the time). This is a problem because we're running `pip install` on a local directory under the `stellar` user, so pip 20.1 cannot create directories in that local directory (that is, in `/build`).

This PR pre-creates the `/build` directory and makes sure it's owned by the `stellar` user, in addition to making sure all the files are copied in under the same user.

See: #1406