### PR TITLE
Remove StellarGraphBase reference in FullBatchGenerator

### DIFF
--- a/stellargraph/mapper/full_batch_generators.py
+++ b/stellargraph/mapper/full_batch_generators.py
@@ -238,7 +238,7 @@ class FullBatchNodeGenerator(FullBatchGenerator):
     For more information, please see the GCN, GAT, PPNP/APPNP and SGC demos: `<https://github.com/stellargraph/stellargraph/blob/master/demos/>`_
 
     Args:
-        G (StellarGraphBase): a machine-learning StellarGraph-type graph
+        G (StellarGraph): a machine-learning StellarGraph-type graph
         name (str): an optional name of the generator
         method (str): Method to pre-process adjacency matrix. One of 'gcn' (default),
             'sgc', 'self_loops', or 'none'.
@@ -324,7 +324,7 @@ class FullBatchLinkGenerator(FullBatchGenerator):
     For more information, please see the GCN, GAT, PPNP/APPNP and SGC demos: `<https://github.com/stellargraph/stellargraph/blob/master/demos/>`_
 
     Args:
-        G (StellarGraphBase): a machine-learning StellarGraph-type graph
+        G (StellarGraph): a machine-learning StellarGraph-type graph
         name (str): an optional name of the generator
         method (str): Method to pre-process adjacency matrix. One of 'gcn' (default),
             'sgc', 'self_loops', or 'none'.

--- a/stellargraph/mapper/full_batch_generators.py
+++ b/stellargraph/mapper/full_batch_generators.py
@@ -157,8 +157,8 @@ class FullBatchGenerator(Generator):
         Args:
             node_ids: an iterable of node ids for the nodes of interest
                 (e.g., training, validation, or test set nodes)
-            targets: a 1D or 2D array of numeric node targets with shape `(len(node_ids),)`
-                or `(len(node_ids), target_size)`
+            targets: a 1D or 2D array of numeric node targets with shape ``(len(node_ids),)``
+                or ``(len(node_ids), target_size)``
 
         Returns:
             A NodeSequence object to use with GCN or GAT models
@@ -262,8 +262,8 @@ class FullBatchNodeGenerator(FullBatchGenerator):
         Args:
             node_ids: an iterable of node ids for the nodes of interest
                 (e.g., training, validation, or test set nodes)
