### PR TITLE
Add custom CSS for cell wrapping in demo table

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,0 +1,14 @@
+/**** override table width restrictions *****/
+
+.wy-table-responsive table td, .wy-table-responsive table th {
+    /* cells can wrap to be multi-line */
+    white-space: normal;
+}
+
+/* table can overhang the normal text width */
+.wy-table-responsive table {
+    background: white;
+}
+.wy-table-responsive {
+    overflow: visible;
+}

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,3 +1,8 @@
+div.wy-nav-content {
+    /* make the main content wider, for wider tables */
+    max-width: 1200px;
+}
+
 /**** override table width restrictions *****/
 
 .wy-table-responsive table td, .wy-table-responsive table th {

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -4,11 +4,3 @@
     /* cells can wrap to be multi-line */
     white-space: normal;
 }
-
-/* table can overhang the normal text width */
-.wy-table-responsive table {
-    background: white;
-}
-.wy-table-responsive {
-    overflow: visible;
-}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -227,3 +227,5 @@ class RewriteLinks(docutils.transforms.Transform):
 
 def setup(app):
     app.add_transform(RewriteLinks)
+
+    app.add_stylesheet("custom.css")


### PR DESCRIPTION
Alternative to #1456, without letting the table overflow the docs' right margin.

Examples: (both screen shots are demonstrating the scrolling)

- Rendered top level index: https://stellargraph--1457.org.readthedocs.build/en/1457/demos/index.html#find-a-demo-for-an-algorithm ![image](https://user-images.githubusercontent.com/1203825/80933673-161b6c80-8e08-11ea-9bc3-739a4601627e.png)
- Rendered sub-index (node classification): https://stellargraph--1457.org.readthedocs.build/en/1457/demos/node-classification/index.html ![image](https://user-images.githubusercontent.com/1203825/80933705-377c5880-8e08-11ea-8e51-b4e04c60e753.png)

See: #1418