### PR TITLE
Point to Read the Docs, not Github, for demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ StellarGraph is built on [TensorFlow 2](https://tensorflow.org/) and its [Keras 
 
 ## Getting Started
 
-[The numerous detailed and narrated examples](https://github.com/stellargraph/stellargraph/tree/master/demos/) are a good way to get started with StellarGraph. There is likely to be one that is similar to your data or your problem (if not, [let us know](#getting-help)).
+[The numerous detailed and narrated examples][demos] are a good way to get started with StellarGraph. There is likely to be one that is similar to your data or your problem (if not, [let us know](#getting-help)).
+
+[demos]: https://stellargraph.readthedocs.io/en/stable/demos/index.html
 
 You can start working with the examples immediately in Google Colab or Binder by clicking the ![](https://colab.research.google.com/assets/colab-badge.svg) and ![](https://mybinder.org/badge_logo.svg) badges within each Jupyter notebook.
 
@@ -97,7 +99,7 @@ All dependencies required to run our demo notebooks locally can be installed usi
 If you get stuck or have a problem, there's many ways to make progress and get help or support:
 
 - [Read the documentation](https://stellargraph.readthedocs.io)
-- [Consult the examples](https://github.com/stellargraph/stellargraph/tree/master/demos/)
+- [Consult the examples][demos]
 - Contact us:
   - [Ask questions and discuss problems on the StellarGraph Discourse forum](https://community.stellargraph.io)
   - [File an issue](https://github.com/stellargraph/stellargraph/issues/new/choose)
@@ -166,7 +168,9 @@ model.fit(generator.flow(train_targets.index, train_targets), epochs=5)
 print(f"Test set: loss = {loss}, accuracy = {accuracy}")
 ```
 
-This algorithm is spelled out in more detail in [its extended narrated notebook](https://github.com/stellargraph/stellargraph/tree/master/demos/node-classification/gcn/gcn-cora-node-classification-example.ipynb). We provide [many more algorithms, each with a detailed example](https://github.com/stellargraph/stellargraph/tree/master/demos/).
+This algorithm is spelled out in more detail in [its extended narrated notebook][gcn-demo]. We provide [many more algorithms, each with a detailed example][demos].
+
+[gcn-demo]: https://stellargraph.readthedocs.io/en/latest/demos/node-classification/gcn/gcn-cora-node-classification-example.html
 
 ## Algorithms
 The StellarGraph library currently includes the following algorithms for graph machine learning:
@@ -207,7 +211,7 @@ To install StellarGraph library from [PyPI](https://pypi.org) using `pip`, execu
 pip install stellargraph
 ```
 
-Some of the examples in the `demos` [directory](https://github.com/stellargraph/stellargraph/tree/master/demos) require installing additional dependencies as well as `stellargraph`. To install these dependencies as well as StellarGraph using `pip` execute the following command:
+[Some of the examples][demos] require installing additional dependencies as well as `stellargraph`. To install these dependencies as well as StellarGraph using `pip` execute the following command:
 ```
 pip install stellargraph[demos]
 ```

--- a/demos/community_detection/attacks_clustering_analysis.ipynb
+++ b/demos/community_detection/attacks_clustering_analysis.ipynb
@@ -69,7 +69,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For more detailed explanation of unsupervised graphSAGE see [Unsupervised graphSAGE demo](https://github.com/stellargraph/stellargraph/master/demos/embeddings/embeddings-unsupervised-graphsage-cora.ipynb)."
+    "For more detailed explanation of unsupervised graphSAGE see [Unsupervised graphSAGE demo](https://stellargraph.readthedocs.io/en/stable/demos/embeddings/embeddings-unsupervised-graphsage-cora.html)."
    ]
   },
   {
@@ -1338,7 +1338,7 @@
    "source": [
     "### Unsupervised graphSAGE\n",
     "\n",
-    "(For a detailed unsupervised GraphSAGE workflow with a narrative, see [Unsupervised graphSAGE demo](https://github.com/stellargraph/stellargraph/master/demos/embeddings/embeddings-unsupervised-graphsage-cora.ipynb))"
+    "(For a detailed unsupervised GraphSAGE workflow with a narrative, see [Unsupervised graphSAGE demo](https://stellargraph.readthedocs.io/en/stable/demos/embeddings/embeddings-unsupervised-graphsage-cora.html))"
    ]
   },
   {

--- a/demos/embeddings/embeddings-unsupervised-graphsage-cora.ipynb
+++ b/demos/embeddings/embeddings-unsupervised-graphsage-cora.ipynb
@@ -31,7 +31,7 @@
     "\n",
     "A high-level explanation of the unsupervised GraphSAGE method of graph representation learning is as follows.\n",
     "\n",
-    "Objective: *Given a graph, learn embeddings of the nodes using only the graph structure and the node features, without using any known node class labels* (hence \"unsupervised\"; for semi-supervised learning of node embeddings, see this [demo](https://github.com/stellargraph/stellargraph/tree/master/demos/node-classification/graphsage/graphsage-cora-node-classification-example.ipynb))\n",
+    "Objective: *Given a graph, learn embeddings of the nodes using only the graph structure and the node features, without using any known node class labels* (hence \"unsupervised\"; for semi-supervised learning of node embeddings, see this [demo](https://stellargraph.readthedocs.io/en/stable/demos/node-classification/graphsage/graphsage-cora-node-classification-example.html))\n",
     "\n",
     "**Unsupervised GraphSAGE model:** In the Unsupervised GraphSAGE model, node embeddings are learnt by solving a simple classification task: given a large set of \"positive\" `(target, context)` node pairs generated from random walks performed on the graph (i.e., node pairs that co-occur within a certain context window in random walks), and an equally large set of \"negative\" node pairs that are randomly selected from the graph according to a certain distribution, learn a binary classifier that predicts whether arbitrary node pairs are likely to co-occur in a random walk performed on the graph. Through learning this simple binary node-pair-classification task, the model automatically learns an inductive mapping from attributes of nodes and their neighbors to node embeddings in a high-dimensional vector space, which preserves structural and feature similarities of the nodes. Unlike embeddings obtained by algorithms such as [Node2Vec](https://snap.stanford.edu/node2vec), this mapping is inductive: given a new node (with attributes) and its links to other nodes in the graph (which was unseen during model training), we can evaluate its embeddings without having to re-train the model. \n",
     "\n",
@@ -681,7 +681,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The obtained accuracy is pretty decent, better than that obtained by using node embeddings obtained by `node2vec` that ignores node attributes, only taking into account the graph structure (see this [demo](https://github.com/stellargraph/stellargraph/tree/master/demos/embeddings/stellargraph-node2vec.ipynb)). "
+    "The obtained accuracy is pretty decent, better than that obtained by using node embeddings obtained by `node2vec` that ignores node attributes, only taking into account the graph structure (see this [demo](https://stellargraph.readthedocs.io/en/stable/demos/embeddings/stellargraph-node2vec.html)). "
    ]
   },
   {

--- a/demos/embeddings/stellargraph-node2vec.ipynb
+++ b/demos/embeddings/stellargraph-node2vec.ipynb
@@ -333,7 +333,7 @@
     "\n",
     "The node embeddings calculated using Word2Vec can be used as feature vectors in a downstream task such as node attribute inference (e.g., inferring the subject of a paper in Cora), community detection (clustering of nodes based on the similarity of their embedding vectors), and link prediction (e.g., prediction of citation links between papers).\n",
     "\n",
-    "For a more detailed example of using Node2Vec for link prediction see [this example](https://github.com/stellargraph/stellargraph/tree/master/demos/link-prediction/random-walks/cora-lp-demo.ipynb)."
+    "For a more detailed example of using Node2Vec for link prediction see [this example](https://stellargraph.readthedocs.io/en/stable/demos/link-prediction/random-walks/cora-lp-demo.html)."
    ]
   },
   {

--- a/stellargraph/mapper/full_batch_generators.py
+++ b/stellargraph/mapper/full_batch_generators.py
@@ -234,7 +234,7 @@ class FullBatchNodeGenerator(FullBatchGenerator):
         # Alternatively, use the generator itself with model.fit:
         model.fit(train_flow, epochs=num_epochs)
 
-    For more information, please see the GCN, GAT, PPNP/APPNP and SGC demos: `<https://github.com/stellargraph/stellargraph/blob/master/demos/>`_
+    For more information, please see the :doc:`GCN, GAT, PPNP/APPNP and SGC demos <demos/index>`.
 
     Args:
         G (StellarGraphBase): a machine-learning StellarGraph-type graph
@@ -320,7 +320,7 @@ class FullBatchLinkGenerator(FullBatchGenerator):
         # Alternatively, use the generator itself with model.fit:
         model.fit(train_flow, epochs=num_epochs)
 
-    For more information, please see the GCN, GAT, PPNP/APPNP and SGC demos: `<https://github.com/stellargraph/stellargraph/blob/master/demos/>`_
+    For more information, please see the :doc:`GCN, GAT, PPNP/APPNP and SGC demos <demos/index>`.
 
     Args:
         G (StellarGraphBase): a machine-learning StellarGraph-type graph

--- a/stellargraph/mapper/full_batch_generators.py
+++ b/stellargraph/mapper/full_batch_generators.py
@@ -234,7 +234,7 @@ class FullBatchNodeGenerator(FullBatchGenerator):
         # Alternatively, use the generator itself with model.fit:
         model.fit(train_flow, epochs=num_epochs)
 
-    For more information, please see the :doc:`GCN, GAT, PPNP/APPNP and SGC demos <demos/index>`.
+    For more information, please see the `GCN, GAT, PPNP/APPNP and SGC demos <https://stellargraph.readthedocs.io/en/stable/demos/index.html>`_.
 
     Args:
         G (StellarGraphBase): a machine-learning StellarGraph-type graph
@@ -320,7 +320,7 @@ class FullBatchLinkGenerator(FullBatchGenerator):
         # Alternatively, use the generator itself with model.fit:
         model.fit(train_flow, epochs=num_epochs)
 
-    For more information, please see the :doc:`GCN, GAT, PPNP/APPNP and SGC demos <demos/index>`.
+    For more information, please see the `GCN, GAT, PPNP/APPNP and SGC demos <https://stellargraph.readthedocs.io/en/stable/demos/index.html>`_.
 
     Args:
         G (StellarGraphBase): a machine-learning StellarGraph-type graph

--- a/stellargraph/mapper/mini_batch_node_generators.py
+++ b/stellargraph/mapper/mini_batch_node_generators.py
@@ -45,7 +45,7 @@ class ClusterNodeGenerator(Generator):
 
     [1] `W. Chiang, X. Liu, S. Si, Y. Li, S. Bengio, C. Hsieh, 2019 <https://arxiv.org/abs/1905.07953>`_.
 
-    For more information, please see :doc:`the ClusterGCN demo <demos/node-classification/cluster-gcn/cluster-gcn-node-classification>`.
+    For more information, please see `the ClusterGCN demo <https://stellargraph.readthedocs.io/en/stable/demos/node-classification/cluster-gcn/cluster-gcn-node-classification.html>`_.
 
     Args:
         G (StellarGraph): a machine-learning StellarGraph-type graph

--- a/stellargraph/mapper/mini_batch_node_generators.py
+++ b/stellargraph/mapper/mini_batch_node_generators.py
@@ -45,7 +45,7 @@ class ClusterNodeGenerator(Generator):
 
     [1] `W. Chiang, X. Liu, S. Si, Y. Li, S. Bengio, C. Hsieh, 2019 <https://arxiv.org/abs/1905.07953>`_.
 
-    For more information, please see the ClusterGCN demo: `<https://github.com/stellargraph/stellargraph/blob/master/demos/>`_
+    For more information, please see :doc:`the ClusterGCN demo <demos/node-classification/cluster-gcn/cluster-gcn-node-classification>`.
 
     Args:
         G (StellarGraph): a machine-learning StellarGraph-type graph


### PR DESCRIPTION
This updates any links to our Github demos folder to instead point to Read the Docs. 

The links within documentation _could_ be ``:doc:`... <demos/index>` `` relative links (or similar), but these will not work outside of Sphinx/Read the Docs (e.g. in `help(ClusterNodeGenerator)`). As such, this instead uses the full URLs always. To get the benefits of relative links (e.g. consistent versioning, and working locally without jumping out to the internet), we can post-process them in future (#1402 #1404).

See: #1420 