### PR TITLE
Don't use abbreviations in rST demo table

### DIFF
--- a/demos/README.md
+++ b/demos/README.md
@@ -29,10 +29,10 @@ The demo notebooks can be run without any installation of Python by using Binder
 <table>
   <tr>
     <th>Algorithm</th>
-    <th><span title='Heterogeneous graphs'>Heter.</span></th>
+    <th><span title='Heterogeneous'>Heter.</span></th>
     <th><span title='Directed'>Dir.</span></th>
     <th><span title='Edge weights'>EW</span></th>
-    <th><span title='Time-varying or temporal graphs'>T</span></th>
+    <th><span title='Time-varying & temporal'>T</span></th>
     <th><span title='Node features'>NF</span></th>
     <th><span title='Node classification'><a href='node-classification/README.md'>NC</a></span></th>
     <th><span title='Link prediction'><a href='link-prediction/README.md'>LP</a></span></th>
@@ -41,7 +41,7 @@ The demo notebooks can be run without any installation of Python by using Binder
     <th><span title='Graph classification'><a href='graph-classification/README.md'>GC</a></span></th>
   </tr>
   <tr>
-    <td><span title='Graph Convolutional Network'>GCN</span></td>
+    <td><span title='Graph Convolutional Network (GCN)'>GCN</span></td>
     <td>see RGCN</td>
     <td></td>
     <td></td>
@@ -50,8 +50,8 @@ The demo notebooks can be run without any installation of Python by using Binder
     <td><a href='node-classification/gcn/gcn-cora-node-classification-example.ipynb'>demo</a></td>
     <td><a href='link-prediction/gcn/cora-gcn-links-example.ipynb'>demo</a></td>
     <td>
-      <span title='UnsupervisedSampler, using link prediction'>US</span>
-      <span title='DeepGraphInfomax, using mutual information'><a href='embeddings/deep-graph-infomax-cora.ipynb'>DGI</a></span>
+      <span title='UnsupervisedSampler'>US</span>
+      <span title='DeepGraphInfomax'><a href='embeddings/deep-graph-infomax-cora.ipynb'>DGI</a></span>
     </td>
     <td>see Cluster-GCN</td>
     <td><a href='graph-classification/supervised-graph-classification.ipynb'>demo</a></td>
@@ -70,8 +70,8 @@ The demo notebooks can be run without any installation of Python by using Binder
     <td></td>
   </tr>
   <tr>
-    <td><span title='Relational GCN'>RGCN</span></td>
-    <td><span title='Multiple edges types and one node type'>yes, edges</span></td>
+    <td><span title='Relational GCN (RGCN)'>RGCN</span></td>
+    <td><span title='Multiple edges types'>yes, edges</span></td>
     <td></td>
     <td></td>
     <td></td>
@@ -83,7 +83,7 @@ The demo notebooks can be run without any installation of Python by using Binder
     <td></td>
   </tr>
   <tr>
-    <td><span title='Graph ATtention Network'>GAT</span></td>
+    <td><span title='Graph ATtention Network (GAT)'>GAT</span></td>
     <td></td>
     <td></td>
     <td></td>
@@ -92,14 +92,14 @@ The demo notebooks can be run without any installation of Python by using Binder
     <td><a href='node-classification/gat/gat-cora-node-classification-example.ipynb'>demo</a></td>
     <td>yes</td>
     <td>
-      <span title='UnsupervisedSampler, using link prediction'>US</span>
-      <span title='DeepGraphInfomax, using mutual information'><a href='embeddings/deep-graph-infomax-cora.ipynb'>DGI</a></span>
+      <span title='UnsupervisedSampler'>US</span>
+      <span title='DeepGraphInfomax'><a href='embeddings/deep-graph-infomax-cora.ipynb'>DGI</a></span>
     </td>
     <td></td>
     <td></td>
   </tr>
   <tr>
-    <td><span title='Simplified Graph Convolution'>SGC</span></td>
+    <td><span title='Simplified Graph Convolution (SGC)'>SGC</span></td>
     <td></td>
     <td></td>
     <td></td>
@@ -112,7 +112,7 @@ The demo notebooks can be run without any installation of Python by using Binder
     <td></td>
   </tr>
   <tr>
-    <td><span title='Personalized Propagation of Neural Predictions'>PPNP</span></td>
+    <td><span title='Personalized Propagation of Neural Predictions (PPNP)'>PPNP</span></td>
     <td></td>
     <td></td>
     <td></td>
@@ -121,14 +121,14 @@ The demo notebooks can be run without any installation of Python by using Binder
     <td><a href='node-classification/ppnp/ppnp-cora-node-classification-example.ipynb'>demo</a></td>
     <td>yes</td>
     <td>
-      <span title='UnsupervisedSampler, using link prediction'>US</span>
-      <span title='DeepGraphInfomax, using mutual information'>DGI</span>
+      <span title='UnsupervisedSampler'>US</span>
+      <span title='DeepGraphInfomax'>DGI</span>
     </td>
     <td></td>
     <td></td>
   </tr>
   <tr>
