### PR TITLE
Link to Loading from Pandas demo in notebooks that use datasets module

### DIFF
--- a/demos/calibration/calibration-pubmed-link-prediction.ipynb
+++ b/demos/calibration/calibration-pubmed-link-prediction.ipynb
@@ -155,7 +155,11 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "DataLoading"
+    ]
+   },
    "outputs": [
     {
      "data": {

--- a/demos/calibration/calibration-pubmed-link-prediction.ipynb
+++ b/demos/calibration/calibration-pubmed-link-prediction.ipynb
@@ -153,6 +153,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "DataLoadingLinks"
+    ]
+   },
+   "source": [
+    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {

--- a/demos/calibration/calibration-pubmed-node-classification.ipynb
+++ b/demos/calibration/calibration-pubmed-node-classification.ipynb
@@ -158,7 +158,11 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "DataLoading"
+    ]
+   },
    "outputs": [
     {
      "data": {

--- a/demos/calibration/calibration-pubmed-node-classification.ipynb
+++ b/demos/calibration/calibration-pubmed-node-classification.ipynb
@@ -156,6 +156,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "DataLoadingLinks"
+    ]
+   },
+   "source": [
+    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {

--- a/demos/connector/neo4j/load-cora-into-neo4j.ipynb
+++ b/demos/connector/neo4j/load-cora-into-neo4j.ipynb
@@ -84,6 +84,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "DataLoadingLinks"
+    ]
+   },
+   "source": [
+    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {

--- a/demos/connector/neo4j/load-cora-into-neo4j.ipynb
+++ b/demos/connector/neo4j/load-cora-into-neo4j.ipynb
@@ -86,7 +86,11 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "DataLoading"
+    ]
+   },
    "outputs": [
     {
      "data": {

--- a/demos/embeddings/deep-graph-infomax-cora.ipynb
+++ b/demos/embeddings/deep-graph-infomax-cora.ipynb
@@ -98,6 +98,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "DataLoadingLinks"
+    ]
+   },
+   "source": [
+    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {

--- a/demos/embeddings/deep-graph-infomax-cora.ipynb
+++ b/demos/embeddings/deep-graph-infomax-cora.ipynb
@@ -100,7 +100,11 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "DataLoading"
+    ]
+   },
    "outputs": [
     {
      "data": {

--- a/demos/embeddings/embeddings-unsupervised-graphsage-cora.ipynb
+++ b/demos/embeddings/embeddings-unsupervised-graphsage-cora.ipynb
@@ -124,7 +124,11 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "DataLoading"
+    ]
+   },
    "outputs": [
     {
      "data": {

--- a/demos/embeddings/embeddings-unsupervised-graphsage-cora.ipynb
+++ b/demos/embeddings/embeddings-unsupervised-graphsage-cora.ipynb
@@ -122,6 +122,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "DataLoadingLinks"
+    ]
+   },
+   "source": [
+    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {

--- a/demos/embeddings/stellargraph-attri2vec-citeseer.ipynb
+++ b/demos/embeddings/stellargraph-attri2vec-citeseer.ipynb
@@ -118,6 +118,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "DataLoadingLinks"
+    ]
+   },
+   "source": [
+    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {

--- a/demos/embeddings/stellargraph-attri2vec-citeseer.ipynb
+++ b/demos/embeddings/stellargraph-attri2vec-citeseer.ipynb
@@ -120,7 +120,11 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "DataLoading"
+    ]
+   },
    "outputs": [
     {
      "data": {

--- a/demos/embeddings/stellargraph-metapath2vec.ipynb
+++ b/demos/embeddings/stellargraph-metapath2vec.ipynb
@@ -101,6 +101,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "DataLoadingLinks"
+    ]
+   },
+   "source": [
+    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {

--- a/demos/embeddings/stellargraph-metapath2vec.ipynb
+++ b/demos/embeddings/stellargraph-metapath2vec.ipynb
@@ -103,7 +103,11 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "DataLoading"
+    ]
+   },
    "outputs": [
     {
      "data": {

--- a/demos/embeddings/stellargraph-node2vec.ipynb
+++ b/demos/embeddings/stellargraph-node2vec.ipynb
@@ -102,6 +102,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "DataLoadingLinks"
+    ]
+   },
+   "source": [
+    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {

--- a/demos/embeddings/stellargraph-node2vec.ipynb
+++ b/demos/embeddings/stellargraph-node2vec.ipynb
@@ -104,7 +104,11 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "DataLoading"
+    ]
+   },
    "outputs": [
     {
      "data": {

--- a/demos/embeddings/watch-your-step-cora-demo.ipynb
+++ b/demos/embeddings/watch-your-step-cora-demo.ipynb
@@ -100,6 +100,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "DataLoadingLinks"
+    ]
+   },
+   "source": [
+    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {

--- a/demos/embeddings/watch-your-step-cora-demo.ipynb
+++ b/demos/embeddings/watch-your-step-cora-demo.ipynb
@@ -102,7 +102,11 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "DataLoading"
+    ]
+   },
    "outputs": [
     {
      "data": {

--- a/demos/ensembles/ensemble-link-prediction-example.ipynb
+++ b/demos/ensembles/ensemble-link-prediction-example.ipynb
@@ -113,7 +113,11 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "DataLoading"
+    ]
+   },
    "outputs": [
     {
      "data": {

--- a/demos/ensembles/ensemble-link-prediction-example.ipynb
+++ b/demos/ensembles/ensemble-link-prediction-example.ipynb
@@ -111,6 +111,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "DataLoadingLinks"
+    ]
+   },
+   "source": [
+    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {

--- a/demos/ensembles/ensemble-node-classification-example.ipynb
+++ b/demos/ensembles/ensemble-node-classification-example.ipynb
@@ -180,6 +180,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "DataLoadingLinks"
+    ]
+   },
+   "source": [
+    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {

--- a/demos/ensembles/ensemble-node-classification-example.ipynb
+++ b/demos/ensembles/ensemble-node-classification-example.ipynb
@@ -182,7 +182,11 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "DataLoading"
+    ]
+   },
    "outputs": [],
    "source": [
     "G, labels = dataset.load()"

--- a/demos/graph-classification/dgcnn-graph-classification.ipynb
+++ b/demos/graph-classification/dgcnn-graph-classification.ipynb
@@ -108,6 +108,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "DataLoadingLinks"
+    ]
+   },
+   "source": [
+    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {

--- a/demos/graph-classification/dgcnn-graph-classification.ipynb
+++ b/demos/graph-classification/dgcnn-graph-classification.ipynb
@@ -110,7 +110,11 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "DataLoading"
+    ]
+   },
    "outputs": [
     {
      "data": {

--- a/demos/graph-classification/supervised-graph-classification.ipynb
+++ b/demos/graph-classification/supervised-graph-classification.ipynb
@@ -114,7 +114,11 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "DataLoading"
+    ]
+   },
    "outputs": [
     {
      "data": {

--- a/demos/graph-classification/supervised-graph-classification.ipynb
+++ b/demos/graph-classification/supervised-graph-classification.ipynb
@@ -112,6 +112,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "DataLoadingLinks"
+    ]
+   },
+   "source": [
+    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {

--- a/demos/interpretability/gat/node-link-importance-demo-gat.ipynb
+++ b/demos/interpretability/gat/node-link-importance-demo-gat.ipynb
@@ -105,6 +105,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "DataLoadingLinks"
+    ]
+   },
+   "source": [
+    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {

--- a/demos/interpretability/gat/node-link-importance-demo-gat.ipynb
+++ b/demos/interpretability/gat/node-link-importance-demo-gat.ipynb
@@ -107,7 +107,11 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "DataLoading"
+    ]
+   },
    "outputs": [
     {
      "data": {

--- a/demos/interpretability/gcn/node-link-importance-demo-gcn-sparse.ipynb
+++ b/demos/interpretability/gcn/node-link-importance-demo-gcn-sparse.ipynb
@@ -109,6 +109,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "DataLoadingLinks"
+    ]
+   },
+   "source": [
+    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {

--- a/demos/interpretability/gcn/node-link-importance-demo-gcn-sparse.ipynb
+++ b/demos/interpretability/gcn/node-link-importance-demo-gcn-sparse.ipynb
@@ -111,7 +111,11 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "DataLoading"
+    ]
+   },
    "outputs": [
     {
      "data": {

--- a/demos/interpretability/gcn/node-link-importance-demo-gcn.ipynb
+++ b/demos/interpretability/gcn/node-link-importance-demo-gcn.ipynb
@@ -109,6 +109,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "DataLoadingLinks"
+    ]
+   },
+   "source": [
+    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {

--- a/demos/interpretability/gcn/node-link-importance-demo-gcn.ipynb
+++ b/demos/interpretability/gcn/node-link-importance-demo-gcn.ipynb
@@ -111,7 +111,11 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "DataLoading"
+    ]
+   },
    "outputs": [
     {
      "data": {

--- a/demos/link-prediction/gcn/cora-gcn-links-example.ipynb
+++ b/demos/link-prediction/gcn/cora-gcn-links-example.ipynb
@@ -97,7 +97,11 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "DataLoading"
+    ]
+   },
    "outputs": [
     {
      "data": {

--- a/demos/link-prediction/gcn/cora-gcn-links-example.ipynb
+++ b/demos/link-prediction/gcn/cora-gcn-links-example.ipynb
@@ -95,6 +95,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "DataLoadingLinks"
+    ]
+   },
+   "source": [
+    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {

--- a/demos/link-prediction/graphsage/cora-links-example.ipynb
+++ b/demos/link-prediction/graphsage/cora-links-example.ipynb
@@ -94,6 +94,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "DataLoadingLinks"
+    ]
+   },
+   "source": [
+    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {

--- a/demos/link-prediction/graphsage/cora-links-example.ipynb
+++ b/demos/link-prediction/graphsage/cora-links-example.ipynb
@@ -96,7 +96,11 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "DataLoading"
+    ]
+   },
    "outputs": [
     {
      "data": {

--- a/demos/link-prediction/hinsage/movielens-recommender.ipynb
+++ b/demos/link-prediction/hinsage/movielens-recommender.ipynb
@@ -124,7 +124,11 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "DataLoading"
+    ]
+   },
    "outputs": [
     {
      "data": {

--- a/demos/link-prediction/hinsage/movielens-recommender.ipynb
+++ b/demos/link-prediction/hinsage/movielens-recommender.ipynb
@@ -122,6 +122,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "DataLoadingLinks"
+    ]
+   },
+   "source": [
+    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {

--- a/demos/link-prediction/knowledge-graphs/complex.ipynb
+++ b/demos/link-prediction/knowledge-graphs/complex.ipynb
@@ -133,6 +133,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "DataLoadingLinks"
+    ]
+   },
+   "source": [
+    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {

--- a/demos/link-prediction/knowledge-graphs/complex.ipynb
+++ b/demos/link-prediction/knowledge-graphs/complex.ipynb
@@ -135,7 +135,11 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "DataLoading"
+    ]
+   },
    "outputs": [
     {
      "data": {
@@ -602,7 +606,11 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "DataLoading"
+    ]
+   },
    "outputs": [
     {
      "data": {

--- a/demos/link-prediction/knowledge-graphs/distmult.ipynb
+++ b/demos/link-prediction/knowledge-graphs/distmult.ipynb
@@ -134,6 +134,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "DataLoadingLinks"
+    ]
+   },
+   "source": [
+    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {

--- a/demos/link-prediction/knowledge-graphs/distmult.ipynb
+++ b/demos/link-prediction/knowledge-graphs/distmult.ipynb
@@ -136,7 +136,11 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "DataLoading"
+    ]
+   },
    "outputs": [
     {
      "data": {
@@ -474,7 +478,11 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "DataLoading"
+    ]
+   },
    "outputs": [
     {
      "data": {

--- a/demos/link-prediction/random-walks/cora-lp-demo.ipynb
+++ b/demos/link-prediction/random-walks/cora-lp-demo.ipynb
@@ -113,7 +113,11 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "DataLoading"
+    ]
+   },
    "outputs": [
     {
      "data": {

--- a/demos/link-prediction/random-walks/cora-lp-demo.ipynb
+++ b/demos/link-prediction/random-walks/cora-lp-demo.ipynb
@@ -111,6 +111,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "DataLoadingLinks"
+    ]
+   },
+   "source": [
+    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {

--- a/demos/link-prediction/random-walks/ctdne-link-prediction.ipynb
+++ b/demos/link-prediction/random-walks/ctdne-link-prediction.ipynb
@@ -98,6 +98,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "DataLoadingLinks"
+    ]
+   },
+   "source": [
+    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {

--- a/demos/link-prediction/random-walks/ctdne-link-prediction.ipynb
+++ b/demos/link-prediction/random-walks/ctdne-link-prediction.ipynb
@@ -100,7 +100,11 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "DataLoading"
+    ]
+   },
    "outputs": [
     {
      "data": {

--- a/demos/node-classification/attri2vec/attri2vec-citeseer-node-classification-example.ipynb
+++ b/demos/node-classification/attri2vec/attri2vec-citeseer-node-classification-example.ipynb
@@ -119,7 +119,11 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "DataLoading"
+    ]
+   },
    "outputs": [
     {
      "data": {

--- a/demos/node-classification/attri2vec/attri2vec-citeseer-node-classification-example.ipynb
+++ b/demos/node-classification/attri2vec/attri2vec-citeseer-node-classification-example.ipynb
@@ -117,6 +117,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "DataLoadingLinks"
+    ]
+   },
+   "source": [
+    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {

--- a/demos/node-classification/cluster-gcn/cluster-gcn-node-classification.ipynb
+++ b/demos/node-classification/cluster-gcn/cluster-gcn-node-classification.ipynb
@@ -167,7 +167,11 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "DataLoading"
+    ]
+   },
    "outputs": [],
    "source": [
     "dataset = \"cora\"  # can also select 'pubmed'\n",

--- a/demos/node-classification/cluster-gcn/cluster-gcn-node-classification.ipynb
+++ b/demos/node-classification/cluster-gcn/cluster-gcn-node-classification.ipynb
@@ -165,6 +165,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "DataLoadingLinks"
+    ]
+   },
+   "source": [
+    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {

--- a/demos/node-classification/gat/gat-cora-node-classification-example.ipynb
+++ b/demos/node-classification/gat/gat-cora-node-classification-example.ipynb
@@ -94,6 +94,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "DataLoadingLinks"
+    ]
+   },
+   "source": [
+    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {

--- a/demos/node-classification/gat/gat-cora-node-classification-example.ipynb
+++ b/demos/node-classification/gat/gat-cora-node-classification-example.ipynb
@@ -96,7 +96,11 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "DataLoading"
+    ]
+   },
    "outputs": [
     {
      "data": {

--- a/demos/node-classification/gcn/gcn-cora-node-classification-example.ipynb
+++ b/demos/node-classification/gcn/gcn-cora-node-classification-example.ipynb
@@ -130,6 +130,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "DataLoadingLinks"
+    ]
+   },
+   "source": [
+    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {

--- a/demos/node-classification/gcn/gcn-cora-node-classification-example.ipynb
+++ b/demos/node-classification/gcn/gcn-cora-node-classification-example.ipynb
@@ -132,7 +132,11 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "DataLoading"
+    ]
+   },
    "outputs": [
     {
      "data": {

--- a/demos/node-classification/graphsage/directed-graphsage-on-cora-example.ipynb
+++ b/demos/node-classification/graphsage/directed-graphsage-on-cora-example.ipynb
@@ -102,7 +102,11 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "DataLoading"
+    ]
+   },
    "outputs": [
     {
      "data": {

--- a/demos/node-classification/graphsage/directed-graphsage-on-cora-example.ipynb
+++ b/demos/node-classification/graphsage/directed-graphsage-on-cora-example.ipynb
@@ -100,6 +100,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "DataLoadingLinks"
+    ]
+   },
+   "source": [
+    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {

--- a/demos/node-classification/graphsage/graphsage-cora-node-classification-example.ipynb
+++ b/demos/node-classification/graphsage/graphsage-cora-node-classification-example.ipynb
@@ -94,6 +94,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "DataLoadingLinks"
+    ]
+   },
+   "source": [
+    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {

--- a/demos/node-classification/graphsage/graphsage-cora-node-classification-example.ipynb
+++ b/demos/node-classification/graphsage/graphsage-cora-node-classification-example.ipynb
@@ -96,7 +96,11 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "DataLoading"
+    ]
+   },
    "outputs": [
     {
      "data": {

--- a/demos/node-classification/graphsage/graphsage-pubmed-inductive-node-classification-example.ipynb
+++ b/demos/node-classification/graphsage/graphsage-pubmed-inductive-node-classification-example.ipynb
@@ -113,7 +113,11 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "DataLoading"
+    ]
+   },
    "outputs": [
     {
      "data": {

--- a/demos/node-classification/graphsage/graphsage-pubmed-inductive-node-classification-example.ipynb
+++ b/demos/node-classification/graphsage/graphsage-pubmed-inductive-node-classification-example.ipynb
@@ -111,6 +111,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "DataLoadingLinks"
+    ]
+   },
+   "source": [
+    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {

--- a/demos/node-classification/node2vec/stellargraph-node2vec-node-classification.ipynb
+++ b/demos/node-classification/node2vec/stellargraph-node2vec-node-classification.ipynb
@@ -115,6 +115,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "DataLoadingLinks"
+    ]
+   },
+   "source": [
+    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {

--- a/demos/node-classification/node2vec/stellargraph-node2vec-node-classification.ipynb
+++ b/demos/node-classification/node2vec/stellargraph-node2vec-node-classification.ipynb
@@ -117,7 +117,11 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "DataLoading"
+    ]
+   },
    "outputs": [
     {
      "data": {

--- a/demos/node-classification/node2vec/stellargraph-node2vec-weighted-random-walks.ipynb
+++ b/demos/node-classification/node2vec/stellargraph-node2vec-weighted-random-walks.ipynb
@@ -163,6 +163,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "DataLoadingLinks"
+    ]
+   },
+   "source": [
+    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {

--- a/demos/node-classification/node2vec/stellargraph-node2vec-weighted-random-walks.ipynb
+++ b/demos/node-classification/node2vec/stellargraph-node2vec-weighted-random-walks.ipynb
@@ -165,7 +165,11 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "DataLoading"
+    ]
+   },
    "outputs": [
     {
      "data": {

--- a/demos/node-classification/ppnp/ppnp-cora-node-classification-example.ipynb
+++ b/demos/node-classification/ppnp/ppnp-cora-node-classification-example.ipynb
@@ -99,6 +99,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "DataLoadingLinks"
+    ]
+   },
+   "source": [
+    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {

--- a/demos/node-classification/ppnp/ppnp-cora-node-classification-example.ipynb
+++ b/demos/node-classification/ppnp/ppnp-cora-node-classification-example.ipynb
@@ -101,7 +101,11 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "DataLoading"
+    ]
+   },
    "outputs": [
     {
      "data": {

--- a/demos/node-classification/rgcn/rgcn-aifb-node-classification-example.ipynb
+++ b/demos/node-classification/rgcn/rgcn-aifb-node-classification-example.ipynb
@@ -118,7 +118,11 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "DataLoading"
+    ]
+   },
    "outputs": [
     {
      "data": {

--- a/demos/node-classification/rgcn/rgcn-aifb-node-classification-example.ipynb
+++ b/demos/node-classification/rgcn/rgcn-aifb-node-classification-example.ipynb
@@ -116,6 +116,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "DataLoadingLinks"
+    ]
+   },
+   "source": [
+    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {

--- a/demos/node-classification/sgc/sgc-node-classification-example.ipynb
+++ b/demos/node-classification/sgc/sgc-node-classification-example.ipynb
@@ -121,6 +121,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "DataLoadingLinks"
+    ]
+   },
+   "source": [
+    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {

--- a/demos/node-classification/sgc/sgc-node-classification-example.ipynb
+++ b/demos/node-classification/sgc/sgc-node-classification-example.ipynb
@@ -123,7 +123,11 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "DataLoading"
+    ]
+   },
    "outputs": [
     {
      "data": {

--- a/demos/time-series/gcn-lstm-LA.ipynb
+++ b/demos/time-series/gcn-lstm-LA.ipynb
@@ -162,7 +162,11 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "DataLoading"
+    ]
+   },
    "outputs": [
     {
      "name": "stdout",

--- a/demos/time-series/gcn-lstm-LA.ipynb
+++ b/demos/time-series/gcn-lstm-LA.ipynb
@@ -160,6 +160,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "DataLoadingLinks"
+    ]
+   },
+   "source": [
+    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {


### PR DESCRIPTION
This inserts a cell with a link to the Pandas loading demo before any cells tagged `DataLoading`. This PR thus also adds a whole pile of those tags (semi-automatically: searching for cells that contain both `datasets` & `load`, and other similar queries).

Example: https://stellargraph--1464.org.readthedocs.build/en/1464/demos/node-classification/gcn/gcn-cora-node-classification-example.html#Loading-the-CORA-network

See: #1330