### PR TITLE
increased atol and added pytest-repeat as test dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,6 @@ EXTRAS_REQUIRES = {
     "neo4j": ["py2neo"],
     "test": [
         "pytest==5.3.1",
-        "pytest-benchmark>=3.1",
         "pytest-cov>=2.6.0",
         "pytest-repeat>=0.8.0",
         "coverage>=4.4,<5.0",

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ EXTRAS_REQUIRES = {
         "pytest==5.3.1",
         "pytest-benchmark>=3.1",
         "pytest-cov>=2.6.0",
+        "pytest-repeat>=0.8.0",
         "coverage>=4.4,<5.0",
         "black>=19.3b0",
         "nbconvert>=5.5.0",

--- a/setup.py
+++ b/setup.py
@@ -50,8 +50,8 @@ EXTRAS_REQUIRES = {
     "neo4j": ["py2neo"],
     "test": [
         "pytest==5.3.1",
+        "pytest-benchmark>=3.1",
         "pytest-cov>=2.6.0",
-        "pytest-repeat>=0.8.0",
         "coverage>=4.4,<5.0",
         "black>=19.3b0",
         "nbconvert>=5.5.0",

--- a/tests/layer/test_knowledge_graph.py
+++ b/tests/layer/test_knowledge_graph.py
@@ -91,7 +91,7 @@ def test_complex(knowledge_graph):
     prediction = model.predict(gen.flow(df))
 
     # (use an absolute tolerance to allow for catastrophic cancellation around very small values)
-    assert np.allclose(prediction[:, 0], actual, rtol=1e-3, atol=1e-14)
+    assert np.allclose(prediction[:, 0], actual, rtol=1e-3, atol=1e-6)
 
     # the model is stateful (i.e. it holds the weights permanently) so the predictions with a second
     # 'build' should be the same as the original one


### PR DESCRIPTION
`test_complex` is flaky and sometimes fails on a floating comparison. This PR fixes this problem by increasing the `atol` from `1e-14` to `1e-6` - indicating that this was probably a numerical instability near zero issue.

This also adds in `pytest-repeat` as a test dependency to help diagnose this issue and similar ones in the future.

To verify the fix I ran:

```pytest tests -k test_complex --count 400```

Which initially failed four times. On this PR the above test pass.

See: #1025 