### PR TITLE
Compute directed/undirected adj lists lazily

### DIFF
--- a/stellargraph/core/element_data.py
+++ b/stellargraph/core/element_data.py
@@ -325,34 +325,43 @@ class EdgeData(ElementData):
         # array, the result will still be int32).
         self._empty_ilocs = np.array([], dtype=np.uint8)
 
-    def _init_adj_lists(self):
+    def _init_directed_adj_lists(self):
         # record the edge ilocs of incoming, outgoing and both-direction edges
         in_dict = {}
         out_dict = {}
-        undirected = {}
 
         for i, (src, tgt) in enumerate(zip(self.sources, self.targets)):
             in_dict.setdefault(tgt, []).append(i)
             out_dict.setdefault(src, []).append(i)
 
+        dtype = np.min_scalar_type(len(self.sources))
+        self._edges_in_dict = _numpyise(in_dict, dtype=dtype)
+        self._edges_out_dict = _numpyise(out_dict, dtype=dtype)
+
+    def _init_undirected_adj_lists(self):
+        # record the edge ilocs of incoming, outgoing and both-direction edges
+        undirected = {}
+
+        for i, (src, tgt) in enumerate(zip(self.sources, self.targets)):
             undirected.setdefault(tgt, []).append(i)
             if src != tgt:
                 undirected.setdefault(src, []).append(i)
 
         dtype = np.min_scalar_type(len(self.sources))
-        self._edges_in_dict = _numpyise(in_dict, dtype=dtype)
-        self._edges_out_dict = _numpyise(out_dict, dtype=dtype)
         self._edges_dict = _numpyise(undirected, dtype=dtype)
 
     def _adj_lookup(self, *, ins, outs):
-        if self._edges_dict is None:
-            self._init_adj_lists()
-
         if ins and outs:
+            if self._edges_dict is None:
+                self._init_undirected_adj_lists()
             return self._edges_dict
         if ins:
+            if self._edges_in_dict is None:
+                self._init_directed_adj_lists()
             return self._edges_in_dict
         if outs:
