### PR TITLE
Use NumPy earlier in StellarGraph construction

### DIFF
--- a/stellargraph/core/convert.py
+++ b/stellargraph/core/convert.py
@@ -150,7 +150,11 @@ class ColumnarConverter:
 
             rows_so_far += len(ids)
 
-        if type_ids:
+        if len(type_ids) == 1:
+            # if there's only one type, avoid copying everything in a no-op concatentation
+            ids = type_ids[0]
+            columns = {col_name: col_arrays[0] for col_name, col_arrays in type_columns.items()}
+        elif type_ids:
             ids = np.concatenate(type_ids)
             columns = {
                 col_name: np.concatenate(col_arrays)

--- a/stellargraph/core/convert.py
+++ b/stellargraph/core/convert.py
@@ -91,11 +91,12 @@ class ColumnarConverter:
 
         # split the dataframe based on the columns we know about
         missing_columns = []
+
         def select_column(old_name):
             if old_name in data.columns:
                 column = data[old_name].to_numpy()
             elif old_name in self.column_defaults:
-                column = np.full_like(ids, self.column_defaults[old_name])
+                column = np.full(len(ids), self.column_defaults[old_name])
             else:
                 nonlocal missing_columns
                 missing_columns.append(old_name)
@@ -152,13 +153,17 @@ class ColumnarConverter:
         if type_ids:
             ids = np.concatenate(type_ids)
             columns = {
-                col_name: np.concatenate(col_arrays) for col_name, col_arrays in type_columns.items()
+                col_name: np.concatenate(col_arrays)
+                for col_name, col_arrays in type_columns.items()
             }
         else:
             # there was no input types and thus no input elements, so create a dummy dataframe, that
             # is maximally flexible by using a "minimal"/highly-promotable type
             ids = []
-            columns = {name: np.empty(dtype=np.uint8) for name in self.selected_columns.values()}
+            columns = {
+                name: np.empty(0, dtype=np.uint8)
+                for name in self.selected_columns.values()
+            }
 
         return ids, columns, type_starts
 
@@ -212,7 +217,9 @@ class ColumnarConverter:
         }
 
         ids, columns, type_starts = self._ids_columns_and_starts_from_singles(singles)
-        features = {type_name: features for type_name, (_, _, features) in singles.items()}
+        features = {
+            type_name: features for type_name, (_, _, features) in singles.items()
+        }
         return (ids, columns, type_starts, features)
 
 
@@ -292,13 +299,7 @@ def convert_edges(
             f"{converter.name()}: expected weight column {weight_column!r} to be numeric, found dtype '{weight_col.dtype}'"
         )
 
-    return EdgeData(
-        ids,
-        columns[SOURCE],
-        columns[TARGET],
-        weight_col,
-        type_starts,
-    )
+    return EdgeData(ids, columns[SOURCE], columns[TARGET], weight_col, type_starts)
 
 
 SingleTypeNodeIdsAndFeatures = namedtuple(

--- a/stellargraph/core/convert.py
+++ b/stellargraph/core/convert.py
@@ -86,26 +86,37 @@ class ColumnarConverter:
             )
 
         existing = set(self.selected_columns).intersection(data.columns)
+
+        ids = data.index
+
         # split the dataframe based on the columns we know about
-        known = data[existing]
-        other = data.drop(columns=existing)
+        missing_columns = []
+        def select_column(old_name):
+            if old_name in data.columns:
+                column = data[old_name].to_numpy()
+            elif old_name in self.column_defaults:
+                column = np.full_like(ids, self.column_defaults[old_name])
+            else:
+                nonlocal missing_columns
+                missing_columns.append(old_name)
+                return None
 
-        # add the defaults to for columns that need one (this will not overwrite any existing ones
-        # of the same name, because they'll be in `other`, not `known`)
-        defaults_required = {
-            name: value
-            for name, value in self.column_defaults.items()
-            if name not in existing
+            transform = self.transform_columns.get(old_name)
+            if transform is not None:
+                column = transform(column)
+
+            return column
+
+        columns = {
+            new_name: select_column(old_name)
+            for old_name, new_name in self.selected_columns.items()
         }
-        known = known.assign(**defaults_required)
+        if missing_columns:
+            raise ValueError(
+                f"{self.name(type_name)}: expected {comma_sep(self.selected_columns)} columns, found: {comma_sep(data.columns)}"
+            )
 
-        # now verify that all of the columns needed are there (that is, the defaults have filled out appropriately)
-        require_dataframe_has_columns(
-            self.name(type_name), known, self.selected_columns
-        )
-
-        for column, transform in self.transform_columns.items():
-            known[column] = transform(known[column])
+        other = data.drop(columns=existing)
 
         if self.allow_features:
             # to_numpy returns an unspecified order but it's Fortran in practice. Row-level bulk
@@ -120,51 +131,59 @@ class ColumnarConverter:
                 f"{self.name(type_name)}: expected zero feature columns, found {comma_sep(other.columns)}"
             )
 
