### PR TITLE
Add custom CSS for cell wrapping and no-scrolling in demo table

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,0 +1,14 @@
+/**** override table width restrictions *****/
+
+.wy-table-responsive table td, .wy-table-responsive table th {
+    /* cells can wrap to be multi-line */
+    white-space: normal;
+}
+
+/* table can overhang the normal text width */
+.wy-table-responsive table {
+    background: white;
+}
+.wy-table-responsive {
+    overflow: visible;
+}

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -5,7 +5,7 @@
     white-space: normal;
 }
 
-@media screen and (min-width: 1400px) {
+@media screen and (min-width: 1600px) {
     /* if the screen is wide enough, allow the table to overhang the normal text width */
     .wy-table-responsive table {
         background: white;

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -5,10 +5,12 @@
     white-space: normal;
 }
 
-/* table can overhang the normal text width */
-.wy-table-responsive table {
-    background: white;
-}
-.wy-table-responsive {
-    overflow: visible;
+@media screen and (min-width: 1400px) {
+    /* if the screen is wide enough, allow the table to overhang the normal text width */
+    .wy-table-responsive table {
+        background: white;
+    }
+    .wy-table-responsive {
+        overflow: visible;
+    }
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -227,3 +227,5 @@ class RewriteLinks(docutils.transforms.Transform):
 
 def setup(app):
     app.add_transform(RewriteLinks)
+
+    app.add_stylesheet("custom.css")


### PR DESCRIPTION
This enables word-wrapping in the demo tables (in all tables, in fact) so that they don't take up so much horizontal room. In addition, it allows the table to overflow the right margin of the docs, so that there's no scrolling required on large screens. (This tries to use a media query, so that only the table scrolls on a small/narrow screen, not the whole page.)


(This PR is a reopening of #1456 to resolves some weirdness I saw with `custom.css` not updating on RtD.)

See: #1418