### PR TITLE
Optimise weighted BiasedRandomWalk (4× speedup)

### DIFF
--- a/stellargraph/data/explorer.py
+++ b/stellargraph/data/explorer.py
@@ -461,8 +461,7 @@ class BiasedRandomWalk(RandomWalk):
                     # select one of the neighbours using the
                     # appropriate transition probabilities
                     choice = naive_weighted_choices(
-                        rs,
-                        (transition_probability(nn) for nn in neighbours),
+                        rs, (transition_probability(nn) for nn in neighbours),
                     )
 
                     previous_node = current_node

--- a/stellargraph/data/explorer.py
+++ b/stellargraph/data/explorer.py
@@ -417,11 +417,11 @@ class BiasedRandomWalk(RandomWalk):
             # calculate the appropriate unnormalised transition probability, given the history of
             # the walk
             def transition_probability(nn, current_node):
-                weight = self.graph._edge_weights(current_node, nn, use_ilocs=True)[0]
+                nn, weight = nn
 
                 if nn == previous_node:  # d_tx = 0
                     return ip * weight
-                elif nn in previous_node_neighbours:  # d_tx = 1
+                elif any(nn == pn for pn, _ in previous_node_neighbours):  # d_tx = 1
                     return weight
                 else:  # d_tx = 2
                     return iq * weight
@@ -451,7 +451,9 @@ class BiasedRandomWalk(RandomWalk):
                 current_node = node
 
                 for _ in range(length - 1):
-                    neighbours = self.graph.neighbors(current_node, use_ilocs=True)
+                    neighbours = self.graph.neighbors(
+                        current_node, use_ilocs=True, include_edge_weight=weighted
+                    )
 
                     if not neighbours:
                         break
@@ -466,6 +468,8 @@ class BiasedRandomWalk(RandomWalk):
                     previous_node = current_node
                     previous_node_neighbours = neighbours
                     current_node = neighbours[choice]
+                    if weighted:
+                        current_node = current_node.node
 
                     walk.append(current_node)
 

--- a/stellargraph/data/explorer.py
+++ b/stellargraph/data/explorer.py
@@ -423,10 +423,10 @@ class BiasedRandomWalk(RandomWalk):
                 # the walk starts at the root
                 walk = [node]
 
-                neighbours = self.graph.neighbors(node, use_ilocs=True)
+                previous_node = None
+                previous_node_neighbours = []
 
-                previous_node = node
-                previous_node_neighbours = neighbours
+                current_node = node
 
                 # calculate the appropriate unnormalised transition
                 # probability, given the history of the walk
@@ -447,28 +447,27 @@ class BiasedRandomWalk(RandomWalk):
                     else:  # d_tx = 2
                         return iq * weight_cn
 
-                if neighbours:
-                    current_node = rs.choice(neighbours)
-                    for _ in range(length - 1):
-                        walk.append(current_node)
-                        neighbours = self.graph.neighbors(current_node, use_ilocs=True)
+                for _ in range(length - 1):
+                    neighbours = self.graph.neighbors(current_node, use_ilocs=True)
 
-                        if not neighbours:
-                            break
+                    if not neighbours:
+                        break
 
-                        # select one of the neighbours using the
-                        # appropriate transition probabilities
-                        choice = naive_weighted_choices(
-                            rs,
-                            (
-                                transition_probability(nn, current_node, weighted)
-                                for nn in neighbours
-                            ),
-                        )
+                    # select one of the neighbours using the
+                    # appropriate transition probabilities
+                    choice = naive_weighted_choices(
+                        rs,
+                        (
+                            transition_probability(nn, current_node, weighted)
+                            for nn in neighbours
+                        ),
+                    )
 
-                        previous_node = current_node
-                        previous_node_neighbours = neighbours
-                        current_node = neighbours[choice]
+                    previous_node = current_node
+                    previous_node_neighbours = neighbours
+                    current_node = neighbours[choice]
+
+                    walk.append(current_node)
 
                 walks.append(list(self.graph.node_ilocs_to_ids(walk)))
 

--- a/stellargraph/data/explorer.py
+++ b/stellargraph/data/explorer.py
@@ -416,7 +416,7 @@ class BiasedRandomWalk(RandomWalk):
 
             # calculate the appropriate unnormalised transition probability, given the history of
             # the walk
-            def transition_probability(nn, current_node):
+            def transition_probability(nn):
                 nn, weight = nn
 
                 if nn == previous_node:  # d_tx = 0
@@ -428,7 +428,7 @@ class BiasedRandomWalk(RandomWalk):
 
         else:
             # without weights
-            def transition_probability(nn, current_node):
+            def transition_probability(nn):
                 if nn == previous_node:  ## d_tx = 0
                     return ip
                 elif nn in previous_node_neighbours:  # d_tx = 1

--- a/stellargraph/data/explorer.py
+++ b/stellargraph/data/explorer.py
@@ -462,7 +462,7 @@ class BiasedRandomWalk(RandomWalk):
                     # appropriate transition probabilities
                     choice = naive_weighted_choices(
                         rs,
-                        (transition_probability(nn, current_node) for nn in neighbours),
+                        (transition_probability(nn) for nn in neighbours),
                     )
 
                     previous_node = current_node

--- a/tests/data/test_biased_random_walker.py
+++ b/tests/data/test_biased_random_walker.py
@@ -155,7 +155,12 @@ class TestBiasedWeightedRandomWalk(object):
 
         biasedrw = BiasedRandomWalk(g)
 
