### PR TITLE
Fix error message with sparse+ppnp

### DIFF
--- a/stellargraph/mapper/full_batch_generators.py
+++ b/stellargraph/mapper/full_batch_generators.py
@@ -128,8 +128,8 @@ class FullBatchGenerator(Generator):
         elif self.method in ["ppnp"]:
             if self.use_sparse:
                 raise ValueError(
-                    "use_sparse=true' is incompatible with 'ppnp'."
-                    "Set 'use_sparse=True' or consider using the APPNP model instead."
+                    "sparse: method='ppnp' requires 'sparse=False', found 'sparse=True' "
+                    "(consider using the APPNP model for sparse support)"
                 )
             self.features, self.Aadj = PPNP_Aadj_feats_op(
                 features=self.features,


### PR DESCRIPTION
Resolves #1410 as per enclosed suggestion.

- Direct users to use `sparse=False` instead of `True` when using `method='ppnp'` (previously an erroneous suggestion)
- Reference the `sparse` parameter instead of "mysterious" `use_sparse` variable