### PR TITLE
Add DGCNN demo to Read the Docs

### DIFF
--- a/docs/demos/graph-classification/dgcnn-graph-classification.nblink
+++ b/docs/demos/graph-classification/dgcnn-graph-classification.nblink
@@ -1,0 +1,3 @@
+{
+  "path": "../../../demos/graph-classification/dgcnn-graph-classification.ipynb"
+}

--- a/docs/demos/graph-classification/index.txt
+++ b/docs/demos/graph-classification/index.txt
@@ -1,9 +1,9 @@
 Graph classification using StellarGraph
 =======================================
 
-`StellarGraph <https://github.com/stellargraph/stellargraph>`_ provides algorithms for graph classification. This folder contains a demo to explain how they works and how to use them as part of a TensorFlow Keras data science workflow.
+`StellarGraph <https://github.com/stellargraph/stellargraph>`_ provides algorithms for graph classification. This folder contains demos to explain how they work and how to use them as part of a TensorFlow Keras data science workflow.
 
-A graph classification task predicts an attribute of each graph in a collection of graphs. For instance, labelling each graph with a categorical class (binary classification or multiclass classification), or predicting a continuous number (regression). It is supervised or semi-supervised, where the model is trained using a subset of graphs that have ground-truth labels.
+A graph classification task predicts an attribute of each graph in a collection of graphs. For instance, labelling each graph with a categorical class (binary classification or multiclass classification), or predicting a continuous number (regression). It is supervised, where the model is trained using a subset of graphs that have ground-truth labels.
 
 Find algorithms and demos for a collection of graphs
 ----------------------------------------------------

--- a/docs/demos/graph-classification/index.txt
+++ b/docs/demos/graph-classification/index.txt
@@ -1,7 +1,7 @@
 Graph classification using StellarGraph
 =======================================
 
-`StellarGraph <https://github.com/stellargraph/stellargraph>`_ provides an algorithm for graph classification. This folder contains a demo to explain how it works and how to use it as part of a TensorFlow Keras data science workflow.
+`StellarGraph <https://github.com/stellargraph/stellargraph>`_ provides algorithms for graph classification. This folder contains a demo to explain how they works and how to use them as part of a TensorFlow Keras data science workflow.
 
 A graph classification task predicts an attribute of each graph in a collection of graphs. For instance, labelling each graph with a categorical class (binary classification or multiclass classification), or predicting a continuous number (regression). It is supervised or semi-supervised, where the model is trained using a subset of graphs that have ground-truth labels.
 
@@ -19,6 +19,10 @@ This table lists all graph classification demos, including the algorithms traine
      - inductive
    * - :doc:`GCN Supervised Graph Classification <supervised-graph-classification>`
      - GCN, mean pooling
+     - yes
+     - yes
+   * - :doc:`DGCNN <dgcnn-graph-classification`
+     - DeepGraphCNN
      - yes
      - yes
 

--- a/docs/demos/graph-classification/index.txt
+++ b/docs/demos/graph-classification/index.txt
@@ -21,7 +21,7 @@ This table lists all graph classification demos, including the algorithms traine
      - GCN, mean pooling
      - yes
      - yes
-   * - :doc:`DGCNN <dgcnn-graph-classification`
+   * - :doc:`DGCNN <dgcnn-graph-classification>`
      - DeepGraphCNN
      - yes
      - yes


### PR DESCRIPTION
This adds the notebook to be rendered on Read the Docs and adjusts the graph classification index to match.

Graph classification index: https://stellargraph--1450.org.readthedocs.build/en/1450/demos/graph-classification/index.html
Notebook: https://stellargraph--1450.org.readthedocs.build/en/1450/demos/graph-classification/dgcnn-graph-classification.html

See: #1449