+            if self._edges_out_dict is None:
+                self._init_directed_adj_lists()
             return self._edges_out_dict
 
         raise ValueError(

--- a/tests/core/test_graph.py
+++ b/tests/core/test_graph.py
@@ -630,7 +630,7 @@ def test_benchmark_get_features(benchmark, num_types, type_arg, feature_size):
 @pytest.mark.parametrize("num_nodes,num_edges", [(0, 0), (100, 200), (1000, 5000)])
 # features or not, to capture their cost
 @pytest.mark.parametrize("feature_size", [None, 100])
-@pytest.mark.parametrize("force_adj_lists", [False, True])
+@pytest.mark.parametrize("force_adj_lists", [None, "directed", "undirected", "both"])
 def test_benchmark_creation(
     benchmark, feature_size, num_nodes, num_edges, force_adj_lists
 ):
@@ -640,8 +640,13 @@ def test_benchmark_creation(
 
     def f():
         sg = StellarGraph(nodes=nodes, edges=edges)
-        if force_adj_lists:
-            sg._edges._init_adj_lists()
+        if force_adj_lists == "directed":
+            sg._edges._init_directed_adj_lists()
+        elif force_adj_lists == "undirected":
+            sg._edges._init_undirected_adj_lists()
+        elif force_adj_lists == "both":
+            sg._edges._init_undirected_adj_lists()
+            sg._edges._init_directed_adj_lists()
         return sg
 
     benchmark(f)
@@ -654,7 +659,7 @@ def test_benchmark_creation(
 @pytest.mark.parametrize("num_nodes,num_edges", [(0, 0), (100, 200), (1000, 5000)])
 # features or not, to capture their cost
 @pytest.mark.parametrize("feature_size", [None, 100])
-@pytest.mark.parametrize("force_adj_lists", [False, True])
+@pytest.mark.parametrize("force_adj_lists", [None, "directed", "undirected", "both"])
 def test_allocation_benchmark_creation(
     allocation_benchmark, feature_size, num_nodes, num_edges, force_adj_lists
 ):
@@ -664,8 +669,13 @@ def test_allocation_benchmark_creation(
 
     def f():
         sg = StellarGraph(nodes=nodes, edges=edges)
-        if force_adj_lists:
-            sg._edges._init_adj_lists()
+        if force_adj_lists == "directed":
+            sg._edges._init_directed_adj_lists()
+        elif force_adj_lists == "undirected":
+            sg._edges._init_undirected_adj_lists()
+        elif force_adj_lists == "both":
+            sg._edges._init_undirected_adj_lists()
+            sg._edges._init_directed_adj_lists()
         return sg
 
     allocation_benchmark(f)


### PR DESCRIPTION
Undirected graphs never call the directed adjacency lists, and even for directed graphs most algorithms only access the directed adjacency lists. 

This PR makes makes adj list initialization even lazier by only constructing the directed or undirected adj list(s) when necessary.

Microbenchmark (`test_allocation_benchmark_creation` and `test_benchmark_creation`, using the `...-None-1000-5000` parameters: 1000 nodes, no features, 5000 edges). 

| adj lists | median memory (KB) | median time (ms) |
|---|---|---|
| undirected | 250 | 11 |
| directed | 403 | 15 |
| both | 578 | 20 |

Relative improvements compared to storing both sets of adj lists:

| adj lists | memory reduction | time reduction |
|---|---|---|
| undirected | 57% | 50% |
| directed | 31% | 25% |
| both | 0% | 0% |

```
---------------------------------------------------------------------------------- benchmark 'StellarGraph creation (time)': 24 tests ---------------------------------------------------------------------------------
Name (time in ms)                                          Min                Max               Mean            StdDev             Median               IQR            Outliers       OPS            Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_benchmark_creation[None-None-100-200]              6.8179 (1.0)      10.9557 (1.31)      7.2733 (1.0)      0.4928 (1.88)      7.1687 (1.0)      0.2016 (1.0)          9;12  137.4900 (1.0)         129           1
test_benchmark_creation[undirected-None-100-200]        7.0056 (1.03)      8.6835 (1.04)      7.4328 (1.02)     0.2698 (1.03)      7.4054 (1.03)     0.2477 (1.23)         26;5  134.5387 (0.98)        124           1
test_benchmark_creation[None-None-1000-5000]            7.0420 (1.03)      8.3579 (1.0)       7.4042 (1.02)     0.2868 (1.09)      7.3288 (1.02)     0.2628 (1.30)        33;10  135.0592 (0.98)        134           1
test_benchmark_creation[undirected-None-0-0]            7.2272 (1.06)      8.8793 (1.06)      7.5914 (1.04)     0.2904 (1.11)      7.5295 (1.05)     0.2366 (1.17)         23;8  131.7276 (0.96)        123           1
test_benchmark_creation[directed-None-0-0]              7.2471 (1.06)     10.8856 (1.30)      8.1945 (1.13)     0.6633 (2.53)      8.2644 (1.15)     1.0835 (5.38)         51;2  122.0330 (0.89)        133           1
test_benchmark_creation[both-None-0-0]                  7.2487 (1.06)      8.9200 (1.07)      7.6023 (1.05)     0.2623 (1.0)       7.5635 (1.06)     0.2297 (1.14)         24;8  131.5389 (0.96)        129           1
test_benchmark_creation[None-None-0-0]                  7.2684 (1.07)     10.6076 (1.27)      7.7037 (1.06)     0.4291 (1.64)      7.6190 (1.06)     0.2773 (1.38)          8;6  129.8074 (0.94)         94           1
test_benchmark_creation[directed-None-100-200]          7.3346 (1.08)      9.9933 (1.20)      8.0718 (1.11)     0.4771 (1.82)      8.0058 (1.12)     0.5606 (2.78)         33;4  123.8889 (0.90)        118           1
test_benchmark_creation[both-None-100-200]              7.4076 (1.09)      9.6311 (1.15)      7.8451 (1.08)     0.3724 (1.42)      7.7496 (1.08)     0.2950 (1.46)        19;13  127.4679 (0.93)        128           1
test_benchmark_creation[None-100-100-200]               9.6079 (1.41)     11.5516 (1.38)     10.0929 (1.39)     0.3904 (1.49)      9.9880 (1.39)     0.4030 (2.00)         14;6   99.0799 (0.72)         86           1
test_benchmark_creation[undirected-100-100-200]         9.8309 (1.44)     12.0583 (1.44)     10.2469 (1.41)     0.3725 (1.42)     10.1518 (1.42)     0.2887 (1.43)         12;7   97.5908 (0.71)         90           1
test_benchmark_creation[both-100-0-0]                   9.9111 (1.45)     12.0686 (1.44)     10.4532 (1.44)     0.3944 (1.50)     10.3500 (1.44)     0.2815 (1.40)         11;6   95.6641 (0.70)         80           1
test_benchmark_creation[None-100-0-0]                   9.9173 (1.45)     11.9950 (1.44)     10.3702 (1.43)     0.4172 (1.59)     10.2388 (1.43)     0.2391 (1.19)        15;12   96.4304 (0.70)         93           1
test_benchmark_creation[None-100-1000-5000]             9.9577 (1.46)     11.7001 (1.40)     10.4368 (1.43)     0.3236 (1.23)     10.3585 (1.44)     0.2924 (1.45)         15;6   95.8150 (0.70)         87           1
test_benchmark_creation[directed-100-100-200]           9.9883 (1.47)     14.0246 (1.68)     10.7697 (1.48)     0.7714 (2.94)     10.4155 (1.45)     0.8575 (4.25)         19;3   92.8529 (0.68)         95           1
test_benchmark_creation[directed-100-0-0]               9.9927 (1.47)     13.0301 (1.56)     10.6463 (1.46)     0.6221 (2.37)     10.4182 (1.45)     0.4683 (2.32)         10;8   93.9298 (0.68)         65           1
test_benchmark_creation[undirected-100-0-0]            10.0248 (1.47)     11.5953 (1.39)     10.4466 (1.44)     0.3261 (1.24)     10.3374 (1.44)     0.3696 (1.83)         19;3   95.7249 (0.70)         91           1
test_benchmark_creation[both-100-100-200]              10.2654 (1.51)     12.3612 (1.48)     10.6402 (1.46)     0.3894 (1.48)     10.5412 (1.47)     0.2143 (1.06)        10;11   93.9829 (0.68)         92           1
test_benchmark_creation[undirected-None-1000-5000]     11.0983 (1.63)     13.2302 (1.58)     11.6400 (1.60)     0.4057 (1.55)     11.5320 (1.61)     0.3701 (1.84)         13;7   85.9107 (0.62)         85           1
test_benchmark_creation[directed-None-1000-5000]       12.6652 (1.86)     65.0279 (7.78)     15.2715 (2.10)     6.4074 (24.43)    14.2916 (1.99)     1.5522 (7.70)          1;1   65.4813 (0.48)         64           1
test_benchmark_creation[undirected-100-1000-5000]      14.1463 (2.07)     16.5267 (1.98)     14.6802 (2.02)     0.4386 (1.67)     14.5496 (2.03)     0.3198 (1.59)          8;5   68.1192 (0.50)         66           1
test_benchmark_creation[directed-100-1000-5000]        15.1417 (2.22)     21.0340 (2.52)     16.2623 (2.24)     1.1573 (4.41)     15.7809 (2.20)     0.9579 (4.75)          9;7   61.4917 (0.45)         60           1
test_benchmark_creation[both-None-1000-5000]           16.4414 (2.41)     18.8715 (2.26)     17.0939 (2.35)     0.5458 (2.08)     16.9026 (2.36)     0.4180 (2.07)         12;6   58.5006 (0.43)         58           1
test_benchmark_creation[both-100-1000-5000]            19.4536 (2.85)     32.4759 (3.89)     20.6571 (2.84)     2.0641 (7.87)     20.0547 (2.80)     0.7322 (3.63)          2;6   48.4095 (0.35)         47           1
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```


```
------------------------------------------------------------------------------------------------------ benchmark 'StellarGraph creation': 24 tests -------------------------------------------------------------------------------------------------------
Name (time in s)                                                           Min                     Max                    Mean                StdDev                  Median                 IQR            Outliers     OPS            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_allocation_benchmark_creation[both-None-0-0]                  14,441.0000 (1.0)       16,537.0000 (1.03)      14,688.6000 (1.00)       445.7271 (1.53)      14,657.0000 (1.0)      192.0000 (inf)           1;1  0.0001 (1.00)         20           1
test_allocation_benchmark_creation[directed-None-0-0]              14,441.0000 (1.0)       16,297.0000 (1.01)      14,694.2000 (1.00)       390.2843 (1.34)      14,657.0000 (1.0)       96.0000 (inf)           1;1  0.0001 (1.00)         20           1
test_allocation_benchmark_creation[undirected-None-0-0]            14,441.0000 (1.0)       16,057.0000 (1.0)       14,682.2000 (1.0)        338.6887 (1.17)      14,657.0000 (1.0)       96.0000 (inf)           1;1  0.0001 (1.0)          20           1
test_allocation_benchmark_creation[None-None-100-200]              14,537.0000 (1.01)      19,021.0000 (1.18)      15,000.8000 (1.02)       983.7025 (3.38)      14,753.0000 (1.01)       0.0000 (1.0)           1;7  0.0001 (0.98)         20           1
test_allocation_benchmark_creation[None-None-0-0]                  14,657.0000 (1.01)      17,001.0000 (1.06)      14,835.4000 (1.01)       531.5865 (1.83)      14,657.0000 (1.0)        0.0000 (1.0)           1;4  0.0001 (0.99)         20           1
test_allocation_benchmark_creation[None-100-0-0]                   15,513.0000 (1.07)      16,889.0000 (1.05)      15,724.6000 (1.07)       290.6947 (1.0)       15,729.0000 (1.07)     192.0000 (inf)           1;1  0.0001 (0.93)         20           1
test_allocation_benchmark_creation[both-100-0-0]                   15,513.0000 (1.07)      17,609.0000 (1.10)      15,760.6000 (1.07)       445.7271 (1.53)      15,729.0000 (1.07)     192.0000 (inf)           1;1  0.0001 (0.93)         20           1
test_allocation_benchmark_creation[directed-100-0-0]               15,513.0000 (1.07)      17,369.0000 (1.08)      15,748.6000 (1.07)       393.5178 (1.35)      15,729.0000 (1.07)     192.0000 (inf)           1;1  0.0001 (0.93)         20           1
test_allocation_benchmark_creation[undirected-100-0-0]             15,513.0000 (1.07)      17,129.0000 (1.07)      15,736.6000 (1.07)       341.7599 (1.18)      15,729.0000 (1.07)     192.0000 (inf)           1;1  0.0001 (0.93)         20           1
test_allocation_benchmark_creation[undirected-None-100-200]        31,213.0000 (2.16)      33,867.0000 (2.11)      31,404.9000 (2.14)       606.1469 (2.09)      31,213.0000 (2.13)       0.0000 (1.0)           1;4  0.0000 (0.47)         20           1
test_allocation_benchmark_creation[directed-None-100-200]          42,064.0000 (2.91)      44,349.0000 (2.76)      42,375.0500 (2.89)       467.2359 (1.61)      42,280.0000 (2.88)       0.0000 (1.0)           1;4  0.0000 (0.35)         20           1
test_allocation_benchmark_creation[None-100-100-200]               54,425.0000 (3.77)      56,417.0000 (3.51)      54,667.4000 (3.72)       423.0583 (1.46)      54,641.0000 (3.73)     192.0000 (inf)           1;1  0.0000 (0.27)         20           1
test_allocation_benchmark_creation[both-None-100-200]              61,643.0000 (4.27)      64,107.0000 (3.99)      61,963.0000 (4.22)       507.0551 (1.74)      61,859.0000 (4.22)       0.0000 (1.0)           1;4  0.0000 (0.24)         20           1
test_allocation_benchmark_creation[undirected-100-100-200]         70,199.0000 (4.86)      74,197.0000 (4.62)      70,584.9000 (4.81)       852.5596 (2.93)      70,415.0000 (4.80)       0.0000 (1.0)           1;4  0.0000 (0.21)         20           1
test_allocation_benchmark_creation[None-None-1000-5000]            71,333.0000 (4.94)      73,725.0000 (4.59)      71,595.4000 (4.88)       510.5347 (1.76)      71,549.0000 (4.88)     192.0000 (inf)           1;1  0.0000 (0.21)         20           1
test_allocation_benchmark_creation[directed-100-100-200]           84,383.0000 (5.84)      88,516.0000 (5.51)      84,728.8500 (5.77)       892.1016 (3.07)      84,535.0000 (5.77)       0.0000 (1.0)           1;4  0.0000 (0.17)         20           1
test_allocation_benchmark_creation[both-100-100-200]              101,519.0000 (7.03)     105,810.0000 (6.59)     101,930.3500 (6.94)       914.5088 (3.15)     101,735.0000 (6.94)       0.0000 (1.0)           1;4  0.0000 (0.14)         20           1
test_allocation_benchmark_creation[undirected-None-1000-5000]     245,511.0000 (17.00)    250,901.0000 (15.63)    245,982.1000 (16.75)    1,158.8689 (3.99)     245,735.0000 (16.77)      0.0000 (1.0)           1;2  0.0000 (0.06)         20           1
test_allocation_benchmark_creation[directed-None-1000-5000]       403,043.0000 (27.91)    406,893.0000 (25.34)    403,302.7000 (27.47)      845.2653 (2.91)     403,115.0000 (27.50)      0.0000 (1.0)           1;4  0.0000 (0.04)         20           1
test_allocation_benchmark_creation[None-100-1000-5000]            466,821.0000 (32.33)    468,213.0000 (29.16)    467,022.6000 (31.81)      297.8729 (1.02)     467,037.0000 (31.86)    204.0000 (inf)           1;1  0.0000 (0.03)         20           1
test_allocation_benchmark_creation[both-None-1000-5000]           578,251.0000 (40.04)    583,719.0000 (36.35)    578,726.0000 (39.42)    1,176.2942 (4.05)     578,475.0000 (39.47)      0.0000 (1.0)           1;2  0.0000 (0.03)         20           1
test_allocation_benchmark_creation[undirected-100-1000-5000]      640,677.0000 (44.37)    645,351.0000 (40.19)    641,112.3000 (43.67)      998.9395 (3.44)     640,901.0000 (43.73)      0.0000 (1.0)           1;2  0.0000 (0.02)         20           1
test_allocation_benchmark_creation[directed-100-1000-5000]        797,275.0000 (55.21)    800,325.0000 (49.84)    797,630.3000 (54.33)      636.2817 (2.19)     797,499.0000 (54.41)      0.0000 (1.0)           1;3  0.0000 (0.02)         20           1
test_allocation_benchmark_creation[both-100-1000-5000]            973,207.0000 (67.39)    977,611.0000 (60.88)    973,628.8000 (66.31)      938.6463 (3.23)     973,431.0000 (66.41)      0.0000 (1.0)           1;2  0.0000 (0.02)         20           1
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

```

See: #1316

edit: changed KiB to KB