### PR TITLE
Reformat DGCNN demo for new cloud runner

### DIFF
--- a/demos/graph-classification/dgcnn-graph-classification.ipynb
+++ b/demos/graph-classification/dgcnn-graph-classification.ipynb
@@ -15,7 +15,7 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/graph-classification/dgcnn-graph-classification.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/graph-classification/dgcnn-graph-classification.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/graph-classification/dgcnn-graph-classification.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/graph-classification/dgcnn-graph-classification.ipynb)"
    ]
   },
   {
@@ -632,7 +632,7 @@
     ]
    },
    "source": [
-    "<table><tr><td>Run the master version of this notebook:</td><td><a href=\"https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/graph-classification/dgcnn-graph-classification.ipynb\" alt=\"Open In Binder\" target=\"_parent\"><img src=\"https://mybinder.org/badge_logo.svg\"/></a></td><td><a href=\"https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/graph-classification/dgcnn-graph-classification.ipynb\" alt=\"Open In Colab\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\"/></a></td></tr></table>"
+    "> Run the master version of this notebook: [![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/graph-classification/dgcnn-graph-classification.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/demos/graph-classification/dgcnn-graph-classification.ipynb)"
    ]
   }
  ],


### PR DESCRIPTION
#1319 (DGCNN demo) added a new demo, and merged just before #1398 (switching cloud runner cells to use a markdown quote). This hit some ["merge skew"](https://bors.tech/): the latter changed the expected format of the notebooks, but the update wasn't applied to the DGCNN demo. Thus CI is failing: https://buildkite.com/stellar/stellargraph-public/builds/3625