### PR TITLE
Add newlines to fix formatting

### DIFF
--- a/demos/time-series/gcn-lstm-time-series.ipynb
+++ b/demos/time-series/gcn-lstm-time-series.ipynb
@@ -33,10 +33,13 @@
     "There has been a few differences in the architecture proposed in the paper and the implementation of the graph convolution component, these issues have been documented [here](https://github.com/lehaifeng/T-GCN/issues/18) and [here](https://github.com/lehaifeng/T-GCN/issues/14). The `GraphConvolutionLSTM` model in `StellarGraph`  emulates the model as explained in the paper while giving additional flexibility of adding any number of `graph convolution` and `LSTM` layers. \n",
     "\n",
     "Concretely, the architecture of `GraphConvolutionLSTM` is as follows:\n",
+    "\n",
     "1. User defined number of  graph convolutional layers (Reference: [Kipf & Welling (ICLR 2017)](http://arxiv.org/abs/1609.02907)).\n",
     "2. User defined number of  LSTM layers. The [TGCN](https://ieeexplore.ieee.org/document/8809901) uses GRU instead of LSTM. In practice there are not any remarkable differences between the two types of layers. We use LSTM as they are more frequently used.\n",
     "3. A Dropout and a Dense layer as they experimentally showed improvement in performance and managing over-fitting.\n",
+    "\n",
     "## References: \n",
+    "\n",
     "* [T-GCN: A Temporal Graph Convolutional Network for Traffic Prediction](https://ieeexplore.ieee.org/document/8809901)\n",
     "* [https://github.com/lehaifeng/T-GCN](https://github.com/lehaifeng/T-GCN)\n",
     "* [Semi-Supervised Classification with Graph Convolutional Networks](http://arxiv.org/abs/1609.02907)\n",
@@ -527,6 +530,7 @@
     "The LSTM model learns a function that maps a sequence of past observations as input to an output observation. As such, the sequence of observations must be transformed into multiple examples from which the LSTM can learn.\n",
     "\n",
     "To make it concrete in terms of the speed prediction problem, we choose to use 50 minutes of historical speed observations to predict the speed in future, lets say, 1 hour ahead. Hence, we would first  reshape the timeseries data into windows of 10 historical observations for each segment as the input and the speed 60 minutes later is the label we are interested in predicting. We use the sliding window approach to prepare the data. This is how it works:  \n",
+    "\n",
     "* Starting from the beginning of the timeseries, we take the first 10 speed records as the 10 input features and the speed 12 timesteps head (60 minutes) as the speed we want to predict. \n",
     "* Shift the timeseries by one timestep and take the 10 observations from the current point as the input feartures and the speed one hour ahead as the output to predict. \n",
     "* Keep shifting by 1 timestep and picking the 10 timestep window from the current time as input feature and the speed one hour ahead of the 10th timestep as the output to predict, for the entire data.\n",
@@ -535,6 +539,7 @@
     "The function below returns the above transformed timeseries data for the model to train on. The parameter `seq_len` is the size of the past window of information. The `pre_len` is how far in the future does the model need to learn to predict. \n",
     "\n",
     "For this demo: \n",
+    "\n",
     "* Each training observation are 10 historical speeds (`seq_len`).\n",
     "* Each training prediction is the speed 60 minutes later (`pre_len`)."
    ]
@@ -1005,7 +1010,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.7.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I'm guessing somewhere in the conversion it doesn't like having no new lines separating between some of these elements

link: https://stellargraph--1505.org.readthedocs.build/en/1505/demos/time-series/gcn-lstm-time-series.html

See #1492 
