### PR TITLE
Return NumPy array in from_iloc

### DIFF
--- a/stellargraph/core/element_data.py
+++ b/stellargraph/core/element_data.py
@@ -35,6 +35,9 @@ class ExternalIdIndex:
 
     def __init__(self, ids):
         self._index = pd.Index(ids)
+        # faster retrieval of the underlying numpy array (this shouldn't result in any additional
+        # memory use)
+        self._index_numpy_cache = self._index.to_numpy()
         self._dtype = np.min_scalar_type(len(self._index))
 
         if not self._index.is_unique:
@@ -101,11 +104,11 @@ class ExternalIdIndex:
             return internal_ids.astype(self._dtype)
         return internal_ids
 
-    def from_iloc(self, internal_ids) -> pd.Index:
+    def from_iloc(self, internal_ids) -> np.ndarray:
         """
         Convert integer locations to their corresponding external ID.
         """
-        return self._index[internal_ids]
+        return self._index_numpy_cache[internal_ids]
 
 
 class ElementData:

--- a/stellargraph/core/element_data.py
+++ b/stellargraph/core/element_data.py
@@ -35,9 +35,6 @@ class ExternalIdIndex:
 
     def __init__(self, ids):
         self._index = pd.Index(ids)
-        # faster retrieval of the underlying numpy array (this shouldn't result in any additional
-        # memory use)
-        self._index_numpy_cache = self._index.to_numpy()
         self._dtype = np.min_scalar_type(len(self._index))
 
         if not self._index.is_unique:
@@ -108,7 +105,7 @@ class ExternalIdIndex:
         """
         Convert integer locations to their corresponding external ID.
         """
-        return self._index_numpy_cache[internal_ids]
+        return self._index.to_numpy()[internal_ids]
 
 
 class ElementData:

--- a/tests/core/test_element_data.py
+++ b/tests/core/test_element_data.py
@@ -46,9 +46,9 @@ def test_benchmark_external_id_index_from_iloc(benchmark):
     N = 1000
     SIZE = 100
     idx = ExternalIdIndex(np.arange(N))
+    x = np.random.randint(0, N, size=SIZE)
 
     def f():
-        x = np.random.randint(0, N, size=SIZE)
         idx.from_iloc(x)
 
     benchmark(f)

--- a/tests/core/test_element_data.py
+++ b/tests/core/test_element_data.py
@@ -42,18 +42,6 @@ def test_external_id_index_to_iloc(count, expected_missing):
     assert idx.to_iloc(["A"]) == expected_missing
 
 
-@pytest.mark.parametrize(
-    "dtype", [np.uint8, np.int, np.float32, np.float64, str, object]
-)
-def test_external_id_index_numpy_cache(dtype):
-    values = np.arange(10).astype(dtype)
-    idx = ExternalIdIndex(values)
-
-    # approximate validation that the cache of the underlying numpy array doesn't result in higher
-    # memory use: repeated to_numpy() calls should be all using the same memory
-    assert np.shares_memory(idx._index.to_numpy(), idx._index_numpy_cache)
-
-
 def test_benchmark_external_id_index_from_iloc(benchmark):
     N = 1000
     SIZE = 100

--- a/tests/core/test_element_data.py
+++ b/tests/core/test_element_data.py
@@ -40,3 +40,27 @@ def test_external_id_index_to_iloc(count, expected_missing):
 
     # missing value
     assert idx.to_iloc(["A"]) == expected_missing
+
+
+@pytest.mark.parametrize(
+    "dtype", [np.uint8, np.int, np.float32, np.float64, str, object]
+)
+def test_external_id_index_numpy_cache(dtype):
+    values = np.arange(10).astype(dtype)
+    idx = ExternalIdIndex(values)
+
+    # approximate validation that the cache of the underlying numpy array doesn't result in higher
+    # memory use: repeated to_numpy() calls should be all using the same memory
+    assert np.shares_memory(idx._index.to_numpy(), idx._index_numpy_cache)
+
+
+def test_benchmark_external_id_index_from_iloc(benchmark):
+    N = 1000
+    SIZE = 100
+    idx = ExternalIdIndex(np.arange(N))
+
+    def f():
+        x = np.random.randint(0, N, size=SIZE)
+        idx.from_iloc(x)
+
+    benchmark(f)

--- a/tests/data/test_breadth_first_walker.py
+++ b/tests/data/test_breadth_first_walker.py
@@ -16,9 +16,10 @@
 
 import pandas as pd
 import pytest
+import numpy as np
 from stellargraph.data.explorer import SampledBreadthFirstWalk
 from stellargraph.core.graph import StellarDiGraph
-from ..test_utils.graphs import create_test_graph, tree_graph
+from ..test_utils.graphs import create_test_graph, tree_graph, example_graph_random
 
 
 def expected_bfw_size(n_size):