-    <td><span title='Approximate PPNP'>APPNP</span></td>
+    <td><span title='Approximate PPNP (APPNP)'>APPNP</span></td>
     <td></td>
     <td></td>
     <td></td>
@@ -137,8 +137,8 @@ The demo notebooks can be run without any installation of Python by using Binder
     <td><a href='node-classification/ppnp/ppnp-cora-node-classification-example.ipynb'>demo</a></td>
     <td>yes</td>
     <td>
-      <span title='UnsupervisedSampler, using link prediction'>US</span>
-      <span title='DeepGraphInfomax, using mutual information'><a href='embeddings/deep-graph-infomax-cora.ipynb'>DGI</a></span>
+      <span title='UnsupervisedSampler'>US</span>
+      <span title='DeepGraphInfomax'><a href='embeddings/deep-graph-infomax-cora.ipynb'>DGI</a></span>
     </td>
     <td></td>
     <td></td>
@@ -150,8 +150,8 @@ The demo notebooks can be run without any installation of Python by using Binder
     <td></td>
     <td></td>
     <td></td>
-    <td><span title='As a downstream task by training a classifier on reprentation/embedding vectors'>via RL</span></td>
-    <td><span title='As a downstream task by training a classifier on reprentation/embedding vectors'>via RL</span></td>
+    <td><span title='Using embedding vectors'>via RL</span></td>
+    <td><span title='Using embedding vectors'>via RL</span></td>
     <td><a href='embeddings/graphwave-barbell.ipynb'>demo</a></td>
     <td></td>
     <td></td>
@@ -179,8 +179,8 @@ The demo notebooks can be run without any installation of Python by using Binder
     <td><a href='node-classification/graphsage/graphsage-cora-node-classification-example.ipynb'>demo</a></td>
     <td><a href='link-prediction/graphsage/cora-links-example.ipynb'>demo</a></td>
     <td>
-      <span title='UnsupervisedSampler, using link prediction'><a href='embeddings/embeddings-unsupervised-graphsage-cora.ipynb'>US</a></span>
-      <span title='DeepGraphInfomax, using mutual information'><a href='embeddings/deep-graph-infomax-cora.ipynb'>DGI</a></span>
+      <span title='UnsupervisedSampler'><a href='embeddings/embeddings-unsupervised-graphsage-cora.ipynb'>US</a></span>
+      <span title='DeepGraphInfomax'><a href='embeddings/deep-graph-infomax-cora.ipynb'>DGI</a></span>
     </td>
     <td><a href='node-classification/graphsage/graphsage-pubmed-inductive-node-classification-example.ipynb'>demo</a></td>
     <td></td>
@@ -194,7 +194,7 @@ The demo notebooks can be run without any installation of Python by using Binder
     <td>yes</td>
     <td>yes</td>
     <td><a href='link-prediction/hinsage/movielens-recommender.ipynb'>demo</a></td>
-    <td><span title='DeepGraphInfomax, using mutual information'><a href='embeddings/deep-graph-infomax-cora.ipynb'>DGI</a></span></td>
+    <td><span title='DeepGraphInfomax'><a href='embeddings/deep-graph-infomax-cora.ipynb'>DGI</a></span></td>
     <td>yes</td>
     <td></td>
   </tr>
@@ -205,8 +205,8 @@ The demo notebooks can be run without any installation of Python by using Binder
     <td><a href='node-classification/node2vec/stellargraph-node2vec-weighted-random-walks.ipynb'>demo</a></td>
     <td></td>
     <td></td>
-    <td><span title='As a downstream task by training a classifier on reprentation/embedding vectors'><a href='node-classification/node2vec/stellargraph-node2vec-node-classification.ipynb'>via RL</a></span></td>
-    <td><span title='As a downstream task by training a classifier on reprentation/embedding vectors'><a href='link-prediction/random-walks/cora-lp-demo.ipynb'>via RL</a></span></td>
+    <td><span title='Using embedding vectors'><a href='node-classification/node2vec/stellargraph-node2vec-node-classification.ipynb'>via RL</a></span></td>
+    <td><span title='Using embedding vectors'><a href='link-prediction/random-walks/cora-lp-demo.ipynb'>via RL</a></span></td>
     <td><a href='embeddings/stellargraph-node2vec.ipynb'>demo</a></td>
     <td></td>
     <td></td>
@@ -218,8 +218,8 @@ The demo notebooks can be run without any installation of Python by using Binder
     <td></td>
     <td></td>
     <td></td>
-    <td><span title='As a downstream task by training a classifier on reprentation/embedding vectors'>via RL</span></td>
-    <td><span title='As a downstream task by training a classifier on reprentation/embedding vectors'>via RL</span></td>
+    <td><span title='Using embedding vectors'>via RL</span></td>
+    <td><span title='Using embedding vectors'>via RL</span></td>
     <td><a href='embeddings/stellargraph-metapath2vec.ipynb'>demo</a></td>
     <td></td>
     <td></td>
