### PR TITLE
Update download link and include in demo readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Alternatively, you can run download a local copy of the demos and run them using
 curl -L https://github.com/stellargraph/stellargraph/archive/master.zip | tar -xz --strip=1 stellargraph-master/demos
 ```
 
-All dependencies required to run our demo notebooks locally can be installed using one of the following:
+The dependencies required to run most of our demo notebooks locally can be installed using one of the following:
 
 - Using pip: `pip install stellargraph[demos]`
 - Using conda: `conda install -c stellargraph stellargraph`

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ You can start working with the examples immediately in Google Colab or Binder by
 
 Alternatively, you can run download a local copy of the demos and run them using `jupyter`. The demos can be downloaded by cloning the `master` branch of this repo, or by using the `curl` command below:
 ```bash
-curl https://github.com/stellargraph/stellargraph/archive/master.zip | tar -xz --strip=1 stellargraph-master/demos
+curl -L https://github.com/stellargraph/stellargraph/archive/master.zip | tar -xz --strip=1 stellargraph-master/demos
 ```
 
 All dependencies required to run our demo notebooks locally can be installed using one of the following:

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ You can start working with the examples immediately in Google Colab or Binder by
 
 Alternatively, you can run download a local copy of the demos and run them using `jupyter`. The demos can be downloaded by cloning the `master` branch of this repo, or by using the `curl` command below:
 ```bash
-curl https://codeload.github.com/stellargraph/stellargraph/tar.gz/master | tar -xz --strip=1 stellargraph-master/demos
+curl https://github.com/stellargraph/stellargraph/archive/master.zip | tar -xz --strip=1 stellargraph-master/demos
 ```
 
 All dependencies required to run our demo notebooks locally can be installed using one of the following:

--- a/demos/README.md
+++ b/demos/README.md
@@ -45,7 +45,7 @@ The demo notebooks can be run without any installation of Python by using Binder
     <td>see RGCN</td>
     <td></td>
     <td></td>
-    <td>see T-GCN</td>
+    <td></td>
     <td>yes</td>
     <td><a href='node-classification/gcn/gcn-cora-node-classification-example.ipynb'>demo</a></td>
     <td><a href='link-prediction/gcn/cora-gcn-links-example.ipynb'>demo</a></td>
@@ -78,19 +78,6 @@ The demo notebooks can be run without any installation of Python by using Binder
     <td>yes</td>
     <td><a href='node-classification/rgcn/rgcn-aifb-node-classification-example.ipynb'>demo</a></td>
     <td>yes</td>
-    <td></td>
-    <td></td>
-    <td></td>
-  </tr>
-  <tr>
-    <td><span title='Temporal GCN, implemented as GCN-LSTM'>T-GCN</span></td>
-    <td></td>
-    <td></td>
-    <td></td>
-    <td>node features</td>
-    <td>time series, sequence</td>
-    <td><a href='time-series/gcn-lstm-LA.ipynb'>demo</a></td>
-    <td></td>
     <td></td>
     <td></td>
     <td></td>

--- a/demos/README.md
+++ b/demos/README.md
@@ -286,7 +286,7 @@ See [the root README](../README.md) or each algorithm's documentation for the re
 You can run download a local copy of the demos using the `curl` command below:
 
 ```bash
-curl https://github.com/stellargraph/stellargraph/archive/master.zip | tar -xz --strip=1 stellargraph-master/demos
+curl -L https://github.com/stellargraph/stellargraph/archive/master.zip | tar -xz --strip=1 stellargraph-master/demos
 ```
 
 All dependencies required to run our demo notebooks locally can be installed using one of the following:

--- a/demos/README.md
+++ b/demos/README.md
@@ -45,7 +45,7 @@ The demo notebooks can be run without any installation of Python by using Binder
     <td>see RGCN</td>
     <td></td>
     <td></td>
-    <td></td>
+    <td>see T-GCN</td>
     <td>yes</td>
     <td><a href='node-classification/gcn/gcn-cora-node-classification-example.ipynb'>demo</a></td>
     <td><a href='link-prediction/gcn/cora-gcn-links-example.ipynb'>demo</a></td>
@@ -78,6 +78,19 @@ The demo notebooks can be run without any installation of Python by using Binder
     <td>yes</td>
     <td><a href='node-classification/rgcn/rgcn-aifb-node-classification-example.ipynb'>demo</a></td>
     <td>yes</td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><span title='Temporal GCN, implemented as GCN-LSTM'>T-GCN</span></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>node features</td>
+    <td>time series, sequence</td>
+    <td><a href='time-series/gcn-lstm-LA.ipynb'>demo</a></td>
+    <td></td>
     <td></td>
     <td></td>
     <td></td>
@@ -280,16 +293,3 @@ The demo notebooks can be run without any installation of Python by using Binder
 <!-- DEMO TABLE MARKER -->
 
 See [the root README](../README.md) or each algorithm's documentation for the relevant citation(s).
-
-## Download the demos
-
-You can run download a local copy of the demos using the `curl` command below:
-
-```bash
-curl -L https://github.com/stellargraph/stellargraph/archive/master.zip | tar -xz --strip=1 stellargraph-master/demos
-```
-
-The dependencies required to run most of our demo notebooks locally can be installed using one of the following:
-
-- Using pip: `pip install stellargraph[demos]`
-- Using conda: `conda install -c stellargraph stellargraph`

--- a/demos/README.md
+++ b/demos/README.md
@@ -289,7 +289,7 @@ You can run download a local copy of the demos using the `curl` command below:
 curl -L https://github.com/stellargraph/stellargraph/archive/master.zip | tar -xz --strip=1 stellargraph-master/demos
 ```
 