@@ -538,10 +539,10 @@ class TestBreadthFirstWalk(object):
         assert w0 == w1
 
     def test_benchmark_bfs_walk(self, benchmark):
-        g = create_test_graph()
+        g = example_graph_random(n_nodes=100, n_edges=500)
         bfw = SampledBreadthFirstWalk(g)
 
-        nodes = [0]
+        nodes = np.arange(0, 50)
         n = 5
         n_size = [5, 5]
 

--- a/tests/data/test_directed_breadth_first_sampler.py
+++ b/tests/data/test_directed_breadth_first_sampler.py
@@ -16,9 +16,10 @@
 
 import random
 import pytest
+import numpy as np
 from stellargraph.data.explorer import DirectedBreadthFirstNeighbours
 from stellargraph.core.graph import StellarDiGraph
-from ..test_utils.graphs import create_test_graph, tree_graph
+from ..test_utils.graphs import create_test_graph, tree_graph, example_graph_random
 
 
 class TestDirectedBreadthFirstNeighbours(object):
@@ -229,10 +230,10 @@ class TestDirectedBreadthFirstNeighbours(object):
             assert len(subgraph[0][14]) == out_size[0] * out_size[1] * out_size[2]
 
     def test_benchmark_bfs_walk(self, benchmark):
-        g = create_test_graph(is_directed=True)
+        g = example_graph_random(n_nodes=100, n_edges=500, is_directed=True)
         bfw = DirectedBreadthFirstNeighbours(g)
 
-        nodes = [0]
+        nodes = np.arange(0, 50)
         n = 5
         in_size = [5, 5]
         out_size = [5, 5]

--- a/tests/data/test_heterogeneous_breadth_first_walker.py
+++ b/tests/data/test_heterogeneous_breadth_first_walker.py
@@ -19,6 +19,7 @@ import numpy as np
 import pytest
 from stellargraph.data.explorer import SampledHeterogeneousBreadthFirstWalk
 from stellargraph.core.graph import StellarGraph
+from ..test_utils.graphs import example_graph_random
 
 
 def _recursive_items_equal(arr1, arr2):
@@ -531,11 +532,10 @@ class TestSampledHeterogeneousBreadthFirstWalk(object):
         assert len(subgraphs) == n * len(nodes)
 
     def test_benchmark_sampledheterogeneousbreadthfirstwalk(self, benchmark):
-
-        g = create_test_graph(self_loop=True)
+        g = example_graph_random(n_nodes=50, n_edges=250, node_types=2, edge_types=2)
         bfw = SampledHeterogeneousBreadthFirstWalk(g)
 
-        nodes = [0]
+        nodes = np.arange(0, 50)
         n = 5
         n_size = [5, 5]
 

--- a/tests/data/test_metapath_walker.py
+++ b/tests/data/test_metapath_walker.py
@@ -19,6 +19,7 @@ import numpy as np
 import pytest
 from stellargraph.data.explorer import UniformRandomMetaPathWalk
 from stellargraph.core.graph import StellarGraph
+from ..test_utils.graphs import example_graph_random
 
 
 # FIXME (#535): Consider using graph fixtures
@@ -316,13 +317,13 @@ class TestMetaPathWalk(object):
         assert all(np.array_equal(w1, w2) for w1, w2 in zip(run_1, run_2))
 
     def test_benchmark_uniformrandommetapathwalk(self, benchmark):
-
-        g = create_test_graph()
+        g = example_graph_random(n_nodes=50, n_edges=500, node_types=2)
         mrw = UniformRandomMetaPathWalk(g)
 
-        nodes = ["0"]
+        # this should be made larger to be more realistic, when it is fast enough
+        nodes = np.arange(0, 5)
         n = 5
         length = 5
-        metapaths = [["s", "n", "n", "s"], ["n", "s", "n"], ["n", "n"]]
+        metapaths = [["n-0", "n-1", "n-1", "n-0"], ["n-0", "n-1", "n-0"], ["n-0", "n-0"]]
 
         benchmark(lambda: mrw.run(nodes=nodes, n=n, length=length, metapaths=metapaths))

--- a/tests/data/test_metapath_walker.py
+++ b/tests/data/test_metapath_walker.py
@@ -324,6 +324,10 @@ class TestMetaPathWalk(object):
         nodes = np.arange(0, 5)
         n = 5
         length = 5
-        metapaths = [["n-0", "n-1", "n-1", "n-0"], ["n-0", "n-1", "n-0"], ["n-0", "n-0"]]
+        metapaths = [
+            ["n-0", "n-1", "n-1", "n-0"],
+            ["n-0", "n-1", "n-0"],
+            ["n-0", "n-0"],
+        ]
 
         benchmark(lambda: mrw.run(nodes=nodes, n=n, length=length, metapaths=metapaths))