@@ -231,8 +231,8 @@ The demo notebooks can be run without any installation of Python by using Binder
     <td></td>
     <td>yes</td>
     <td></td>
-    <td><span title='As a downstream task by training a classifier on reprentation/embedding vectors'>via RL</span></td>
-    <td><span title='As a downstream task by training a classifier on reprentation/embedding vectors'><a href='link-prediction/random-walks/ctdne-link-prediction.ipynb'>via RL</a></span></td>
+    <td><span title='Using embedding vectors'>via RL</span></td>
+    <td><span title='Using embedding vectors'><a href='link-prediction/random-walks/ctdne-link-prediction.ipynb'>via RL</a></span></td>
     <td>yes</td>
     <td></td>
     <td></td>
@@ -244,20 +244,20 @@ The demo notebooks can be run without any installation of Python by using Binder
     <td></td>
     <td></td>
     <td></td>
-    <td><span title='As a downstream task by training a classifier on reprentation/embedding vectors'><a href='embeddings/watch-your-step-cora-demo.ipynb'>via RL</a></span></td>
-    <td><span title='As a downstream task by training a classifier on reprentation/embedding vectors'>via RL</span></td>
+    <td><span title='Using embedding vectors'><a href='embeddings/watch-your-step-cora-demo.ipynb'>via RL</a></span></td>
+    <td><span title='Using embedding vectors'>via RL</span></td>
     <td><a href='embeddings/watch-your-step-cora-demo.ipynb'>demo</a></td>
     <td></td>
     <td></td>
   </tr>
   <tr>
     <td>ComplEx</td>
-    <td><span title='Multiple edges types and one node type'>yes, edges</span></td>
+    <td><span title='Multiple edges types'>yes, edges</span></td>
     <td>yes</td>
     <td></td>
     <td></td>
     <td></td>
-    <td><span title='As a downstream task by training a classifier on reprentation/embedding vectors'>via RL</span></td>
+    <td><span title='Using embedding vectors'>via RL</span></td>
     <td><a href='link-prediction/knowledge-graphs/complex.ipynb'>demo</a></td>
     <td>yes</td>
     <td></td>
@@ -265,12 +265,12 @@ The demo notebooks can be run without any installation of Python by using Binder
   </tr>
   <tr>
     <td>DistMult</td>
-    <td><span title='Multiple edges types and one node type'>yes, edges</span></td>
+    <td><span title='Multiple edges types'>yes, edges</span></td>
     <td>yes</td>
     <td></td>
     <td></td>
     <td></td>
-    <td><span title='As a downstream task by training a classifier on reprentation/embedding vectors'>via RL</span></td>
+    <td><span title='Using embedding vectors'>via RL</span></td>
     <td><a href='link-prediction/knowledge-graphs/distmult.ipynb'>demo</a></td>
     <td>yes</td>
     <td></td>

--- a/demos/README.md
+++ b/demos/README.md
@@ -83,7 +83,7 @@ The demo notebooks can be run without any installation of Python by using Binder
     <td></td>
   </tr>
   <tr>
-    <td><span title='Temporal GCN, implemented as GCN-LSTM'>T-GCN</span></td>
+    <td><span title='Temporal GCN (T-GCN), implemented as GCN-LSTM'>T-GCN</span></td>
     <td></td>
     <td></td>
     <td></td>

--- a/demos/README.md
+++ b/demos/README.md
@@ -32,7 +32,7 @@ The demo notebooks can be run without any installation of Python by using Binder
     <th><span title='Heterogeneous'>Heter.</span></th>
     <th><span title='Directed'>Dir.</span></th>
     <th><span title='Edge weights'>EW</span></th>
-    <th><span title='Time-varying & temporal'>T</span></th>
+    <th><span title='Time-varying, temporal'>T</span></th>
     <th><span title='Node features'>NF</span></th>
     <th><span title='Node classification'><a href='node-classification/README.md'>NC</a></span></th>
     <th><span title='Link prediction'><a href='link-prediction/README.md'>LP</a></span></th>
@@ -71,7 +71,7 @@ The demo notebooks can be run without any installation of Python by using Binder
   </tr>
   <tr>
     <td><span title='Relational GCN (RGCN)'>RGCN</span></td>
-    <td><span title='Multiple edges types'>yes, edges</span></td>
+    <td><span title='multiple edges types'>yes, edges</span></td>
     <td></td>
     <td></td>
     <td></td>
@@ -150,8 +150,8 @@ The demo notebooks can be run without any installation of Python by using Binder
     <td></td>
     <td></td>
     <td></td>
-    <td><span title='Using embedding vectors'>via RL</span></td>
-    <td><span title='Using embedding vectors'>via RL</span></td>
+    <td><span title='via embedding vectors'>via RL</span></td>
+    <td><span title='via embedding vectors'>via RL</span></td>
     <td><a href='embeddings/graphwave-barbell.ipynb'>demo</a></td>
     <td></td>
     <td></td>
