### PR TITLE
Allow images within links in notebooks

### DIFF
--- a/demos/spatio-temporal/gcn-lstm-LA.ipynb
+++ b/demos/spatio-temporal/gcn-lstm-LA.ipynb
@@ -40,7 +40,7 @@
     "* [https://github.com/lehaifeng/T-GCN](https://github.com/lehaifeng/T-GCN)\n",
     "* [Semi-Supervised Classification with Graph Convolutional Networks](http://arxiv.org/abs/1609.02907)\n",
     "\n",
-    "***Note: this method is applicable for uni-variate timeseries forecasting.***"
+    "**Note: this method is applicable for uni-variate timeseries forecasting.**"
    ]
   },
   {

--- a/scripts/notebook_text_checker.py
+++ b/scripts/notebook_text_checker.py
@@ -127,6 +127,10 @@ def is_text(elem):
     return elem.t == "text"
 
 
+def is_image(elem):
+    return elem.t == "image"
+
+
 SYNTAX_SUMMARY = {
     "block_quote": "> text",
     "code": "`code`",
@@ -348,8 +352,10 @@ def simple_inline_formatting(cells):
                 # not an inline formatting, so not relevant
                 continue
 
-            if all(is_text(child) for child in direct_children(elem)):
-                # if all of the children are plain text, this is perfect!
+            if all(
+                is_text(child) or is_image(child) for child in direct_children(elem)
+            ):
+                # if all of the children are plain text or images, this is perfect!
                 continue
 
             # an inline element that contains non-text elements, error!


### PR DESCRIPTION
Pull requests #1398 (using pure markdown for colab links) and #1394 (no nested formatting in notebooks) merged at about the same time, but they conflicted. The syntax used in #1398 failed the check of #1394, and indeed revealed a missing piece: it's ok to have a link that contains an image in notebook markdown, because this passes through the reStructuredText conversion ok.

(This was yet more "merge skew".)

This also has to remove an replace of ***bold-italic*** with plain **bold** in the GCN-LSTM notebook, because the CI requires that this doesn't appear (as it doesn't render correctly on Read the Docs; #1394 discusses this in more detail).