### PR TITLE
fix calibration headings for demo documentation (#1443)

### DIFF
--- a/demos/calibration/README.md
+++ b/demos/calibration/README.md
@@ -1,4 +1,4 @@
-## Ensemble learning for graph neural network algorithms
+## Model calibration
 
 This folder contains two [Jupyter](http://jupyter.org/) python notebooks demonstrating `StellarGraph` model calibration
 for binary (`calibration-pubmed-link-prediction.ipynb`) and multi-class

--- a/docs/demos/calibration/index.txt
+++ b/docs/demos/calibration/index.txt
@@ -1,4 +1,4 @@
-Ensemble learning for graph neural network algorithms
+Model calibration
 =====================================================
 
 This folder contains two `Jupyter <http://jupyter.org/>`_ python notebooks demonstrating ``StellarGraph`` model calibration for binary (``calibration-pubmed-link-prediction.ipynb``) and multi-class classification (``calibration-pubmed-node-classification.ipynb``) problems.


### PR DESCRIPTION
See: #1443
The readme for the calibration demos (and readthedocs) was never updated to say "model calibration"