@@ -205,8 +205,8 @@ The demo notebooks can be run without any installation of Python by using Binder
     <td><a href='node-classification/node2vec/stellargraph-node2vec-weighted-random-walks.ipynb'>demo</a></td>
     <td></td>
     <td></td>
-    <td><span title='Using embedding vectors'><a href='node-classification/node2vec/stellargraph-node2vec-node-classification.ipynb'>via RL</a></span></td>
-    <td><span title='Using embedding vectors'><a href='link-prediction/random-walks/cora-lp-demo.ipynb'>via RL</a></span></td>
+    <td><span title='via embedding vectors'><a href='node-classification/node2vec/stellargraph-node2vec-node-classification.ipynb'>via RL</a></span></td>
+    <td><span title='via embedding vectors'><a href='link-prediction/random-walks/cora-lp-demo.ipynb'>via RL</a></span></td>
     <td><a href='embeddings/stellargraph-node2vec.ipynb'>demo</a></td>
     <td></td>
     <td></td>
@@ -218,8 +218,8 @@ The demo notebooks can be run without any installation of Python by using Binder
     <td></td>
     <td></td>
     <td></td>
-    <td><span title='Using embedding vectors'>via RL</span></td>
-    <td><span title='Using embedding vectors'>via RL</span></td>
+    <td><span title='via embedding vectors'>via RL</span></td>
+    <td><span title='via embedding vectors'>via RL</span></td>
     <td><a href='embeddings/stellargraph-metapath2vec.ipynb'>demo</a></td>
     <td></td>
     <td></td>
@@ -231,8 +231,8 @@ The demo notebooks can be run without any installation of Python by using Binder
     <td></td>
     <td>yes</td>
     <td></td>
-    <td><span title='Using embedding vectors'>via RL</span></td>
-    <td><span title='Using embedding vectors'><a href='link-prediction/random-walks/ctdne-link-prediction.ipynb'>via RL</a></span></td>
+    <td><span title='via embedding vectors'>via RL</span></td>
+    <td><span title='via embedding vectors'><a href='link-prediction/random-walks/ctdne-link-prediction.ipynb'>via RL</a></span></td>
     <td>yes</td>
     <td></td>
     <td></td>
@@ -244,20 +244,20 @@ The demo notebooks can be run without any installation of Python by using Binder
     <td></td>
     <td></td>
     <td></td>
-    <td><span title='Using embedding vectors'><a href='embeddings/watch-your-step-cora-demo.ipynb'>via RL</a></span></td>
-    <td><span title='Using embedding vectors'>via RL</span></td>
+    <td><span title='via embedding vectors'><a href='embeddings/watch-your-step-cora-demo.ipynb'>via RL</a></span></td>
+    <td><span title='via embedding vectors'>via RL</span></td>
     <td><a href='embeddings/watch-your-step-cora-demo.ipynb'>demo</a></td>
     <td></td>
     <td></td>
   </tr>
   <tr>
     <td>ComplEx</td>
-    <td><span title='Multiple edges types'>yes, edges</span></td>
+    <td><span title='multiple edges types'>yes, edges</span></td>
     <td>yes</td>
     <td></td>
     <td></td>
     <td></td>
-    <td><span title='Using embedding vectors'>via RL</span></td>
+    <td><span title='via embedding vectors'>via RL</span></td>
     <td><a href='link-prediction/knowledge-graphs/complex.ipynb'>demo</a></td>
     <td>yes</td>
     <td></td>
@@ -265,12 +265,12 @@ The demo notebooks can be run without any installation of Python by using Binder
   </tr>
   <tr>
     <td>DistMult</td>
-    <td><span title='Multiple edges types'>yes, edges</span></td>
+    <td><span title='multiple edges types'>yes, edges</span></td>
     <td>yes</td>
     <td></td>
     <td></td>
     <td></td>
-    <td><span title='Using embedding vectors'>via RL</span></td>
+    <td><span title='via embedding vectors'>via RL</span></td>
     <td><a href='link-prediction/knowledge-graphs/distmult.ipynb'>demo</a></td>
     <td>yes</td>
     <td></td>

--- a/docs/demos/index.txt
+++ b/docs/demos/index.txt
@@ -41,18 +41,18 @@ Find a demo for an algorithm
 
    *
      - Algorithm
-     - Heter.
-     - Dir.
-     - EW
-     - T
-     - NF
-     - :any:`NC <node-classification/index>`
-     - :any:`LP <link-prediction/index>`
-     - :any:`RL <embeddings/index>`
-     - Ind.
-     - :any:`GC <graph-classification/index>`
+     - Heterogeneous
+     - Directed
+     - Edge weights
+     - Time-varying & temporal
+     - Node features
+     - :any:`Node classification <node-classification/index>`
+     - :any:`Link prediction <link-prediction/index>`
+     - :any:`Representation learning <embeddings/index>`
+     - Inductive
+     - :any:`Graph classification <graph-classification/index>`
    *
