### PR TITLE
Stop publishing the docker image

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -229,36 +229,6 @@ steps:
     agents:
       queue: "t2medium"
 
-  - label: ":docker: build image"
-    <<: *timeout
-    plugins:
-      <<: *plugins
-      docker-compose#v3.2.0:
-        <<: *compose-config
-        build:
-          - stellargraph
-        image-repository: index.docker.io/stellargraph/stellargraph
-        # Caching can cause packages to be pinned to old (possibly-vulnerable) versions for long
-        # periods.  Setting `REFRESH_BUILD=true` allows for builds (e.g. scheduled builds) to start
-        # from scratch and refresh the caches.
-        no-cache: ${REFRESH_BUILD-false}
-        cache-from:
-          - stellargraph:index.docker.io/stellargraph/stellargraph:${IMAGE_TAG}
-          - stellargraph:index.docker.io/stellargraph/stellargraph:latest
-    agents:
-      queue: "t2medium"
-
-  - wait
-
-  - label: ":docker: publish image"
-    <<: *timeout
-    plugins:
-      <<: *plugins
-      docker-compose#v3.2.0:
-        <<: *compose-config
-        push:
-          - stellargraph:index.docker.io/stellargraph/stellargraph:${IMAGE_TAG}
-
   # Analyse the results of the testing, e.g. failures. This is not part of the testing, and has
   # explicit dependencies, so can be listed after all of the `wait` steps and publishings, so that
   # it runs in parallel with them.

--- a/README.md
+++ b/README.md
@@ -27,9 +27,6 @@
   <a href="https://codecov.io/gh/stellargraph/stellargraph">
     <img src="https://codecov.io/gh/stellargraph/stellargraph/branch/develop/graph/badge.svg" />
   </a>
-  <a href="https://cloud.docker.com/r/stellargraph/stellargraph" alt="docker hub">
-    <img alt="Docker Pulls" src="https://img.shields.io/docker/pulls/stellargraph/stellargraph.svg">
-  </a>
   <a href="https://pypi.org/project/stellargraph" alt="pypi downloads">
     <img alt="pypi downloads" src="https://pepy.tech/badge/stellargraph">
   </a>
@@ -50,7 +47,6 @@
        * [Install StellarGraph using PyPI](#install-stellargraph-using-pypi)
        * [Install StellarGraph in Anaconda Python](#Install-stellargraph-in-anaconda-python)
        * [Install StellarGraph from Github source](#install-stellargraph-from-github-source)
-       * [Docker Image](#docker-image)
    * [Citing](#citing)
    * [References](#references)
 
@@ -240,13 +236,6 @@ Some of the examples in the `demos` directory require installing additional depe
 ```
 pip install .[demos]
 ```
-
-
-#### Docker Image
-
-* [stellargraph/stellargraph](https://hub.docker.com/r/stellargraph/stellargraph): Docker image with `stellargraph` installed.
-
-Images can be pulled via `docker pull stellargraph/stellargraph`
 
 
 ## Citing


### PR DESCRIPTION
Per #1382, our docker image is currently only published from `develop`, meaning there's no stable releases. We don't particularly want our users using random points on `develop`, because this doesn't have the bug fixing and polish that happens just before each release.

Rather than try to get stable images published for the upcoming 1.0 release tomorrow, this just disables them for now.

Thoughts?

See: #1382