### PR TITLE
Try using new nbsphinx_markdown_renderer option for doc builds

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -215,6 +215,8 @@ nbsphinx_prolog = r"""
 
 nbsphinx_epilog = nbsphinx_prolog  # also insert after each notebook
 
+nbsphinx_markdown_renderer = "commonmark"
+
 # -- Options for todo extension ----------------------------------------------
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 recommonmark==0.6.0
 sphinx-markdown-tables==0.0.12
-nbsphinx==0.6.1
+https://github.com/huonw/nbsphinx/archive/feature/faster-via-alternative-renderer.zip
 nbsphinx-link==1.3.0
 # needed for Pygments highlighting in notebooks
 ipython==7.13.0


### PR DESCRIPTION
This is an experiment with making our doc builds (much) faster via https://github.com/spatialaudio/nbsphinx/pull/455. It's not "production-ready", e.g. there's no mathematics support.

Timing on macOS (via `$ make clean && time make html` in `docs/`), compared to the current state of `develop` (4e706203):

| time | develop (s) | this PR (s) |
|---|---|---|
| real | 121 | 45 |
| user | 64 | 41 |
| sys | 41 | 2.0 |

The basic rendering seems reasonable, for instance:

- https://stellargraph--1517.org.readthedocs.build/en/1517/demos/basics/loading-pandas.html
- https://stellargraph--1517.org.readthedocs.build/en/1517/demos/node-classification/gcn-node-classification.html

Equations fail, though https://stellargraph--1517.org.readthedocs.build/en/1517/demos/graph-classification/dgcnn-graph-classification.html#Create-the-Keras-graph-classification-model

> The model’s input is the graph represented by its adjacency and node features matrices. The first four layers are Graph Convolutional as in [2] but using the adjacency normalisation from [1], $D^{-1}A$ where $A$ is the adjacency matrix with self loops and $D$ is the corresponding degree matrix. The graph convolutional layers each have 32, 32, 32, 1 units and tanh activations.