-        with pytest.raises(ValueError):
+        neg_message = r"graph: expected all edge weights to be non-negative and finite, found some negative or infinite: 1 to 2 \(weight = -2\)"
+
+        with pytest.raises(ValueError, match=neg_message):
+            BiasedRandomWalk(g, weighted=True)
+
+        with pytest.raises(ValueError, match=neg_message):
             biasedrw.run(
                 nodes=nodes, n=n, p=p, q=q, length=length, seed=seed, weighted=True
             )
@@ -165,7 +170,11 @@ class TestBiasedWeightedRandomWalk(object):
 
         biasedrw = BiasedRandomWalk(g)
 
-        with pytest.raises(ValueError):
+        inf_message = r"graph: expected all edge weights to be non-negative and finite, found some negative or infinite: 1 to 2 \(weight = inf\)"
+        with pytest.raises(ValueError, match=inf_message):
+            BiasedRandomWalk(g, weighted=True)
+
+        with pytest.raises(ValueError, match=inf_message):
             biasedrw.run(
                 nodes=nodes, n=n, p=p, q=q, length=length, seed=seed, weighted=True
             )

--- a/tests/data/test_biased_random_walker.py
+++ b/tests/data/test_biased_random_walker.py
@@ -20,7 +20,7 @@ import pytest
 import networkx as nx
 from stellargraph.data.explorer import BiasedRandomWalk
 from stellargraph.core.graph import StellarGraph
-from ..test_utils.graphs import create_test_graph
+from ..test_utils.graphs import create_test_graph, example_graph_random
 
 
 # FIXME (#535): Consider using graph fixtures
@@ -209,11 +209,11 @@ class TestBiasedWeightedRandomWalk(object):
         g[4][1]["wt"] = 4
 
     def test_benchmark_biasedweightedrandomwalk(self, benchmark):
-        g = create_test_weighted_graph()
+        g = example_graph_random(n_nodes=100, n_edges=500)
         biasedrw = BiasedRandomWalk(g)
 
-        nodes = ["0"]
-        n = 5
+        nodes = np.arange(0, 50)
+        n = 2
         p = 2
         q = 3
         length = 5
@@ -527,11 +527,11 @@ class TestBiasedRandomWalk(object):
         }
 
     def test_benchmark_biasedrandomwalk(self, benchmark):
-        g = create_test_graph()
+        g = example_graph_random(n_nodes=100, n_edges=500)
         biasedrw = BiasedRandomWalk(g)
 
-        nodes = ["0"]
-        n = 5
+        nodes = np.arange(0, 50)
+        n = 2
         p = 2
         q = 3
         length = 5


### PR DESCRIPTION
The switch to using ilocs for edges and thus in the random walkers (#1267 991db681) resulted in some dramatic slowdowns in the `BiasedRandomWalk` code. This is mainly due to requiring more ID<->iloc conversions for some methods. Some of that overhead is unavoidable. This PR removes some of the avoidable overhead.

This increases the size of the `BiasedRandomWalk` benchmark, so that they're slightly more realistic without taking ridiculously long. In particular, it's rare that someone would do a random walk starting at a single node.

Given that, it then optimises the `BiasedRandomWalk` code, focusing on the weighted form, because of the large slowdown observed in the change to use ilocs (from f2a96aab to 991db681).

The following table reports the median times for the `` and `` benchmarks (as run by `pytest -k 'benchmark and biased'`), along with the speedups (vs. `develop`), and incremental speedups (vs. the previous row).

| change | unweighted (ms) | speedup (incr.) | weighted (ms) | speedup (incr.) |
|---|---|---|---|---|
| f2a96aab (pre-iloc), new benchmark | 8.58 | 2.0× (N/A) | 86.7 | 1.6× |
| `develop`, new benchmark | 17.5 | 1.0× (N/A) | 143 | 1.0× (N/A)  |
| numpy-ised weight validation | 17.5 | 1.0× (1.0×) | 75.0 | 1.9× (1.9×) |
| do `length` `neighbors` calls, not `length + 1` | 15.4 | 1.1× (1.1×) | 71.1 | 2.0× (1.05×) |
| move `def transition_probability` | 15.4 |  1.1× (1.0×) | 70.9 | 2.0× (1.0×) |
| use `include_edge_weights`, not `_edge_weights` | 15.4 |  1.1× (1.0×) | 36.8 | 3.9× (1.9×) |

That is, weighted random walks with the new form sees a speedup of almost 4× over the current state of `develop`, and 2.4× over the state before the iloc change. This recovers only a slight amount of the performance regression for unweighted walks.

Here's the numbers on a "real world" dataset (Cora), comparing this PR, with the state when ilocs were introduced and the state immediately before that. Measured using:

```python
import stellargraph as sg
G, _ = sg.datasets.Cora().load()
rw = sg.data.BiasedRandomWalk(G, n=3, length=10, p=2, q=4)
%timeit -n 1 -r 3 rw.run(G.nodes())
%timeit -n 1 -r 3 rw.run(G.nodes(), weighted=True)
```

(NB. the weighted walks are equivalent to the unweighted ones, given they're all the default weight of 1, but it's still using the weighted code path.)

| code | unweighted (s) | weighted (s) |
|---|---|---|
| f2a96aab (pre-iloc)  | 1.36 ± 0.0233 | 11.7 ± 0.0724 |
| 991db681 (iloc) | 2.02 ± 0.0173 | 13 ± 0.427 |
| This PR | 2 ± 0.101 | 5.64 ± 0.179  |

The speedups/slowdowns are less dramatic here, because there's more real work, and so the constant overhead of the initial iloc conversion and the weight validation is less noticeable.

See: #1441