### PR TITLE
Use a relative link for the reference to the Pandas notebook

### DIFF
--- a/demos/calibration/calibration-link-prediction.ipynb
+++ b/demos/calibration/calibration-link-prediction.ipynb
@@ -161,7 +161,7 @@
     ]
    },
    "source": [
-    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+    "(See [the \"Loading from Pandas\" demo](../basics/loading-pandas.ipynb) for details on how data can be loaded.)"
    ]
   },
   {

--- a/demos/calibration/calibration-node-classification.ipynb
+++ b/demos/calibration/calibration-node-classification.ipynb
@@ -164,7 +164,7 @@
     ]
    },
    "source": [
-    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+    "(See [the \"Loading from Pandas\" demo](../basics/loading-pandas.ipynb) for details on how data can be loaded.)"
    ]
   },
   {

--- a/demos/connector/neo4j/load-cora-into-neo4j.ipynb
+++ b/demos/connector/neo4j/load-cora-into-neo4j.ipynb
@@ -92,7 +92,7 @@
     ]
    },
    "source": [
-    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+    "(See [the \"Loading from Pandas\" demo](../../basics/loading-pandas.ipynb) for details on how data can be loaded.)"
    ]
   },
   {

--- a/demos/embeddings/attri2vec-embeddings.ipynb
+++ b/demos/embeddings/attri2vec-embeddings.ipynb
@@ -126,7 +126,7 @@
     ]
    },
    "source": [
-    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+    "(See [the \"Loading from Pandas\" demo](../basics/loading-pandas.ipynb) for details on how data can be loaded.)"
    ]
   },
   {

--- a/demos/embeddings/deep-graph-infomax-embeddings.ipynb
+++ b/demos/embeddings/deep-graph-infomax-embeddings.ipynb
@@ -106,7 +106,7 @@
     ]
    },
    "source": [
-    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+    "(See [the \"Loading from Pandas\" demo](../basics/loading-pandas.ipynb) for details on how data can be loaded.)"
    ]
   },
   {

--- a/demos/embeddings/graphsage-unsupervised-sampler-embeddings.ipynb
+++ b/demos/embeddings/graphsage-unsupervised-sampler-embeddings.ipynb
@@ -130,7 +130,7 @@
     ]
    },
    "source": [
-    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+    "(See [the \"Loading from Pandas\" demo](../basics/loading-pandas.ipynb) for details on how data can be loaded.)"
    ]
   },
   {

--- a/demos/embeddings/metapath2vec-embeddings.ipynb
+++ b/demos/embeddings/metapath2vec-embeddings.ipynb
@@ -109,7 +109,7 @@
     ]
    },
    "source": [
-    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+    "(See [the \"Loading from Pandas\" demo](../basics/loading-pandas.ipynb) for details on how data can be loaded.)"
    ]
   },
   {

--- a/demos/embeddings/node2vec-embeddings.ipynb
+++ b/demos/embeddings/node2vec-embeddings.ipynb
@@ -110,7 +110,7 @@
     ]
    },
    "source": [
-    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+    "(See [the \"Loading from Pandas\" demo](../basics/loading-pandas.ipynb) for details on how data can be loaded.)"
    ]
   },
   {

--- a/demos/embeddings/watch-your-step-embeddings.ipynb
+++ b/demos/embeddings/watch-your-step-embeddings.ipynb
@@ -108,7 +108,7 @@
     ]
    },
    "source": [
-    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+    "(See [the \"Loading from Pandas\" demo](../basics/loading-pandas.ipynb) for details on how data can be loaded.)"
    ]
   },
   {

--- a/demos/ensembles/ensemble-link-prediction-example.ipynb
+++ b/demos/ensembles/ensemble-link-prediction-example.ipynb
@@ -119,7 +119,7 @@
     ]
    },
    "source": [
-    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+    "(See [the \"Loading from Pandas\" demo](../basics/loading-pandas.ipynb) for details on how data can be loaded.)"
    ]
   },
   {

--- a/demos/ensembles/ensemble-node-classification-example.ipynb
+++ b/demos/ensembles/ensemble-node-classification-example.ipynb
@@ -188,7 +188,7 @@
     ]
    },
    "source": [
-    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+    "(See [the \"Loading from Pandas\" demo](../basics/loading-pandas.ipynb) for details on how data can be loaded.)"
    ]
   },
   {

--- a/demos/graph-classification/dgcnn-graph-classification.ipynb
+++ b/demos/graph-classification/dgcnn-graph-classification.ipynb
@@ -116,7 +116,7 @@
     ]
    },
    "source": [
-    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+    "(See [the \"Loading from Pandas\" demo](../basics/loading-pandas.ipynb) for details on how data can be loaded.)"
    ]
   },
   {

--- a/demos/graph-classification/gcn-supervised-graph-classification.ipynb
+++ b/demos/graph-classification/gcn-supervised-graph-classification.ipynb
@@ -120,7 +120,7 @@
     ]
    },
    "source": [
-    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+    "(See [the \"Loading from Pandas\" demo](../basics/loading-pandas.ipynb) for details on how data can be loaded.)"
    ]
   },
   {

--- a/demos/interpretability/gat-node-link-importance.ipynb
+++ b/demos/interpretability/gat-node-link-importance.ipynb
@@ -113,7 +113,7 @@
     ]
    },
    "source": [
-    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+    "(See [the \"Loading from Pandas\" demo](../basics/loading-pandas.ipynb) for details on how data can be loaded.)"
    ]
   },
   {

--- a/demos/interpretability/gcn-node-link-importance.ipynb
+++ b/demos/interpretability/gcn-node-link-importance.ipynb
@@ -117,7 +117,7 @@
     ]
    },
    "source": [
-    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+    "(See [the \"Loading from Pandas\" demo](../basics/loading-pandas.ipynb) for details on how data can be loaded.)"
    ]
   },
   {

--- a/demos/interpretability/gcn-sparse-node-link-importance.ipynb
+++ b/demos/interpretability/gcn-sparse-node-link-importance.ipynb
@@ -117,7 +117,7 @@
     ]
    },
    "source": [
-    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+    "(See [the \"Loading from Pandas\" demo](../basics/loading-pandas.ipynb) for details on how data can be loaded.)"
    ]
   },
   {

--- a/demos/link-prediction/complex-link-prediction.ipynb
+++ b/demos/link-prediction/complex-link-prediction.ipynb
@@ -141,7 +141,7 @@
     ]
    },
    "source": [
-    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+    "(See [the \"Loading from Pandas\" demo](../basics/loading-pandas.ipynb) for details on how data can be loaded.)"
    ]
   },
   {

--- a/demos/link-prediction/ctdne-link-prediction.ipynb
+++ b/demos/link-prediction/ctdne-link-prediction.ipynb
@@ -106,7 +106,7 @@
     ]
    },
    "source": [
-    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+    "(See [the \"Loading from Pandas\" demo](../basics/loading-pandas.ipynb) for details on how data can be loaded.)"
    ]
   },
   {

--- a/demos/link-prediction/distmult-link-prediction.ipynb
+++ b/demos/link-prediction/distmult-link-prediction.ipynb
@@ -142,7 +142,7 @@
     ]
    },
    "source": [
-    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+    "(See [the \"Loading from Pandas\" demo](../basics/loading-pandas.ipynb) for details on how data can be loaded.)"
    ]
   },
   {

--- a/demos/link-prediction/gcn-link-prediction.ipynb
+++ b/demos/link-prediction/gcn-link-prediction.ipynb
@@ -103,7 +103,7 @@
     ]
    },
    "source": [
-    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+    "(See [the \"Loading from Pandas\" demo](../basics/loading-pandas.ipynb) for details on how data can be loaded.)"
    ]
   },
   {

--- a/demos/link-prediction/graphsage-link-prediction.ipynb
+++ b/demos/link-prediction/graphsage-link-prediction.ipynb
@@ -102,7 +102,7 @@
     ]
    },
    "source": [
-    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+    "(See [the \"Loading from Pandas\" demo](../basics/loading-pandas.ipynb) for details on how data can be loaded.)"
    ]
   },
   {

--- a/demos/link-prediction/hinsage-link-prediction.ipynb
+++ b/demos/link-prediction/hinsage-link-prediction.ipynb
@@ -130,7 +130,7 @@
     ]
    },
    "source": [
-    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+    "(See [the \"Loading from Pandas\" demo](../basics/loading-pandas.ipynb) for details on how data can be loaded.)"
    ]
   },
   {

--- a/demos/link-prediction/node2vec-link-prediction.ipynb
+++ b/demos/link-prediction/node2vec-link-prediction.ipynb
@@ -119,7 +119,7 @@
     ]
    },
    "source": [
-    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+    "(See [the \"Loading from Pandas\" demo](../basics/loading-pandas.ipynb) for details on how data can be loaded.)"
    ]
   },
   {

--- a/demos/node-classification/attri2vec-node-classification.ipynb
+++ b/demos/node-classification/attri2vec-node-classification.ipynb
@@ -125,7 +125,7 @@
     ]
    },
    "source": [
-    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+    "(See [the \"Loading from Pandas\" demo](../basics/loading-pandas.ipynb) for details on how data can be loaded.)"
    ]
   },
   {

--- a/demos/node-classification/cluster-gcn-node-classification.ipynb
+++ b/demos/node-classification/cluster-gcn-node-classification.ipynb
@@ -173,7 +173,7 @@
     ]
    },
    "source": [
-    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+    "(See [the \"Loading from Pandas\" demo](../basics/loading-pandas.ipynb) for details on how data can be loaded.)"
    ]
   },
   {

--- a/demos/node-classification/directed-graphsage-node-classification.ipynb
+++ b/demos/node-classification/directed-graphsage-node-classification.ipynb
@@ -108,7 +108,7 @@
     ]
    },
    "source": [
-    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+    "(See [the \"Loading from Pandas\" demo](../basics/loading-pandas.ipynb) for details on how data can be loaded.)"
    ]
   },
   {

--- a/demos/node-classification/gat-node-classification.ipynb
+++ b/demos/node-classification/gat-node-classification.ipynb
@@ -102,7 +102,7 @@
     ]
    },
    "source": [
-    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+    "(See [the \"Loading from Pandas\" demo](../basics/loading-pandas.ipynb) for details on how data can be loaded.)"
    ]
   },
   {

--- a/demos/node-classification/gcn-node-classification.ipynb
+++ b/demos/node-classification/gcn-node-classification.ipynb
@@ -138,7 +138,7 @@
     ]
    },
    "source": [
-    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+    "(See [the \"Loading from Pandas\" demo](../basics/loading-pandas.ipynb) for details on how data can be loaded.)"
    ]
   },
   {

--- a/demos/node-classification/graphsage-inductive-node-classification.ipynb
+++ b/demos/node-classification/graphsage-inductive-node-classification.ipynb
@@ -119,7 +119,7 @@
     ]
    },
    "source": [
-    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+    "(See [the \"Loading from Pandas\" demo](../basics/loading-pandas.ipynb) for details on how data can be loaded.)"
    ]
   },
   {

--- a/demos/node-classification/graphsage-node-classification.ipynb
+++ b/demos/node-classification/graphsage-node-classification.ipynb
@@ -102,7 +102,7 @@
     ]
    },
    "source": [
-    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+    "(See [the \"Loading from Pandas\" demo](../basics/loading-pandas.ipynb) for details on how data can be loaded.)"
    ]
   },
   {

--- a/demos/node-classification/node2vec-node-classification.ipynb
+++ b/demos/node-classification/node2vec-node-classification.ipynb
@@ -123,7 +123,7 @@
     ]
    },
    "source": [
-    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+    "(See [the \"Loading from Pandas\" demo](../basics/loading-pandas.ipynb) for details on how data can be loaded.)"
    ]
   },
   {

--- a/demos/node-classification/node2vec-weighted-node-classification.ipynb
+++ b/demos/node-classification/node2vec-weighted-node-classification.ipynb
@@ -171,7 +171,7 @@
     ]
    },
    "source": [
-    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+    "(See [the \"Loading from Pandas\" demo](../basics/loading-pandas.ipynb) for details on how data can be loaded.)"
    ]
   },
   {

--- a/demos/node-classification/ppnp-node-classification.ipynb
+++ b/demos/node-classification/ppnp-node-classification.ipynb
@@ -107,7 +107,7 @@
     ]
    },
    "source": [
-    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+    "(See [the \"Loading from Pandas\" demo](../basics/loading-pandas.ipynb) for details on how data can be loaded.)"
    ]
   },
   {

--- a/demos/node-classification/rgcn-node-classification.ipynb
+++ b/demos/node-classification/rgcn-node-classification.ipynb
@@ -124,7 +124,7 @@
     ]
    },
    "source": [
-    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+    "(See [the \"Loading from Pandas\" demo](../basics/loading-pandas.ipynb) for details on how data can be loaded.)"
    ]
   },
   {

--- a/demos/node-classification/sgc-node-classification.ipynb
+++ b/demos/node-classification/sgc-node-classification.ipynb
@@ -129,7 +129,7 @@
     ]
    },
    "source": [
-    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+    "(See [the \"Loading from Pandas\" demo](../basics/loading-pandas.ipynb) for details on how data can be loaded.)"
    ]
   },
   {

--- a/demos/time-series/gcn-lstm-time-series.ipynb
+++ b/demos/time-series/gcn-lstm-time-series.ipynb
@@ -168,7 +168,7 @@
     ]
    },
    "source": [
-    "(See [the \"Loading from Pandas\" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"
+    "(See [the \"Loading from Pandas\" demo](../basics/loading-pandas.ipynb) for details on how data can be loaded.)"
    ]
   },
   {

--- a/scripts/format_notebooks.py
+++ b/scripts/format_notebooks.py
@@ -261,13 +261,11 @@ class LoadingLinksPreprocessor(InsertTaggedCellsPreprocessor):
         """
         directories = os.path.dirname(path).split("/")
         demos_idx = next(
-            index for index, directory in enumerate(directories)
-            if directory == "demos"
+            index for index, directory in enumerate(directories) if directory == "demos"
         )
         nested_depth = len(directories) - (demos_idx + 1)
         parents = "../" * nested_depth
         return f"{parents}basics/loading-pandas.ipynb"
-
 
     def preprocess(self, nb, resources):
         self.remove_tagged_cells_from_notebook(nb)
@@ -282,7 +280,9 @@ class LoadingLinksPreprocessor(InsertTaggedCellsPreprocessor):
 
         if first_data_loading is not None:
             path = self._relative_path(resources[PATH_RESOURCE_NAME])
-            links_cell = nbformat.v4.new_markdown_cell(self.data_loading_description.format(path))
+            links_cell = nbformat.v4.new_markdown_cell(
+                self.data_loading_description.format(path)
+            )
             self.tag_cell(links_cell)
             nb.cells.insert(first_data_loading, links_cell)
 

--- a/scripts/format_notebooks.py
+++ b/scripts/format_notebooks.py
@@ -44,6 +44,9 @@ with open("stellargraph/version.py", "r") as fh:
 SG_VERSION = version["__version__"]
 
 
+PATH_RESOURCE_NAME = "notebook_path"
+
+
 class ClearWarningsPreprocessor(preprocessors.Preprocessor):
     filter_all_stderr = Bool(True, help="Remove all stderr outputs.").tag(config=True)
 
@@ -159,7 +162,6 @@ class InsertTaggedCellsPreprocessor(preprocessors.Preprocessor):
 
 
 class CloudRunnerPreprocessor(InsertTaggedCellsPreprocessor):
-    path_resource_name = "cloud_runner_path"
     metadata_tag = "CloudRunner"
     git_branch = "master"
     demos_path_prefix = "demos/"
@@ -188,7 +190,7 @@ if 'google.colab' in sys.modules:
         return f"<table><tr><td>Run the latest release of this notebook:</td><td>{self._binder_badge(notebook_path)}</td><td>{self._colab_badge(notebook_path)}</td></tr></table>"
 
     def preprocess(self, nb, resources):
-        notebook_path = resources[self.path_resource_name]
+        notebook_path = resources[PATH_RESOURCE_NAME]
         if not notebook_path.startswith(self.demos_path_prefix):
             print(
                 f"WARNING: Notebook file path of {notebook_path} didn't start with {self.demos_path_prefix}, and may result in bad links to cloud runners."
@@ -248,8 +250,24 @@ class LoadingLinksPreprocessor(InsertTaggedCellsPreprocessor):
     metadata_tag = "DataLoadingLinks"
     search_tag = "DataLoading"
 
-    data_loading_description = f"""\
-(See [the "Loading from Pandas" demo](https://stellargraph.readthedocs.io/en/stable/demos/basics/loading-pandas.html) for details on how data can be loaded.)"""
+    data_loading_description = """\
+(See [the "Loading from Pandas" demo]({}) for details on how data can be loaded.)"""
+
+    def _relative_path(self, path):
+        """
+        Find the relative path from this notebook to the Loading Pandas one.
+
+        This assumes that "demos" appears in the path, and is the root of the demos directories.
+        """
+        directories = os.path.dirname(path).split("/")
+        demos_idx = next(
+            index for index, directory in enumerate(directories)
+            if directory == "demos"
+        )
+        nested_depth = len(directories) - (demos_idx + 1)
+        parents = "../" * nested_depth
+        return f"{parents}basics/loading-pandas.ipynb"
+
 
     def preprocess(self, nb, resources):
         self.remove_tagged_cells_from_notebook(nb)
@@ -263,7 +281,8 @@ class LoadingLinksPreprocessor(InsertTaggedCellsPreprocessor):
         )
 
         if first_data_loading is not None:
-            links_cell = nbformat.v4.new_markdown_cell(self.data_loading_description)
+            path = self._relative_path(resources[PATH_RESOURCE_NAME])
+            links_cell = nbformat.v4.new_markdown_cell(self.data_loading_description.format(path))
             self.tag_cell(links_cell)
             nb.cells.insert(first_data_loading, links_cell)
 
@@ -466,7 +485,7 @@ if __name__ == "__main__":
         in_notebook = nbformat.read(str(file_loc), as_version=4)
 
         # the CloudRunnerPreprocessor needs to know the filename of this notebook
-        resources = {CloudRunnerPreprocessor.path_resource_name: str(file_loc)}
+        resources = {PATH_RESOURCE_NAME: str(file_loc)}
 
         writer = writers.FilesWriter()
 


### PR DESCRIPTION
This works better for someone editing locally, and ensures it's a correct link for the specific version of the documentation the user is looking at.

See: #1495