-        return known.rename(columns=self.selected_columns), features
+        return ids, columns, features
 
-    def _shared_and_starts_from_singles(self, singles):
+    def _ids_columns_and_starts_from_singles(self, singles):
         rows_so_far = 0
         type_starts = []
-        type_dfs = []
+        type_ids = []
+        type_columns = defaultdict(list)
 
         for type_name in sorted(singles.keys()):
-            type_data, _ = singles[type_name]
+            ids, columns, _ = singles[type_name]
 
             type_starts.append((type_name, rows_so_far))
-            type_dfs.append(type_data)
+            type_ids.append(ids)
+            for col_name, col_array in columns.items():
+                type_columns[col_name].append(col_array)
 
-            rows_so_far += len(type_data)
+            rows_so_far += len(ids)
 
-        if type_dfs:
-            shared = pd.concat(type_dfs)
+        if type_ids:
+            ids = np.concatenate(type_ids)
+            columns = {
+                col_name: np.concatenate(col_arrays) for col_name, col_arrays in type_columns.items()
+            }
         else:
             # there was no input types and thus no input elements, so create a dummy dataframe, that
             # is maximally flexible by using a "minimal"/highly-promotable type
-            shared = pd.DataFrame(
-                columns=self.selected_columns.values(), dtype=np.uint8
-            )
+            ids = []
+            columns = {name: np.empty(dtype=np.uint8) for name in self.selected_columns.values()}
 
-        return shared, type_starts
+        return ids, columns, type_starts
 
     def _convert_with_type_column(self, data):
         # we've got a type column, so there's no dictionaries or separate dataframes. We just need
         # to make sure things are arranged right, i.e. nodes of each type are contiguous, and
         # 'range(...)' objects describing each one.
-        known, features = self._convert_single(None, data)
+        ids, columns, features = self._convert_single(None, data)
         assert features is None
 
         # the column we see in `known` is after being selected/renamed
-        selected_type_column = self.selected_columns[self.type_column]
-
-        known.sort_values(selected_type_column, inplace=True)
+        type_column_name = self.selected_columns[self.type_column]
 
         # the shared data doesn't use the type column; that info is encoded in `type_ranges` below
-        shared = known.drop(columns=selected_type_column)
+        type_column = columns.pop(type_column_name)
+
+        sorting = np.argsort(type_column)
+
+        # arrange everything to be sorted by type
+        ids = ids[sorting]
+        type_column = type_column[sorting]
+        columns = {name: array[sorting] for name, array in columns.items()}
 
         # deduce the type ranges based on the first index of each of the known values
-        types, first_occurance = np.unique(
-            known[selected_type_column], return_index=True
-        )
+        types, first_occurance = np.unique(type_column, return_index=True)
 
         type_starts = [
             (type_name, start) for type_name, start in zip(types, first_occurance)
@@ -173,7 +192,7 @@ class ColumnarConverter:
         # per the assert above, the features are None for every type
         features = {type_name: None for type_name in types}
 
-        return shared, type_starts, features
+        return ids, columns, type_starts, features
 
     def convert(self, elements):
         if self.type_column is not None:
@@ -192,9 +211,9 @@ class ColumnarConverter:
             for type_name, data in elements.items()
         }
 
-        shared, type_starts = self._shared_and_starts_from_singles(singles)
-        features = {type_name: features for type_name, (_, features) in singles.items()}
-        return (shared, type_starts, features)
+        ids, columns, type_starts = self._ids_columns_and_starts_from_singles(singles)
+        features = {type_name: features for type_name, (_, _, features) in singles.items()}
+        return (ids, columns, type_starts, features)
 
 
 def convert_nodes(data, *, name, default_type, dtype) -> NodeData:
