### PR TITLE
Add download links to demo notebooks on readthedocs (#1390)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -196,7 +196,7 @@ nbsphinx_prolog = r"""
 .. raw:: html
 
     <div>
-      <p><a href="{{ env.docname.rsplit('/', 1).pop() }}.ipynb" class="btn btn-primary">Download this notebook</a></p>
+      <p><a href="{{ env.docname.rsplit('/', 1).pop() }}.ipynb" class="btn">Download this notebook</a></p>
     </div>
 """
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -195,8 +195,8 @@ texinfo_documents = [
 nbsphinx_prolog = r"""
 .. raw:: html
 
-    <div class="admonition note">
-      <a href="{{ env.docname.rsplit('/', 1).pop() }}.ipynb"><button type="button">download this notebook</a>
+    <div>
+      <p><a href="{{ env.docname.rsplit('/', 1).pop() }}.ipynb" class="btn btn-primary">download this notebook</a></p>
     </div>
 """
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -191,6 +191,16 @@ texinfo_documents = [
 
 # -- Extension configuration -------------------------------------------------
 
+# This is processed by Jinja2 and inserted before each notebook
+nbsphinx_prolog = r"""
+.. raw:: html
+      
+    <a href="{{ env.docname.rsplit('/', 1).pop() }}.ipynb"><button type="button">download this notebook</a>
+
+"""
+
+nbsphinx_epilog = nbsphinx_prolog  # also insert after each notebook
+
 # -- Options for todo extension ----------------------------------------------
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -194,9 +194,10 @@ texinfo_documents = [
 # This is processed by Jinja2 and inserted before each notebook
 nbsphinx_prolog = r"""
 .. raw:: html
-      
-    <a href="{{ env.docname.rsplit('/', 1).pop() }}.ipynb"><button type="button">download this notebook</a>
 
+    <div class="admonition note">
+      <a href="{{ env.docname.rsplit('/', 1).pop() }}.ipynb"><button type="button">download this notebook</a>
+    </div>
 """
 
 nbsphinx_epilog = nbsphinx_prolog  # also insert after each notebook

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -196,7 +196,7 @@ nbsphinx_prolog = r"""
 .. raw:: html
 
     <div>
-      <p><a href="{{ env.docname.rsplit('/', 1).pop() }}.ipynb" class="btn btn-primary">download this notebook</a></p>
+      <p><a href="{{ env.docname.rsplit('/', 1).pop() }}.ipynb" class="btn btn-primary">Download this notebook</a></p>
     </div>
 """
 


### PR DESCRIPTION
Adding links to our html documentation to download the notebook source files - there's now a "Download this notebook" button at the top and bottom of each demo.

Our use of `.nblink` files for nbsphinx makes this a little more complicated than expected.

See: #1390