-            targets: a 1D or 2D array of numeric node targets with shape `(len(node_ids)`
-                or (len(node_ids), target_size)`
+            targets: a 1D or 2D array of numeric node targets with shape ``(len(node_ids),)``
+                or ``(len(node_ids), target_size)``
 
         Returns:
             A NodeSequence object to use with GCN or GAT models
@@ -348,8 +348,8 @@ class FullBatchLinkGenerator(FullBatchGenerator):
         Args:
             link_ids: an iterable of link ids specified as tuples of node ids
                 or an array of shape (N_links, 2) specifying the links.
-            targets: a 1D or 2D array of numeric node targets with shape `(len(node_ids),)`
-                or `(len(node_ids), target_size)`
+            targets: a 1D or 2D array of numeric node targets with shape ``(len(node_ids),)``
+                or ``(len(node_ids), target_size)``
 
         Returns:
             A NodeSequence object to use with GCN or GAT models
@@ -453,7 +453,7 @@ class RelationalFullBatchNodeGenerator(Generator):
         Args:
             node_ids: and iterable of node ids for the nodes of interest
                 (e.g., training, validation, or test set nodes)
-            targets: a 2D array of numeric node targets with shape `(len(node_ids), target_size)`
+            targets: a 2D array of numeric node targets with shape ``(len(node_ids), target_size)``
 
         Returns:
             A NodeSequence object to use with RGCN models

--- a/stellargraph/mapper/full_batch_generators.py
+++ b/stellargraph/mapper/full_batch_generators.py
@@ -157,8 +157,8 @@ class FullBatchGenerator(Generator):
         Args:
             node_ids: an iterable of node ids for the nodes of interest
                 (e.g., training, validation, or test set nodes)
-            targets: a 1D or 2D array of numeric node targets with shape `(len(node_ids)`
-                or (len(node_ids), target_size)`
+            targets: a 1D or 2D array of numeric node targets with shape `(len(node_ids),)`
+                or `(len(node_ids), target_size)`
 
         Returns:
             A NodeSequence object to use with GCN or GAT models
@@ -209,18 +209,18 @@ class FullBatchNodeGenerator(FullBatchGenerator):
     'method' option should be specified with the correct pre-processing for
     each algorithm. The options are as follows:
 
-    *   ``method='gcn'`` Normalizes the adjacency matrix for the GCN algorithm.
+    *   ``method='gcn'``: Normalizes the adjacency matrix for the GCN algorithm.
         This implements the linearized convolution of Eq. 8 in [1].
     *   ``method='sgc'``: This replicates the k-th order smoothed adjacency matrix
         to implement the Simplified Graph Convolutions of Eq. 8 in [2].
     *   ``method='self_loops'`` or ``method='gat'``: Simply sets the diagonal elements
         of the adjacency matrix to one, effectively adding self-loops to the graph. This is
         used by the GAT algorithm of [3].
-    *   ``method='ppnp'`` Calculates the personalized page rank matrix of Eq 2 in [4].
+    *   ``method='ppnp'``: Calculates the personalized page rank matrix of Eq. 2 in [4].
 
     [1] `Kipf and Welling, 2017 <https://arxiv.org/abs/1609.02907>`_.
     [2] `Wu et al. 2019 <https://arxiv.org/abs/1902.07153>`_.
-    [3] `Veličković et al., 2018 <https://arxiv.org/abs/1710.10903>`_
+    [3] `Veličković et al., 2018 <https://arxiv.org/abs/1710.10903>`_.
     [4] `Klicpera et al., 2018 <https://arxiv.org/abs/1810.05997>`_.
 
     Example::
@@ -295,18 +295,18 @@ class FullBatchLinkGenerator(FullBatchGenerator):
     'method' option should be specified with the correct pre-processing for
     each algorithm. The options are as follows:
 
-    *   ``method='gcn'`` Normalizes the adjacency matrix for the GCN algorithm.
+    *   ``method='gcn'``: Normalizes the adjacency matrix for the GCN algorithm.
         This implements the linearized convolution of Eq. 8 in [1].
     *   ``method='sgc'``: This replicates the k-th order smoothed adjacency matrix
         to implement the Simplified Graph Convolutions of Eq. 8 in [2].
     *   ``method='self_loops'`` or ``method='gat'``: Simply sets the diagonal elements
         of the adjacency matrix to one, effectively adding self-loops to the graph. This is
         used by the GAT algorithm of [3].
-    *   ``method='ppnp'`` Calculates the personalized page rank matrix of Eq 2 in [4].
+    *   ``method='ppnp'``: Calculates the personalized page rank matrix of Eq. 2 in [4].
 
     [1] `Kipf and Welling, 2017 <https://arxiv.org/abs/1609.02907>`_.
     [2] `Wu et al. 2019 <https://arxiv.org/abs/1902.07153>`_.
-    [3] `Veličković et al., 2018 <https://arxiv.org/abs/1710.10903>`_
+    [3] `Veličković et al., 2018 <https://arxiv.org/abs/1710.10903>`_.
     [4] `Klicpera et al., 2018 <https://arxiv.org/abs/1810.05997>`_.
 
     Example::
@@ -348,8 +348,8 @@ class FullBatchLinkGenerator(FullBatchGenerator):
         Args:
             link_ids: an iterable of link ids specified as tuples of node ids
                 or an array of shape (N_links, 2) specifying the links.
-            targets: a 1D or 2D array of numeric node targets with shape `(len(node_ids)`
-                or (len(node_ids), target_size)`
+            targets: a 1D or 2D array of numeric node targets with shape `(len(node_ids),)`
+                or `(len(node_ids), target_size)`
 
         Returns:
             A NodeSequence object to use with GCN or GAT models

--- a/stellargraph/mapper/graphwave_generator.py
+++ b/stellargraph/mapper/graphwave_generator.py
@@ -114,8 +114,8 @@ class GraphWaveGenerator(Generator):
             sample_points: a 1D array of points at which to sample the characteristic function. This should be of the
                 form: `sample_points=np.linspace(0, max_val, number_of_samples)` and is graph dependent.
             batch_size (int): the number of node embeddings to include in a batch.
-            targets: a 1D or 2D array of numeric node targets with shape `(len(node_ids)`
-                or (len(node_ids), target_size)`
+            targets: a 1D or 2D array of numeric node targets with shape ``(len(node_ids),)``
+                or ``(len(node_ids), target_size)``
             shuffle (bool): indicates whether to shuffle the dataset after each epoch
             seed (int,optional): the random seed to use for shuffling the dataset
             repeat (bool): indicates whether iterating through the DataSet will continue infinitely or stop after one

--- a/stellargraph/mapper/mini_batch_node_generators.py
+++ b/stellargraph/mapper/mini_batch_node_generators.py
@@ -152,8 +152,8 @@ class ClusterNodeGenerator(Generator):
         Args:
             node_ids (iterable): an iterable of node ids for the nodes of interest
                 (e.g., training, validation, or test set nodes)
-            targets (2d array, optional): a 2D array of numeric node targets with shape `(len(node_ids),
-                target_size)`
+            targets (2d array, optional): a 2D array of numeric node targets with shape ``(len(node_ids),
+                target_size)``
             name (str, optional): An optional name for the returned generator object.
 
         Returns:

--- a/stellargraph/mapper/padded_graph_generator.py
+++ b/stellargraph/mapper/padded_graph_generator.py
@@ -93,8 +93,8 @@ class PaddedGraphGenerator(Generator):
         Args:
             graph_ilocs (iterable): an iterable of graph indexes in self.graphs for the graphs of interest
                 (e.g., training, validation, or test set nodes).
-            targets (2d array, optional): a 2D array of numeric graph targets with shape `(len(graph_ilocs),
-                len(targets))`.
+            targets (2d array, optional): a 2D array of numeric graph targets with shape ``(len(graph_ilocs),
+                len(targets))``.
             symmetric_normalization (bool, optional): The type of normalization to be applied on the graph adjacency
                 matrices. If True, the adjacency matrix is left and right multiplied by the inverse square root of the
                 degree matrix; otherwise, the adjacency matrix is only left multiplied by the inverse of the degree

--- a/stellargraph/mapper/sampled_link_generators.py
+++ b/stellargraph/mapper/sampled_link_generators.py
@@ -106,7 +106,7 @@ class BatchedLinkGenerator(Generator):
         Args:
             link_ids: an iterable of tuples of node IDs as (source, target)
             targets: a 2D array of numeric targets with shape
-                `(len(link_ids), target_size)`
+                ``(len(link_ids), target_size)``
             shuffle (bool): If True the links will be shuffled at each
                 epoch, if False the links will be processed in order.
             seed (int, optional): Random seed
@@ -414,7 +414,7 @@ class HinSAGELinkGenerator(BatchedLinkGenerator):
 
         Returns:
             A list of the same length as `num_samples` of collected features from
-            the sampled nodes of shape: `(len(head_nodes), num_sampled_at_layer, feature_size)`
+            the sampled nodes of shape: ``(len(head_nodes), num_sampled_at_layer, feature_size)``
             where num_sampled_at_layer is the cumulative product of `num_samples`
             for that layer.
         """

--- a/stellargraph/mapper/sampled_node_generators.py
+++ b/stellargraph/mapper/sampled_node_generators.py
@@ -119,7 +119,7 @@ class BatchedNodeGenerator(Generator):
         Args:
             node_ids: an iterable of node IDs
             targets: a 2D array of numeric targets with shape
-                `(len(node_ids), target_size)`
+                ``(len(node_ids), target_size)``
             shuffle (bool): If True the node_ids will be shuffled at each
                 epoch, if False the node_ids will be processed in order.
 


### PR DESCRIPTION
Resolves #1436 

This PR removes legacy StellarGraphBase reference as the type of G, a parameter of the `FullBatchNodeGenerator` and `FullBatchLinkGenerator` classes.

I also took the liberty to tidy up the docstring of these 2 classes a little bit. (missing punctuation)

