### PR TITLE
Reformat gcn-lstm-LA demo

### DIFF
--- a/demos/spatio-temporal/gcn-lstm-LA.ipynb
+++ b/demos/spatio-temporal/gcn-lstm-LA.ipynb
@@ -45,7 +45,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
     "nbsphinx": "hidden",
     "tags": [
@@ -57,7 +57,7 @@
     "# install StellarGraph if running on Google Colab\n",
     "import sys\n",
     "if 'google.colab' in sys.modules:\n",
-    "    %pip install -q stellargraph[demos]==1.0.0rc2"
+    "  %pip install -q stellargraph[demos]==1.0.0rc2"
    ]
   },
   {


### PR DESCRIPTION
This notebook was merged with incorrect formatting in #1412 (https://buildkite.com/stellar/stellargraph-public/builds/3622 was the final build), and so every CI build since then has failed. This PR does the automated reformatting to get CI working again.