-     - GCN
+     - Graph Convolutional Network (GCN)
      - see RGCN
      -
      -
@@ -60,7 +60,7 @@ Find a demo for an algorithm
      - yes
      - :any:`demo <node-classification/gcn/gcn-cora-node-classification-example>`
      - :any:`demo <link-prediction/gcn/cora-gcn-links-example>`
-     - US :any:`DGI <embeddings/deep-graph-infomax-cora>`
+     - UnsupervisedSampler :any:`DeepGraphInfomax <embeddings/deep-graph-infomax-cora>`
      - see Cluster-GCN
      - :any:`demo <graph-classification/supervised-graph-classification>`
    *
@@ -76,8 +76,8 @@ Find a demo for an algorithm
      - yes
      -
    *
-     - RGCN
-     - yes, edges
+     - Relational GCN (RGCN)
+     - Multiple edges types
      -
      -
      -
@@ -88,7 +88,7 @@ Find a demo for an algorithm
      -
      -
    *
-     - GAT
+     - Graph ATtention Network (GAT)
      -
      -
      -
@@ -96,11 +96,11 @@ Find a demo for an algorithm
      - yes
      - :any:`demo <node-classification/gat/gat-cora-node-classification-example>`
      - yes
-     - US :any:`DGI <embeddings/deep-graph-infomax-cora>`
+     - UnsupervisedSampler :any:`DeepGraphInfomax <embeddings/deep-graph-infomax-cora>`
      -
      -
    *
-     - SGC
+     - Simplified Graph Convolution (SGC)
      -
      -
      -
@@ -112,7 +112,7 @@ Find a demo for an algorithm
      -
      -
    *
-     - PPNP
+     - Personalized Propagation of Neural Predictions (PPNP)
      -
      -
      -
@@ -120,11 +120,11 @@ Find a demo for an algorithm
      - yes
      - :any:`demo <node-classification/ppnp/ppnp-cora-node-classification-example>`
      - yes
-     - US DGI
+     - UnsupervisedSampler DeepGraphInfomax
      -
      -
    *
-     - APPNP
+     - Approximate PPNP (APPNP)
      -
      -
      -
@@ -132,7 +132,7 @@ Find a demo for an algorithm
      - yes
      - :any:`demo <node-classification/ppnp/ppnp-cora-node-classification-example>`
      - yes
-     - US :any:`DGI <embeddings/deep-graph-infomax-cora>`
+     - UnsupervisedSampler :any:`DeepGraphInfomax <embeddings/deep-graph-infomax-cora>`
      -
      -
    *
@@ -142,8 +142,8 @@ Find a demo for an algorithm
      -
      -
      -
-     - via RL
-     - via RL
+     - Using embedding vectors
+     - Using embedding vectors
      - :any:`demo <embeddings/graphwave-barbell>`
      -
      -
@@ -168,7 +168,7 @@ Find a demo for an algorithm
      - yes
      - :any:`demo <node-classification/graphsage/graphsage-cora-node-classification-example>`
      - :any:`demo <link-prediction/graphsage/cora-links-example>`
-     - :any:`US <embeddings/embeddings-unsupervised-graphsage-cora>` :any:`DGI <embeddings/deep-graph-infomax-cora>`
+     - :any:`UnsupervisedSampler <embeddings/embeddings-unsupervised-graphsage-cora>` :any:`DeepGraphInfomax <embeddings/deep-graph-infomax-cora>`
      - :any:`demo <node-classification/graphsage/graphsage-pubmed-inductive-node-classification-example>`
      -
    *
@@ -180,7 +180,7 @@ Find a demo for an algorithm
      - yes
      - yes
      - :any:`demo <link-prediction/hinsage/movielens-recommender>`
-     - :any:`DGI <embeddings/deep-graph-infomax-cora>`
+     - :any:`DeepGraphInfomax <embeddings/deep-graph-infomax-cora>`
      - yes
      -
    *
@@ -190,8 +190,8 @@ Find a demo for an algorithm
      - :any:`demo <node-classification/node2vec/stellargraph-node2vec-weighted-random-walks>`
      -
      -
-     - :any:`via RL <node-classification/node2vec/stellargraph-node2vec-node-classification>`
-     - :any:`via RL <link-prediction/random-walks/cora-lp-demo>`
+     - :any:`Using embedding vectors <node-classification/node2vec/stellargraph-node2vec-node-classification>`
+     - :any:`Using embedding vectors <link-prediction/random-walks/cora-lp-demo>`
      - :any:`demo <embeddings/stellargraph-node2vec>`
      -
      -
@@ -202,20 +202,20 @@ Find a demo for an algorithm
      -
      -
      -
-     - via RL
-     - via RL
+     - Using embedding vectors
+     - Using embedding vectors
      - :any:`demo <embeddings/stellargraph-metapath2vec>`
      -
      -
    *
