### PR TITLE
Add custom CSS for cell wrapping in demo table

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,0 +1,14 @@
+/**** override table width restrictions *****/
+
+.wy-table-responsive table td, .wy-table-responsive table th {
+    /* cells can wrap to be multi-line */
+    white-space: normal;
+}
+
+/* table can overhang the normal text width */
+.wy-table-responsive table {
+    background: white;
+}
+.wy-table-responsive {
+    overflow: visible;
+}

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,3 +1,8 @@
+div.wy-nav-content {
+    /* make the main content wider, for wider tables */
+    max-width: 1200px;
+}
+
 /**** override table width restrictions *****/
 
 .wy-table-responsive table td, .wy-table-responsive table th {

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -4,11 +4,3 @@
     /* cells can wrap to be multi-line */
     white-space: normal;
 }
-
-/* table can overhang the normal text width */
-.wy-table-responsive table {
-    background: white;
-}
-.wy-table-responsive {
-    overflow: visible;
-}

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,6 +1,6 @@
 div.wy-nav-content {
     /* make the main content wider, for wider tables */
-    max-width: 1200px;
+    max-width: 1000px;
 }
 
 /**** override table width restrictions *****/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -227,3 +227,5 @@ class RewriteLinks(docutils.transforms.Transform):
 
 def setup(app):
     app.add_transform(RewriteLinks)
+
+    app.add_stylesheet("custom.css")


### PR DESCRIPTION
This does two things to make our wide demo table slightly easier to manage and reduce the sideways scrolling:

- allows individual cell contents to wrap across multiple lines, making each column narrower
- makes all docs wider (a maximum width 1000px instead of 800px) so that the there's more of the table visible at a time for people with wide-enough screens (total maximum doc width is 1300px), without making the line length too long

The second point affects all of our documentation and so may need to be balanced.

Demo table: https://stellargraph--1472.org.readthedocs.build/en/1472/demos/index.html#find-a-demo-for-an-algorithm ![image](https://user-images.githubusercontent.com/1203825/80956042-c0fd4c00-8e43-11ea-854d-72393d851acf.png)

Node classification table: https://stellargraph--1472.org.readthedocs.build/en/1472/demos/node-classification/index.html#find-algorithms-and-demos-for-a-graph ![image](https://user-images.githubusercontent.com/1203825/80956069-cce90e00-8e43-11ea-8770-4dc2411b7d36.png)

API docs (to gauge the affect of widening): https://stellargraph--1472.org.readthedocs.build/en/1472/api.html

Current equivalent develop links, for comparison:

- https://stellargraph.readthedocs.io/en/latest/demos/index.html#find-a-demo-for-an-algorithm
- https://stellargraph.readthedocs.io/en/latest/demos/node-classification/index.html
- https://stellargraph.readthedocs.io/en/latest/api.html

This is an alternative to #1461, which ensures the table doesn't require scrolling by allowing it to overhang.

See: #1418