@@ -208,8 +227,9 @@ def convert_nodes(data, *, name, default_type, dtype) -> NodeData:
         transform_columns={},
         dtype=dtype,
     )
-    nodes, type_starts, node_features = converter.convert(data)
-    return NodeData(nodes, type_starts, node_features)
+    ids, columns, type_starts, node_features = converter.convert(data)
+    assert len(columns) == 0
+    return NodeData(ids, type_starts, node_features)
 
 
 DEFAULT_WEIGHT = np.float32(1)
@@ -261,18 +281,24 @@ def convert_edges(
         },
         allow_features=False,
     )
-    edges, type_starts, edge_features = converter.convert(data)
+    ids, columns, type_starts, edge_features = converter.convert(data)
 
     # validation:
     assert all(features is None for features in edge_features.values())
 
-    weight_col = edges[WEIGHT]
+    weight_col = columns[WEIGHT]
     if not pd.api.types.is_numeric_dtype(weight_col):
         raise TypeError(
             f"{converter.name()}: expected weight column {weight_column!r} to be numeric, found dtype '{weight_col.dtype}'"
         )
 
-    return EdgeData(edges, type_starts)
+    return EdgeData(
+        ids,
+        columns[SOURCE],
+        columns[TARGET],
+        weight_col,
+        type_starts,
+    )
 
 
 SingleTypeNodeIdsAndFeatures = namedtuple(

--- a/stellargraph/core/convert.py
+++ b/stellargraph/core/convert.py
@@ -157,8 +157,8 @@ class ColumnarConverter:
                 for col_name, col_arrays in type_columns.items()
             }
         else:
