### PR TITLE
Fix autoclass syntax for GraphSAGE aggregators

### DIFF
--- a/docs/api.txt
+++ b/docs/api.txt
@@ -45,10 +45,10 @@ GraphSAGE
 .. autoclass:: MeanPoolingAggregator
   :members:
 
-.. autoclass: MaxPoolingAggregator
+.. autoclass:: MaxPoolingAggregator
   :members:
 
-.. autoclass: AttentionalAggregator
+.. autoclass:: AttentionalAggregator
   :members:
 
 


### PR DESCRIPTION
Resolves #1445. Previously `.. autoclass:` (single colon) was used, resulting
in MaxPoolingAggregator and AttentionalAggregator being missing from
Read the Docs.