-     - CTDNE
+     - Continuous-Time Dynamic Network Embeddings
      -
      -
      -
      - yes
      -
-     - via RL
-     - :any:`via RL <link-prediction/random-walks/ctdne-link-prediction>`
+     - Using embedding vectors
+     - :any:`Using embedding vectors <link-prediction/random-walks/ctdne-link-prediction>`
      - yes
      -
      -
@@ -226,31 +226,31 @@ Find a demo for an algorithm
      -
      -
      -
-     - :any:`via RL <embeddings/watch-your-step-cora-demo>`
-     - via RL
+     - :any:`Using embedding vectors <embeddings/watch-your-step-cora-demo>`
+     - Using embedding vectors
      - :any:`demo <embeddings/watch-your-step-cora-demo>`
      -
      -
    *
      - ComplEx
-     - yes, edges
+     - Multiple edges types
      - yes
      -
      -
      -
-     - via RL
+     - Using embedding vectors
      - :any:`demo <link-prediction/knowledge-graphs/complex>`
      - yes
      -
      -
    *
      - DistMult
-     - yes, edges
+     - Multiple edges types
      - yes
      -
      -
      -
-     - via RL
+     - Using embedding vectors
      - :any:`demo <link-prediction/knowledge-graphs/distmult>`
      - yes
      -

--- a/docs/demos/index.txt
+++ b/docs/demos/index.txt
@@ -89,7 +89,7 @@ Find a demo for an algorithm
      -
      -
    *
-     - Temporal GCN, implemented as GCN-LSTM
+     - Temporal GCN (T-GCN), implemented as GCN-LSTM
      -
      -
      -

--- a/docs/demos/index.txt
+++ b/docs/demos/index.txt
@@ -44,7 +44,7 @@ Find a demo for an algorithm
      - Heterogeneous
      - Directed
      - Edge weights
-     - Time-varying & temporal
+     - Time-varying, temporal
      - Node features
      - :any:`Node classification <node-classification/index>`
      - :any:`Link prediction <link-prediction/index>`
@@ -60,7 +60,7 @@ Find a demo for an algorithm
      - yes
      - :any:`demo <node-classification/gcn/gcn-cora-node-classification-example>`
      - :any:`demo <link-prediction/gcn/cora-gcn-links-example>`
-     - UnsupervisedSampler :any:`DeepGraphInfomax <embeddings/deep-graph-infomax-cora>`
+     - UnsupervisedSampler, :any:`DeepGraphInfomax <embeddings/deep-graph-infomax-cora>`
      - see Cluster-GCN
      - :any:`demo <graph-classification/supervised-graph-classification>`
    *
@@ -77,7 +77,7 @@ Find a demo for an algorithm
      -
    *
      - Relational GCN (RGCN)
-     - Multiple edges types
+     - multiple edges types
      -
      -
      -
@@ -96,7 +96,7 @@ Find a demo for an algorithm
      - yes
      - :any:`demo <node-classification/gat/gat-cora-node-classification-example>`
      - yes
-     - UnsupervisedSampler :any:`DeepGraphInfomax <embeddings/deep-graph-infomax-cora>`
+     - UnsupervisedSampler, :any:`DeepGraphInfomax <embeddings/deep-graph-infomax-cora>`
      -
      -
    *
@@ -120,7 +120,7 @@ Find a demo for an algorithm
      - yes
      - :any:`demo <node-classification/ppnp/ppnp-cora-node-classification-example>`
      - yes
-     - UnsupervisedSampler DeepGraphInfomax
+     - UnsupervisedSampler, DeepGraphInfomax
      -
      -
    *
@@ -132,7 +132,7 @@ Find a demo for an algorithm
      - yes
      - :any:`demo <node-classification/ppnp/ppnp-cora-node-classification-example>`
      - yes
-     - UnsupervisedSampler :any:`DeepGraphInfomax <embeddings/deep-graph-infomax-cora>`
+     - UnsupervisedSampler, :any:`DeepGraphInfomax <embeddings/deep-graph-infomax-cora>`
      -
      -
    *
@@ -142,8 +142,8 @@ Find a demo for an algorithm
      -
      -
      -
-     - Using embedding vectors
-     - Using embedding vectors
+     - via embedding vectors
+     - via embedding vectors
      - :any:`demo <embeddings/graphwave-barbell>`
      -
      -
@@ -168,7 +168,7 @@ Find a demo for an algorithm
      - yes
      - :any:`demo <node-classification/graphsage/graphsage-cora-node-classification-example>`
      - :any:`demo <link-prediction/graphsage/cora-links-example>`
-     - :any:`UnsupervisedSampler <embeddings/embeddings-unsupervised-graphsage-cora>` :any:`DeepGraphInfomax <embeddings/deep-graph-infomax-cora>`
+     - :any:`UnsupervisedSampler <embeddings/embeddings-unsupervised-graphsage-cora>`, :any:`DeepGraphInfomax <embeddings/deep-graph-infomax-cora>`
      - :any:`demo <node-classification/graphsage/graphsage-pubmed-inductive-node-classification-example>`
      -
    *