--- a/tests/data/test_uniform_random_walker.py
+++ b/tests/data/test_uniform_random_walker.py
@@ -17,7 +17,7 @@
 import pytest
 import numpy as np
 from stellargraph.data.explorer import UniformRandomWalk
-from ..test_utils.graphs import create_test_graph
+from ..test_utils.graphs import create_test_graph, example_graph_random
 
 
 class TestUniformRandomWalk(object):
@@ -239,11 +239,11 @@ class TestUniformRandomWalk(object):
         assert np.array_equal(run_1, run_2)
 
     def test_benchmark_uniformrandomwalk(self, benchmark):
-
-        g = create_test_graph()
+        g = example_graph_random(n_nodes=100, n_edges=500)
         urw = UniformRandomWalk(g)
 
-        nodes = ["0"]  # this node has no edges including itself
+        nodes = np.arange(0, 50)
+        n = 2
         n = 5
         length = 5
 


### PR DESCRIPTION
Indexing Pandas types is slow, and indexing a `pandas.Index` is particularly slow, because it returns a whole `Index` object. This isn't generally useful for what we use `from_iloc` for, which is getting a sequence of node, edge or type IDs from some ilocs. The result is generally then used for things where having an `Index` isn't useful.

This makes the included microbenchmark of `from_iloc` (`test_benchmark_external_id_index_from_iloc`) significantly faster (times in microseconds):

| code | min | mean &pm; std | max | median &pm; IQR | 
|---|---|---|---|---|
| develop | 50.27 |  57.1 &pm; 9.7 | 224 | 52.9 &pm; 10 |
| this PR | 3.83 | 4.82 &pm; 3.1 | 64.6 | 4.25 &pm; 0.37 |

That is, a speed up of 12&times; going by the medians (ranging from 3.5-13&times; depending on which number one compares).

In #1267 991db681, random walks slowed down significantly compare to the previous commit (f2a96aab) due to more iloc conversions from storing edges as ilocs, see #1441.

In order to more accurately capture the effect of this change on those, the random walk benchmarks are increased to be slightly more realistic, with larger graphs and more head nodes. (#1444 does this change to the `BiasedRandomWalk` benchmarks, this does the rest.)

The `from_iloc` change thus has a significant impact on various benchmarks. The ones with the largest change are listed in the following table. The before/after columns are median times in microseconds &pm; IQR, and the speedup columns are comparing "after" with the specified before column.

| `test_benchmark_...` | before (pre-ilocs f2a96aab) | before (post-ilocs `develop`) | after | speedup vs. pre-ilocs | speedup vs. post-ilocs |
|---|---|---|---|---|--|
| `get_neighbours[False]`* | N/A | 16.1 &pm; 1.9 | 9.60 &pm; 1.3 | N/A | 1.7× |
| `biasedrandomwalk` | 7.79 &pm; 1.1 | 15.9 &pm; 2.1 | 8.12 &pm; 1.0 | 0.96× | 2.0× |
| `biasedweightedrandomwalk`^ | 83.7 &pm; 11 | 37.4 &pm; 5.7 | 29.2 &pm; 3.2 | 2.9× | 1.3× |
| `uniformrandommetapathwalk` | 235 &pm; 26 | 112 &pm; 11 | 39.4 &pm; 4.6 | 6.0× | 2.8× |
| `uniformrandomwalk` | 10.6 &pm; 1.3 | 31.8 &pm; 1.3 | 14.0 &pm; 1.4 | 0.76× | 2.3× |

\* `test_benchmark_get_neighbours[use_ilocs=False]` didn't exist before ilocs
^ `BiasedRandomWalk(..., weighted=True)` has independent optimisations applied in #1444, included here.

Some other benchmarks have smaller improvements (speedups up to ~1.1&times;), such as the GraphSAGE and HinSAGE random walkers.

In summary, this is a 1.3&times;-2.8&times; speedups on many random walk benchmarks, bringing the benchmarks with slowdowns in #1441 to be about what they were before ilocs were used for edges in #1267 991db681. It likely reduces memory use too, due to not needing the metadata of the `Index` type.

For a real world dataset, continuing the Cora table from #1444:

| code | unweighted (s) | weighted (s) |
|---|---|---|
| f2a96aab (pre-iloc)  | 1.36 ± 0.0233 | 11.7 ± 0.0724 |
| 991db681 (iloc) | 2.02 ± 0.0173 | 13 ± 0.427 |
| #1444 | 2 ± 0.101 | 5.64 ± 0.179  |
| This PR | 1.46 ± 0.0376 | 5.46 ± 0.0562 |

See: #1441