### PR TITLE
Add a diff to format_notebooks output on CI, for diagnosis

### DIFF
--- a/demos/basics/loading-networkx.ipynb
+++ b/demos/basics/loading-networkx.ipynb
@@ -64,7 +64,7 @@
    "metadata": {
     "nbsphinx": "hidden",
     "tags": [
-         "VersionCheck"
+     "VersionCheck"
     ]
    },
    "outputs": [],
@@ -589,7 +589,7 @@
     }
    ],
    "source": [
-    "g_directed    = nx.DiGraph(    \n)\n",
+    "g_directed = nx.DiGraph()\n",
     "g_directed.add_edge(\"a\", \"b\")\n",
     "g_directed.add_edge(\"b\", \"c\")\n",
     "g_directed.add_edge(\"c\", \"d\")\n",

--- a/demos/basics/loading-networkx.ipynb
+++ b/demos/basics/loading-networkx.ipynb
@@ -64,7 +64,7 @@
    "metadata": {
     "nbsphinx": "hidden",
     "tags": [
-     "VersionCheck"
+         "VersionCheck"
     ]
    },
    "outputs": [],
@@ -589,7 +589,7 @@
     }
    ],
    "source": [
-    "g_directed = nx.DiGraph()\n",
+    "g_directed    = nx.DiGraph(    \n)\n",
     "g_directed.add_edge(\"a\", \"b\")\n",
     "g_directed.add_edge(\"b\", \"c\")\n",
     "g_directed.add_edge(\"c\", \"d\")\n",

--- a/scripts/format_notebooks.py
+++ b/scripts/format_notebooks.py
@@ -22,6 +22,7 @@ a machine-learning ready graph used by models.
 
 """
 import argparse
+import difflib
 import nbformat
 import re
 import shlex
@@ -459,6 +460,18 @@ if __name__ == "__main__":
 
                 if original != updated:
                     check_failed.append(str(file_loc))
+
+                    if on_ci:
+                        # CI doesn't provide enough state to diagnose a peculiar or
+                        # seemingly-spurious difference, so include a diff in the logs. This allows
+                        # us to inspect the change retroactive if required, but doesn't junk up the
+                        # final output/annotation.
+                        sys.stdout.writelines(
+                            difflib.unified_diff(
+                                original.splitlines(keepends=True),
+                                updated.splitlines(keepends=True),
+                            )
+                        )
 
                 tempdir.cleanup()
 


### PR DESCRIPTION
In builds like https://buildkite.com/stellar/stellargraph-public/builds/3569 and https://buildkite.com/stellar/stellargraph-public/builds/3573 on #1253, we observed an unexplained formatting failure, where ~every notebook was apparently formatted incorrectly. The first commit that hit this was https://github.com/stellargraph/stellargraph/pull/1253/commits/11fd94010a948c0ffff7b6a014dd772f6d05a7b3 which didn't change any notebooks or the `format_notebooks.py` script.

CI doesn't have enough state to be able to work out what's going on. For instance, we can't get the final formatted notebook to do a comparison. Including a diff is the simplest way to get more visibility into this. (Another option would be uploading the before/after for failing notebooks as Buildkite artifacts, but that's a bit more fiddly, and, a human is likely to just download them and do a diff manually anyway.)

Example: I manually broke the formatting of a notebook in https://github.com/stellargraph/stellargraph/pull/1421/commits/6a3216959faf45b046bbbe76186b72706f5a3515 . A CI run on that commit contains output like https://buildkite.com/stellar/stellargraph-public/builds/3644#036dc2ba-e920-46a3-afd0-6fac24464484/159-183 :

```diff
---
+++
@@ -64,7 +64,7 @@
    "metadata": {
     "nbsphinx": "hidden",
     "tags": [
-         "VersionCheck"
+     "VersionCheck"
     ]
    },
    "outputs": [],
@@ -589,7 +589,7 @@
     }
    ],
    "source": [
-    "g_directed    = nx.DiGraph(    \n)\n",
+    "g_directed = nx.DiGraph()\n",
     "g_directed.add_edge(\"a\", \"b\")\n",
     "g_directed.add_edge(\"b\", \"c\")\n",
     "g_directed.add_edge(\"c\", \"d\")\n",
```