-All dependencies required to run our demo notebooks locally can be installed using one of the following:
+The dependencies required to run most of our demo notebooks locally can be installed using one of the following:
 
 - Using pip: `pip install stellargraph[demos]`
 - Using conda: `conda install -c stellargraph stellargraph`

--- a/demos/README.md
+++ b/demos/README.md
@@ -280,3 +280,16 @@ The demo notebooks can be run without any installation of Python by using Binder
 <!-- DEMO TABLE MARKER -->
 
 See [the root README](../README.md) or each algorithm's documentation for the relevant citation(s).
+
+## Download the demos
+
+You can run download a local copy of the demos using the `curl` command below:
+
+```bash
+curl https://github.com/stellargraph/stellargraph/archive/master.zip | tar -xz --strip=1 stellargraph-master/demos
+```
+
+All dependencies required to run our demo notebooks locally can be installed using one of the following:
+
+- Using pip: `pip install stellargraph[demos]`
+- Using conda: `conda install -c stellargraph stellargraph`

--- a/docs/demos/index.txt
+++ b/docs/demos/index.txt
@@ -270,7 +270,7 @@ You can run download a local copy of the demos using the :code:`curl` command be
 
     curl -L https://github.com/stellargraph/stellargraph/archive/master.zip | tar -xz --strip=1 stellargraph-master/demos
 
-All dependencies required to run our demo notebooks locally can be installed using one of the following:
+The dependencies required to run most of our demo notebooks locally can be installed using one of the following:
 
 - Using pip: :code:`pip install stellargraph[demos]`
 - Using conda: :code:`conda install -c stellargraph stellargraph`

--- a/docs/demos/index.txt
+++ b/docs/demos/index.txt
@@ -260,6 +260,20 @@ Find a demo for an algorithm
 
 See :doc:`the root README <../README>` or each algorithm's documentation for the relevant citation(s).
 
+
+Download the demos
+------------------
+
+You can run download a local copy of the demos using the `curl` command below:
+```bash
+curl https://github.com/stellargraph/stellargraph/archive/master.zip | tar -xz --strip=1 stellargraph-master/demos
+```
+
+All dependencies required to run our demo notebooks locally can be installed using one of the following:
+
+- Using pip: `pip install stellargraph[demos]`
+- Using conda: `conda install -c stellargraph stellargraph`
+
 Table of contents
 -----------------
 

--- a/docs/demos/index.txt
+++ b/docs/demos/index.txt
@@ -264,15 +264,16 @@ See :doc:`the root README <../README>` or each algorithm's documentation for the
 Download the demos
 ------------------
 
-You can run download a local copy of the demos using the `curl` command below:
-```bash
-curl https://github.com/stellargraph/stellargraph/archive/master.zip | tar -xz --strip=1 stellargraph-master/demos
-```
+You can run download a local copy of the demos using the :code:`curl` command below:
+
+.. code-block:: console
+
+    curl https://github.com/stellargraph/stellargraph/archive/master.zip | tar -xz --strip=1 stellargraph-master/demos
 
 All dependencies required to run our demo notebooks locally can be installed using one of the following:
 
-- Using pip: `pip install stellargraph[demos]`
-- Using conda: `conda install -c stellargraph stellargraph`
+- Using pip: :code:`pip install stellargraph[demos]`
+- Using conda: :code:`conda install -c stellargraph stellargraph`
 
 Table of contents
 -----------------

--- a/docs/demos/index.txt
+++ b/docs/demos/index.txt
@@ -268,7 +268,7 @@ You can run download a local copy of the demos using the :code:`curl` command be
 
 .. code-block:: console
 
-    curl https://github.com/stellargraph/stellargraph/archive/master.zip | tar -xz --strip=1 stellargraph-master/demos
+    curl -L https://github.com/stellargraph/stellargraph/archive/master.zip | tar -xz --strip=1 stellargraph-master/demos
 
 All dependencies required to run our demo notebooks locally can be installed using one of the following:
 


### PR DESCRIPTION
This adds the demo download instructions to the demo readme (both on github and readthedocs)

Follow-up to address #1202 raised in https://github.com/stellargraph/stellargraph/pull/1377#pullrequestreview-400801873

Download link per notebook still needs to be done #1390 (#1460 )

readthedocs link: https://stellargraph--1459.org.readthedocs.build/en/1459/demos/index.html#download-the-demos