### PR TITLE
Update ignore link for hateful twitter

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -99,7 +99,7 @@ exclude_patterns = [
     "requirements.txt",
     "demos/community_detection/*",
     "demos/use-cases/*",
-    "demos/interpretability/gcn/hateful-twitters-interpretability.*",
+    "demos/interpretability/hateful-twitters-interpretability.nblink",
 ]
 
 # The name of the Pygments (syntax highlighting) style to use.


### PR DESCRIPTION
The notebook names/paths were updated as part of #1471 so the ignore path has to be updated.

Link (now there's no hateful twitter interpretability): https://stellargraph--1507.org.readthedocs.build/en/1507/demos/interpretability/index.html

See #1500 