@@ -190,8 +190,8 @@ Find a demo for an algorithm
      - :any:`demo <node-classification/node2vec/stellargraph-node2vec-weighted-random-walks>`
      -
      -
-     - :any:`Using embedding vectors <node-classification/node2vec/stellargraph-node2vec-node-classification>`
-     - :any:`Using embedding vectors <link-prediction/random-walks/cora-lp-demo>`
+     - :any:`via embedding vectors <node-classification/node2vec/stellargraph-node2vec-node-classification>`
+     - :any:`via embedding vectors <link-prediction/random-walks/cora-lp-demo>`
      - :any:`demo <embeddings/stellargraph-node2vec>`
      -
      -
@@ -202,8 +202,8 @@ Find a demo for an algorithm
      -
      -
      -
-     - Using embedding vectors
-     - Using embedding vectors
+     - via embedding vectors
+     - via embedding vectors
      - :any:`demo <embeddings/stellargraph-metapath2vec>`
      -
      -
@@ -214,8 +214,8 @@ Find a demo for an algorithm
      -
      - yes
      -
-     - Using embedding vectors
-     - :any:`Using embedding vectors <link-prediction/random-walks/ctdne-link-prediction>`
+     - via embedding vectors
+     - :any:`via embedding vectors <link-prediction/random-walks/ctdne-link-prediction>`
      - yes
      -
      -
@@ -226,31 +226,31 @@ Find a demo for an algorithm
      -
      -
      -
-     - :any:`Using embedding vectors <embeddings/watch-your-step-cora-demo>`
-     - Using embedding vectors
+     - :any:`via embedding vectors <embeddings/watch-your-step-cora-demo>`
+     - via embedding vectors
      - :any:`demo <embeddings/watch-your-step-cora-demo>`
      -
      -
    *
      - ComplEx
-     - Multiple edges types
+     - multiple edges types
      - yes
      -
      -
      -
-     - Using embedding vectors
+     - via embedding vectors
      - :any:`demo <link-prediction/knowledge-graphs/complex>`
      - yes
      -
      -
    *
      - DistMult
-     - Multiple edges types
+     - multiple edges types
      - yes
      -
      -
      -
-     - Using embedding vectors
+     - via embedding vectors
      - :any:`demo <link-prediction/knowledge-graphs/distmult>`
      - yes
      -