-            # there was no input types and thus no input elements, so create a dummy dataframe, that
-            # is maximally flexible by using a "minimal"/highly-promotable type
+            # there was no input types and thus no input elements, so create a dummy set of columns,
+            # that is maximally flexible by using a "minimal"/highly-promotable type
             ids = []
             columns = {
                 name: np.empty(0, dtype=np.uint8)

--- a/stellargraph/core/convert.py
+++ b/stellargraph/core/convert.py
@@ -153,7 +153,9 @@ class ColumnarConverter:
         if len(type_ids) == 1:
             # if there's only one type, avoid copying everything in a no-op concatentation
             ids = type_ids[0]
-            columns = {col_name: col_arrays[0] for col_name, col_arrays in type_columns.items()}
+            columns = {
+                col_name: col_arrays[0] for col_name, col_arrays in type_columns.items()
+            }
         elif type_ids:
             ids = np.concatenate(type_ids)
             columns = {

--- a/stellargraph/core/element_data.py
+++ b/stellargraph/core/element_data.py
@@ -311,9 +311,14 @@ class EdgeData(ElementData):
                     f"{name}: expected a NumPy ndarray, found {type(column).__name__}"
                 )
 
-            if column.shape != ids.shape:
+            if len(column.shape) != 1:
                 raise TypeError(
-                    f"{name}: expected a shape of {ids.shape} to match 'ids', found {column.shape}"
+                    f"{name}: expected rank-1 array, found shape {column.shape}"
+                )
+
+            if len(column) != len(self._id_index):
+                raise TypeError(
+                    f"{name}: expected length {len(self._id_index)} to match IDs, found length {len(column)}"
                 )
 
         self.sources = sources

--- a/stellargraph/core/element_data.py
+++ b/stellargraph/core/element_data.py
@@ -119,29 +119,18 @@ class ElementData:
     than indexing pandas dataframes, series or indices.
 
     Args:
-        shared (pandas DataFrame): information for each element
+        ids (sequence): the IDs of each element
         type_starts (list of tuple of type name, int): the starting iloc of the elements of each type within ``shared``
     """
 
-    # any columns that must be in the `shared` dataframes passed to `__init__` (this should be
-    # overridden by subclasses as appropriate)
-    _SHARED_REQUIRED_COLUMNS = []
-
-    def __init__(self, shared, type_starts):
-        if not isinstance(shared, pd.DataFrame):
-            raise TypeError(
-                f"shared: expected pandas DataFrame, found {type(shared).__name__}"
-            )
-
-        require_dataframe_has_columns("shared", shared, self._SHARED_REQUIRED_COLUMNS)
-
+    def __init__(self, ids, type_starts):
         if not isinstance(type_starts, list):
             raise TypeError(
                 f"type_starts: expected list, found {type(type_starts).__name__}"
             )
 
         type_ranges = {}
-        type_stops = type_starts[1:] + [(None, len(shared))]
+        type_stops = type_starts[1:] + [(None, len(ids))]
         consecutive_types = zip(type_starts, type_stops)
         for idx, ((type_name, start), (_, stop)) in enumerate(consecutive_types):
             if idx == 0 and start != 0:
@@ -154,8 +143,7 @@ class ElementData:
                 )
             type_ranges[type_name] = range(start, stop)
 
-        self._id_index = ExternalIdIndex(shared.index)
-        self._columns = {name: data.to_numpy() for name, data in shared.iteritems()}
+        self._id_index = ExternalIdIndex(ids)
 
         # there's typically a small number of types, so we can map them down to a small integer type
         # (usually uint8) for minimum storage requirements
@@ -171,9 +159,6 @@ class ElementData:
 
     def __contains__(self, item) -> bool:
         return self._id_index.contains_external(item)
-
-    def _column(self, column) -> np.ndarray:
-        return self._columns[column]
 
     @property
     def ids(self) -> ExternalIdIndex:
@@ -223,13 +208,13 @@ class ElementData:
 class NodeData(ElementData):
     """
     Args:
-        shared (pandas DataFrame): information for the nodes
+        ids (sequence): the IDs of each element
         type_starts (list of tuple of type name, int): the starting iloc of the nodes of each type within ``shared``
         features (dict of type name to numpy array): a 2D numpy or scipy array of feature vectors for the nodes of each type
     """
 
-    def __init__(self, shared, type_starts, features):
-        super().__init__(shared, type_starts)
+    def __init__(self, ids, type_starts, features):
+        super().__init__(ids, type_starts)
         if not isinstance(features, dict):
             raise TypeError(f"features: expected dict, found {type(features).__name__}")
 
@@ -306,19 +291,34 @@ def _numpyise(d, dtype):
 class EdgeData(ElementData):
     """
     Args:
-        shared (pandas DataFrame): information for the edges
+        ids (sequence): the IDs of each element
+        sources (numpy.ndarray): the ilocs of the source of each edge
+        targets (numpy.ndarray): the ilocs of the target of each edge
+        weight (numpy.ndarray): the weight of each edge
         type_starts (list of tuple of type name, int): the starting iloc of the edges of each type within ``shared``
     """
 
-    _SHARED_REQUIRED_COLUMNS = [SOURCE, TARGET, WEIGHT]
+    def __init__(self, ids, sources, targets, weights, type_starts):
+        super().__init__(ids, type_starts)
 
-    def __init__(self, shared, type_starts):
-        super().__init__(shared, type_starts)
+        for name, column in {
+            "sources": sources,
+            "targets": targets,
+            "weights": weights,
+        }.items():
+            if not isinstance(column, np.ndarray):
+                raise TypeError(
+                    f"{name}: expected a NumPy ndarray, found {type(column).__name__}"
+                )
 
-        # cache these columns to avoid having to do more method and dict look-ups
-        self.sources = self._column(SOURCE)
-        self.targets = self._column(TARGET)
-        self.weights = self._column(WEIGHT)
+            if column.shape != ids.shape:
+                raise TypeError(
+                    f"{name}: expected a shape of {ids.shape} to match 'ids', found {column.shape}"
+                )
+
+        self.sources = sources
+        self.targets = targets
+        self.weights = weights
 
         # These are lazily initialized, to only pay the (construction) time and memory cost when
         # actually using them

--- a/tests/core/test_convert.py
+++ b/tests/core/test_convert.py
@@ -69,7 +69,9 @@ def test_columnar_convert_column_default():
     converter = ColumnarConverter(
         "some_name", "foo", None, {"before": 123}, {"before": "before"}, False, {}
     )
-    ids, columns, type_starts, features = converter.convert({"x": _EMPTY_DF, "y": _EMPTY_DF})
+    ids, columns, type_starts, features = converter.convert(
+        {"x": _EMPTY_DF, "y": _EMPTY_DF}
+    )
 
     assert type_starts == [("x", 0), ("y", 2)]
     np.testing.assert_array_equal(columns["before"], 123)
@@ -80,7 +82,9 @@ def test_columnar_convert_column_default_selected_columns():
     converter = ColumnarConverter(
         "x", "foo", None, {"before": 123}, {"before": "after"}, False, {}
     )
-    ids, columns, type_starts, features = converter.convert({"x": _EMPTY_DF, "y": _EMPTY_DF})
+    ids, columns, type_starts, features = converter.convert(
+        {"x": _EMPTY_DF, "y": _EMPTY_DF}
+    )
 
     assert type_starts == [("x", 0), ("y", 2)]
 

--- a/tests/core/test_graph.py
+++ b/tests/core/test_graph.py
@@ -179,7 +179,7 @@ def test_graph_constructor_nodes_from_edges():
 
     with pytest.raises(
         ValueError,
-        match=r"edges.*: expected 'source', 'target', 'weight' columns, found: 'weight'",
+        match=r"edges.*: expected 'source', 'target', 'weight' columns, found: 'x'",
     ):
         StellarGraph(edges=pd.DataFrame(columns=["x"]))
 

--- a/tests/core/test_graph.py
+++ b/tests/core/test_graph.py
@@ -759,7 +759,7 @@ def test_benchmark_get_features(
 # various element counts, to give an indication of the relationship
 # between those and memory use (0,0 gives the overhead of the
 # StellarGraph object itself, without any data)
-@pytest.mark.parametrize("num_nodes,num_edges", [(0, 0), (100, 200), (1000, 5000)])
+@pytest.mark.parametrize("num_nodes,num_edges", [(0, 0), (1000, 5000), (20000, 100000)])
 # features or not, to capture their cost
 @pytest.mark.parametrize("feature_size", [None, 100])
 @pytest.mark.parametrize("force_adj_lists", [None, "directed", "undirected", "both"])


### PR DESCRIPTION
This switches away from doing Pandas manipulations to using NumPy directly, and passing around columns directly rather than the unnecessarily complexity of the "shared" DataFrame in `ElementData`. Almost all of our manipulations are simple (filtering, shuffling and concatenating), and we're working with simple data types, so this is both safe and efficient.

This makes construction significantly faster and have slightly less memory overhead. At this point, there's essentially no time difference between the `num_nodes=0, num_edges=0` benchmark and the `num_nodes=1000, num_edges=5000` one. Thus, this replaces the `num_nodes=100, num_edges=200` version with one 200 times larger: `num_nodes=20000, num_edges=100000 `. The memory benchmark is more sensitive (it's easy to distinguish each of the levels so they give useful information about the cost of nodes and edges) and runs slower, so it remains with `num_nodes=100, num_edges=200`.

This patch doesn't affect features nor the time for adjacency list construction, so this reports the median times (ms) and memory (KiB) in the creation benchmarks for `feature_size=None` and `force_adj_lists=None`.

| nodes | edges | time (develop) | time (this PR) | speedup | memory (develop) | memory (this PR) | reduction |
|---|---|---|---|---|---|---|---|
| 0 | 0 | 8.54 | 2.19 | 3.9× | 14.1 | 6.84 | -51% |
| 1000 | 5000 | 9.22 | 2.45 | 3.8× | 69.9 | 62.6 | -10% |
| 20000 | 100000 | 13.0 | 5.65 | 2.3× |  N/A | N/A | N/A |

The memory reduction of about 7k seems to be entirely having less overhead. For instance, by constructing Pandas indices directly from NumPy arrays, it seems like they no longer cache some arrays internally, saving a little bit of memory for each index.

On real world datasets, measuring allocations end-to-end with `tracemalloc` via https://gist.github.com/huonw/deb88a9179cfb588f9d5fff59955f56d (times in ms, memory in MiB):

| dataset | time (develop) | time (this PR) | speedup | memory (develop) | memory (this PR) | reduction |
|---|---|---|---|---|---|---|
| Cora | 6.31 | 1.92 | 3.3× | 0.093 | 0.088 | -6% |
| FB15k | 144 | 113 | 1.3× | 6.104 | 6.100 | -0.07% |
| Reddit | 967 | 471 | 2.1× | 146.781 | 146.777 | -0.003% |

I think FB15k sees less of a speedup because its IDs are strings, whereas the other datasets are integers.

This patch is a critical building block towards construction directly from NumPy (#1524), but also helps with things like #1336:

```python
import stellargraph as sg
dataset = sg.datasets.MUTAG()
%timeit -n 1 dataset.load()
```

- develop: `1.18 s ± 25.5 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)`
- this PR: `464 ms ± 14.8 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)`

See: #1524