--- a/scripts/demo_table.py
+++ b/scripts/demo_table.py
@@ -385,7 +385,7 @@ ALGORITHMS = [
         lp=True,
     ),
     Algorithm(
-        T("T-GCN", details="Temporal GCN, implemented as GCN-LSTM"),
+        T("T-GCN", details="Temporal GCN (T-GCN), implemented as GCN-LSTM"),
         features="time series, sequence",
         temporal="node features",
         nc=T(link="time-series/gcn-lstm-LA"),

--- a/scripts/demo_table.py
+++ b/scripts/demo_table.py
@@ -352,11 +352,7 @@ def rl_dgi(link="embeddings/deep-graph-infomax-cora"):
 
 
 def via_rl(link=None):
-    return T(
-        "via RL",
-        link=link,
-        details="Using embedding vectors",
-    )
+    return T("via RL", link=link, details="Using embedding vectors",)
 
 
 ALGORITHMS = [

--- a/scripts/demo_table.py
+++ b/scripts/demo_table.py
@@ -223,11 +223,13 @@ class Rst(Format):
 
     def _render_t(self, t):
         link = self.link(t)
+        # RST doesn't support the title, directly, but CSS gives us a bit more control to display
+        # longer column headings
+        text = t.details if t.details else t.text
         if link:
-            # RST doesn't support the title, directly
-            return f":any:`{t.text} <{link}>`"
+            return f":any:`{text} <{link}>`"
 
-        return t.text
+        return text
 
     def _render_cell(self, cell):
         if not cell:
@@ -278,10 +280,10 @@ def index_link(*args, **kwargs):
 
 
 ALGORITHM = T("Algorithm")
-HETEROGENEOUS = T("Heter.", details="Heterogeneous graphs")
+HETEROGENEOUS = T("Heter.", details="Heterogeneous")
 DIRECTED = T("Dir.", details="Directed")
 WEIGHTED = T("EW", details="Edge weights")
-TEMPORAL = T("T", details="Time-varying or temporal graphs")
+TEMPORAL = T("T", details="Time-varying & temporal")
 FEATURES = T("NF", details="Node features")
 NC = index_link("NC", link="node-classification", details="Node classification")
 LP = index_link("LP", link="link-prediction", details="Link prediction")
@@ -338,28 +340,28 @@ class Algorithm:
         self.columns = {name: T.textify(value) for name, value in columns.items()}
 
 
-HETEROGENEOUS_EDGE = T("yes, edges", details="Multiple edges types and one node type")
+HETEROGENEOUS_EDGE = T("yes, edges", details="Multiple edges types")
 
 
 def rl_us(link=None):
-    return T("US", link=link, details="UnsupervisedSampler, using link prediction")
+    return T("US", link=link, details="UnsupervisedSampler")
 
 
 def rl_dgi(link="embeddings/deep-graph-infomax-cora"):
-    return T("DGI", link=link, details="DeepGraphInfomax, using mutual information")
+    return T("DGI", link=link, details="DeepGraphInfomax")
 
 
 def via_rl(link=None):
     return T(
         "via RL",
         link=link,
-        details="As a downstream task by training a classifier on reprentation/embedding vectors",
+        details="Using embedding vectors",
     )
 
 
 ALGORITHMS = [
     Algorithm(
-        T("GCN", details="Graph Convolutional Network"),
+        T("GCN", details="Graph Convolutional Network (GCN)"),
         heterogeneous="see RGCN",
         features=True,
         nc=T(link="node-classification/gcn/gcn-cora-node-classification-example"),
@@ -379,14 +381,14 @@ ALGORITHMS = [
         inductive=True,
     ),
     Algorithm(
-        T("RGCN", details="Relational GCN"),
+        T("RGCN", details="Relational GCN (RGCN)"),
         heterogeneous=HETEROGENEOUS_EDGE,
         features=True,
         nc=T(link="node-classification/rgcn/rgcn-aifb-node-classification-example"),
         lp=True,
     ),
     Algorithm(
-        T("GAT", details="Graph ATtention Network"),
+        T("GAT", details="Graph ATtention Network (GAT)"),
         features=True,
         nc=T(link="node-classification/gat/gat-cora-node-classification-example"),
         interpretability_nc=T(
@@ -396,20 +398,20 @@ ALGORITHMS = [
         rl=[rl_us(), rl_dgi()],
     ),
     Algorithm(
-        T("SGC", details="Simplified Graph Convolution"),
+        T("SGC", details="Simplified Graph Convolution (SGC)"),
         features=True,
         nc=T(link="node-classification/sgc/sgc-node-classification-example"),
         lp=True,
     ),
     Algorithm(
-        T("PPNP", details="Personalized Propagation of Neural Predictions"),
+        T("PPNP", details="Personalized Propagation of Neural Predictions (PPNP)"),
         features=True,
         nc=T(link="node-classification/ppnp/ppnp-cora-node-classification-example"),
         lp=True,
         rl=[rl_us(), rl_dgi(link=None)],
     ),
     Algorithm(
-        T("APPNP", details="Approximate PPNP"),
+        T("APPNP", details="Approximate PPNP (APPNP)"),
         features=True,
         nc=T(link="node-classification/ppnp/ppnp-cora-node-classification-example"),
         lp=True,

--- a/scripts/demo_table.py
+++ b/scripts/demo_table.py
@@ -236,7 +236,7 @@ class Rst(Format):
             return ""
 
         if isinstance(cell, list):
-            return " ".join(self._render_cell(contents) for contents in cell)
+            return ", ".join(self._render_cell(contents) for contents in cell)
         else:
             return self._render_t(cell)
 
@@ -283,7 +283,7 @@ ALGORITHM = T("Algorithm")
 HETEROGENEOUS = T("Heter.", details="Heterogeneous")
 DIRECTED = T("Dir.", details="Directed")
 WEIGHTED = T("EW", details="Edge weights")
-TEMPORAL = T("T", details="Time-varying & temporal")
+TEMPORAL = T("T", details="Time-varying, temporal")
 FEATURES = T("NF", details="Node features")
 NC = index_link("NC", link="node-classification", details="Node classification")
 LP = index_link("LP", link="link-prediction", details="Link prediction")
@@ -340,7 +340,7 @@ class Algorithm:
         self.columns = {name: T.textify(value) for name, value in columns.items()}
 
 
-HETEROGENEOUS_EDGE = T("yes, edges", details="Multiple edges types")
+HETEROGENEOUS_EDGE = T("yes, edges", details="multiple edges types")
 
 
 def rl_us(link=None):
@@ -352,7 +352,7 @@ def rl_dgi(link="embeddings/deep-graph-infomax-cora"):
 
 
 def via_rl(link=None):
-    return T("via RL", link=link, details="Using embedding vectors",)
+    return T("via RL", link=link, details="via embedding vectors",)
 
 
 ALGORITHMS = [


### PR DESCRIPTION
This replaces the abbreviations used in the reStructuredText demo table with the full, more descriptive text. The full text is obviously longer, so the lack of word-wrapping and extreme sideways scrolling is made worse, but that's a separate/pre-existing problem #1418.

Rendered table: https://stellargraph--1447.org.readthedocs.build/en/1447/demos/index.html#find-a-demo-for-an-algorithm

See: #1417