### PR TITLE
Implement RotE and RotH

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -160,6 +160,12 @@ Knowledge Graph models
 .. autoclass:: RotatEScore
   :members:
 
+.. autoclass:: RotE
+  :members:
+
+.. autoclass:: RotH
+  :members:
+
 GCN Supervised Graph Classification
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -230,6 +236,9 @@ Utilities
 
 .. automodule:: stellargraph.utils
   :members: plot_history
+
+.. automodule:: stellargraph.utils.hyperbolic
+  :members:
 
 
 Datasets

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -4,6 +4,7 @@ Alemi
 Ananthram
 Bai
 Bengio
+Bécigneul
 Bishan
 Bloehdorn
 Bloem
@@ -41,6 +42,7 @@ Frossard
 GAT
 GCN
 Gao
+Ganea
 Gaussier
 Gensim
 Giang
@@ -55,6 +57,7 @@ Haija
 Hallac
 Hjelm
 Hoang
+Hofmann
 Hsiej
 Infomax
 Jaccard

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -74,6 +74,7 @@ Mannion
 Mikolov
 Minervini
 Monti
+Möbius
 Muhan
 Nesreen
 NetworkX
@@ -84,6 +85,7 @@ Peng
 Perozzi
 Platt
 Pleiss
+Poincaré
 Pontus
 Pubmed
 Qu
@@ -91,6 +93,8 @@ Rfou
 Riedel
 Rong
 Rossi
+RotE
+RotH
 SNE
 Schlichtkrull
 Shang

--- a/stellargraph/layer/knowledge_graph.py
+++ b/stellargraph/layer/knowledge_graph.py
@@ -671,7 +671,7 @@ class RotatE(KGModel):
         )
 
 
-class RotationHEScoring(Layer, KGScore):
+class RotHEScoring(Layer, KGScore):
     def __init__(self, hyperbolic):
         self._hyperbolic = hyperbolic
         if self._hyperbolic:
@@ -795,7 +795,24 @@ class RotationHEScoring(Layer, KGScore):
         return mod_o_pred.numpy(), mod_s_pred.numpy()
 
 
-class RotationH(KGModel):
+@experimental(reason="demo is missing", issues=[1664])
+class RotH(KGModel):
+    """
+    Embedding layers and a RotH scoring layer that implement the RotH knowledge graph
+    embedding algorithm as in https://arxiv.org/pdf/2005.00545.pdf
+
+    Args:
+        generator (KGTripleGenerator): A generator of triples to feed into the model.
+
+        embedding_dimension (int): the dimension of the embeddings (that is, a vector in
+            ``R^embedding_dimension`` plus a bias in ``R`` is learnt for each node, along with a pair of
+            vectors in ``R^embedding_dimension`` and ``R^(embedding_dimension / 2)`` for each node
+            type). It must be even.
+
+        embeddings_initializer (str or func, optional): The initialiser to use for the embeddings.
+
+        embeddings_regularizer (str or func, optional): The regularizer to use for the embeddings.
+    """
     def __init__(
         self,
         generator,
@@ -805,14 +822,31 @@ class RotationH(KGModel):
     ):
         super().__init__(
             generator,
-            RotationHEScoring(hyperbolic=True),
+            RotHEScoring(hyperbolic=True),
             embedding_dimension=embedding_dimension,
             embeddings_initializer=embeddings_initializer,
             embeddings_regularizer=embeddings_regularizer,
         )
 
 
-class RotationE(KGModel):
+@experimental(reason="demo is missing", issues=[1664])
+class RotE(KGModel):
+    """
+    Embedding layers and a RotE scoring layer that implement the RotE knowledge graph
+    embedding algorithm as in https://arxiv.org/pdf/2005.00545.pdf
+
+    Args:
+        generator (KGTripleGenerator): A generator of triples to feed into the model.
+
+        embedding_dimension (int): the dimension of the embeddings (that is, a vector in
+            ``R^embedding_dimension`` plus a bias in ``R`` is learnt for each node, along with a pair of
+            vectors in ``R^embedding_dimension`` and ``R^(embedding_dimension / 2)`` for each node
+            type). It must be even.
+
+        embeddings_initializer (str or func, optional): The initialiser to use for the embeddings.
+
+        embeddings_regularizer (str or func, optional): The regularizer to use for the embeddings.
+    """
     def __init__(
         self,
         generator,
@@ -822,7 +856,7 @@ class RotationE(KGModel):
     ):
         super().__init__(
             generator,
-            RotationHEScoring(hyperbolic=False),
+            RotHEScoring(hyperbolic=False),
             embedding_dimension=embedding_dimension,
             embeddings_initializer=embeddings_initializer,
             embeddings_regularizer=embeddings_regularizer,

--- a/stellargraph/layer/knowledge_graph.py
+++ b/stellargraph/layer/knowledge_graph.py
@@ -718,6 +718,7 @@ class RotHEScoring(Layer, KGScore):
         super().build(input_shapes)
 
     def _curvature(self, expand=1):
+        assert self.built
         if not self._hyperbolic:
             return tf.constant([0.0])
 

--- a/stellargraph/layer/knowledge_graph.py
+++ b/stellargraph/layer/knowledge_graph.py
@@ -675,7 +675,7 @@ class RotHEScoring(Layer, KGScore):
     def __init__(self, hyperbolic):
         self._hyperbolic = hyperbolic
         if self._hyperbolic:
-            self._convert = poincare_ball_exp_map0
+            self._convert = lambda c, v: poincare_ball_exp(c, None, v)
             self._add = poincare_ball_mobius_add
             self._squared_distance = lambda c, v, w: tf.square(
                 poincare_ball_distance(c, v, w)
@@ -799,7 +799,7 @@ class RotHEScoring(Layer, KGScore):
 class RotH(KGModel):
     """
     Embedding layers and a RotH scoring layer that implement the RotH knowledge graph
-    embedding algorithm as in https://arxiv.org/pdf/2005.00545.pdf
+    embedding algorithm as in https://arxiv.org/abs/2005.00545
 
     Args:
         generator (KGTripleGenerator): A generator of triples to feed into the model.
@@ -813,6 +813,7 @@ class RotH(KGModel):
 
         embeddings_regularizer (str or func, optional): The regularizer to use for the embeddings.
     """
+
     def __init__(
         self,
         generator,
@@ -847,6 +848,7 @@ class RotE(KGModel):
 
         embeddings_regularizer (str or func, optional): The regularizer to use for the embeddings.
     """
+
     def __init__(
         self,
         generator,

--- a/stellargraph/layer/knowledge_graph.py
+++ b/stellargraph/layer/knowledge_graph.py
@@ -717,7 +717,7 @@ class RotHEScoring(Layer, KGScore):
 
         super().build(input_shapes)
 
-    def _curvature(self, expand=1):
+    def _curvature(self):
         assert self.built
         if not self._hyperbolic:
             return tf.constant([0.0])

--- a/stellargraph/utils/__init__.py
+++ b/stellargraph/utils/__init__.py
@@ -21,3 +21,4 @@ This contains the utility objects used by the StellarGraph library.
 
 from .history import *
 from .version_validation import *
+from . import hyperbolic

--- a/stellargraph/utils/hyperbolic.py
+++ b/stellargraph/utils/hyperbolic.py
@@ -16,17 +16,61 @@
 
 __all__ = [
     "poincare_ball_distance",
-    "poincare_ball_exp_map",
-    "poincare_ball_exp_map0",
+    "poincare_ball_exp",
     "poincare_ball_mobius_add",
 ]
 
 import tensorflow as tf
+import numpy as np
+
+
+# helper functions to manage numerical issues, inspired by https://github.com/dalab/hyperbolic_nn
+
+PROJECTION_EPS = 1e-5
+TANH_LIMIT = 15.0
+ATANH_LIMIT = tf.math.nextafter(1, 0)
+
+
+def _project(c, x):
+    """
+    Ensure ``x`` lies on the Poincaré ball with curvature ``-c``, in the presence of small numerical
+    errors.
+    """
+    max_norm = tf.math.rsqrt(c) * (1 - PROJECTION_EPS)
+    return tf.clip_by_norm(x, clip_norm=max_norm, axes=-1)
+
+
+def _tanh(x):
+    return tf.tanh(tf.clip_by_value(x, -TANH_LIMIT, TANH_LIMIT))
+
+
+def _atanh(x):
+    return tf.atanh(tf.clip_by_value(x, -ATANH_LIMIT, ATANH_LIMIT))
 
 
 def poincare_ball_mobius_add(c, x, y):
     r"""
     Möbius addition of ``x`` and ``y``, on the Poincaré ball with curvature ``-c``: :math:`\mathbf{x} \oplus^c \mathbf{y}`.
+
+    See Section 2 of [1] for more details.
+
+    [1] O.-E. Ganea, G. Bécigneul, and T. Hofmann, “Hyperbolic Neural Networks,” `arXiv:1805.09112 <http://arxiv.org/abs/1805.09112>`_, Jun. 2018.
+
+    Args:
+        c (tensorflow Tensor-like): the curvature of the hyperbolic space(s). Must be able to be
+            broadcast to ``x`` and ``y``.
+        x (tensorflow Tensor-like): a tensor containing vectors in hyperbolic space, where each
+            vector is an element of the last axis (for example, if ``x`` has shape ``(2, 3, 4)``, it
+            represents ``2 * 3 = 6`` hyperbolic vectors, each of length ``4``). Must be able to be
+            broadcast to ``y``.
+        y (tensorflow Tensor-like): a tensor containing vectors in hyperbolic space, where each
+            vector is an element of the last axis similar to ``x``. Must be able to be broadcast to
+            ``x``.
+
+    Returns:
+        A TensorFlow Tensor containing the Möbius addition of each of the vectors (last axis) in
+        ``x`` and ``y``, using the corresponding curvature from ``c``. This tensor has the same
+        shape as the Euclidean equivalent ``x + y``.
     """
     x_norm2 = tf.reduce_sum(x * x, axis=-1, keepdims=True)
     y_norm2 = tf.reduce_sum(y * y, axis=-1, keepdims=True)
@@ -36,41 +80,72 @@ def poincare_ball_mobius_add(c, x, y):
     numer = (inner + c * y_norm2) * x + (1 - c * x_norm2) * y
     denom = inner + c * c * x_norm2 * y_norm2
 
-    return numer / denom
+    return _project(c, numer / denom)
 
 
-def _exp_map_multiply(c, v, denom):
-    v_norm2 = tf.reduce_sum(v * v, axis=-1, keepdims=True)
-    c_v_norm = tf.sqrt(c * v_norm2)
-    inner = c_v_norm if denom is None else c_v_norm / denom
-    coeff = tf.math.tanh(inner) / c_v_norm
-    return coeff * v
-
-
-def poincare_ball_exp_map(x, c, v):
+def poincare_ball_exp(c, x, v):
     r"""
     The exponential map of ``v`` at ``x`` on the Poincaré ball with curvature ``-c``:
     :math:`\exp_{\mathbf{x}}^c(\mathbf{v})`.
+
+    See Section 2 of [1] for more details.
+
+    [1] O.-E. Ganea, G. Bécigneul, and T. Hofmann, “Hyperbolic Neural Networks,” `arXiv:1805.09112 <http://arxiv.org/abs/1805.09112>`_, Jun. 2018.
+
+    Args:
+        c (tensorflow Tensor-like): the curvature of the hyperbolic space(s). Must be able to be
+            broadcast to ``x`` and ``v``.
+
+        x (tensorflow Tensor-like, optional): a tensor containing vectors in hyperbolic space
+            representing the base points for the exponential map, where each vector is an element of
+            the last axis (for example, if ``x`` has shape ``(2, 3, 4)``, it represents ``2 * 3 =
+            6`` hyperbolic vectors, each of length ``4``). Must be able to be broadcast to ``v``. An
+            explicit ``x = None`` is equivalent to ``x`` being all zeros, but uses a more efficient
+            form of :math:`\exp_{\mathbf{0}}^c(\mathbf{v})`.
+
+        v (tensorflow Tensor-like): a tensor containing vectors in Euclidean space representing the
+            tangent vectors for the exponential map, where each vector is an element of the last
+            axis similar to ``x``. Must be able to be broadcast to ``x``.
     """
+
+    v_norm2 = tf.reduce_sum(v * v, axis=-1, keepdims=True)
+    c_v_norm = tf.sqrt(c * v_norm2)
+
+    if x is None:
+        coeff = _tanh(c_v_norm) / c_v_norm
+        return _project(c, coeff * v)
 
     x_norm2 = tf.reduce_sum(x * x, axis=-1, keepdims=True)
-    return poincare_ball_mobius_add(c, x, _exp_map_multiply(c, v, 1 - c * x_norm2))
-
-
-def poincare_ball_exp_map0(c, v):
-    r"""
-    :math:`\exp_{\mathbf{x}}^c(\mathbf{v})` specialised for :math:`\mathbf{x} = \mathbf{0}`.
-
-    .. seealso:: :func:`poincare_ball_exp_map`
-    """
-    return _exp_map_multiply(c, v, denom=None)
+    inner = c_v_norm / (1 - c * x_norm2)
+    coeff = _tanh(inner) / c_v_norm
+    return poincare_ball_mobius_add(c, x, coeff * v)
 
 
 def poincare_ball_distance(c, x, y):
-    """
+    r"""
     Distance between ``x`` and ``y``, on the Poincaré ball with curvature ``-c``: :math:`d_c(\mathbf{x}, \mathbf{y})`.
+
+    See Section 2 of [1] for more details.
+
+    [1] O.-E. Ganea, G. Bécigneul, and T. Hofmann, “Hyperbolic Neural Networks,” `arXiv:1805.09112 <http://arxiv.org/abs/1805.09112>`_, Jun. 2018.
+
+    Args:
+        c (tensorflow Tensor-like): the curvature of the hyperbolic space(s). Must be able to be
+            broadcast to ``x`` and ``y``.
+        x (tensorflow Tensor-like): a tensor containing vectors in hyperbolic space, where each
+            vector is an element of the last axis (for example, if ``x`` has shape ``(2, 3, 4)``, it
+            represents ``2 * 3 = 6`` hyperbolic vectors, each of length ``4``). Must be able to be
+            broadcast to ``y``.
+        y (tensorflow Tensor-like): a tensor containing vectors in hyperbolic space, where each
+            vector is an element of the last axis similar to ``x``. Must be able to be broadcast to
+            ``x``.
+
+    Returns:
+        A TensorFlow Tensor containing the hyperbolic distance between each of the vectors (last
+        axis) in ``x`` and ``y``, using the corresponding curvature from ``c``. This tensor has the
+        same shape as the Euclidean equivalent ``tf.norm(x - y)``.
     """
     sqrt_c = tf.sqrt(c)
-    return (2 / sqrt_c) * tf.atanh(
-        sqrt_c * tf.norm(-poincare_ball_mobius_add(c, x, y), axis=-1)
+    return (2 / sqrt_c) * _atanh(
+        sqrt_c * tf.norm(poincare_ball_mobius_add(c, -x, y), axis=-1)
     )

--- a/stellargraph/utils/hyperbolic.py
+++ b/stellargraph/utils/hyperbolic.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2020 Data61, CSIRO
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__all__ = [
+    "poincare_ball_distance",
+    "poincare_ball_exp_map",
+    "poincare_ball_exp_map0",
+    "poincare_ball_mobius_add",
+]
+
+import tensorflow as tf
+
+
+def poincare_ball_mobius_add(c, x, y):
+    r"""
+    Möbius addition of ``x`` and ``y``, on the Poincaré ball with curvature ``c``: :math:`\mathbf{x} \oplus^c \mathbf{y}`.
+    """
+    x_norm2 = tf.reduce_sum(x * x, axis=-1, keepdims=True)
+    y_norm2 = tf.reduce_sum(y * y, axis=-1, keepdims=True)
+    x_dot_y = tf.reduce_sum(x * y, axis=-1, keepdims=True)
+
+    inner = 1 + 2 * c * x_dot_y
+    numer = (inner + c * y_norm2) * x + (1 - c * x_norm2) * y
+    denom = inner + c * c * x_norm2 * y_norm2
+
+    return numer / denom
+
+
+def _exp_map_multiply(c, v, denom):
+    v_norm2 = tf.reduce_sum(v * v, axis=-1, keepdims=True)
+    c_v_norm = tf.sqrt(c * v_norm2)
+    inner = c_v_norm if denom is None else c_v_norm / denom
+    coeff = tf.math.tanh(inner) / c_v_norm
+    return coeff * v
+
+
+def poincare_ball_exp_map(x, c, v):
+    r"""
+    The exponential map of ``v`` at ``x`` on the Poincaré ball with curvature ``c``:
+    :math:`\exp_{\mathbf{x}}^c(\mathbf{v})`.
+    """
+
+    x_norm2 = tf.reduce_sum(x * x, axis=-1, keepdims=True)
+    return poincare_ball_mobius_add(c, x, _exp_map_multiply(c, v, 1 - c * x_norm2))
+
+
+def poincare_ball_exp_map0(c, v):
+    r"""
+    :math:`\exp_{\mathbf{x}}^c(\mathbf{v})` specialised for :math:`\mathbf{x} = \mathbf{0}`.
+
+    .. seealso:: :func:`poincare_ball_exp_map`
+    """
+    return _exp_map_multiply(c, v, denom=None)
+
+
+def poincare_ball_distance(c, x, y):
+    """
+    Distance between ``x`` and ``y``, on the Poincaré ball with curvature ``c``: :math:`d_c(\mathbf{x}, \mathbf{y})`.
+    """
+    sqrt_c = tf.sqrt(c)
+    return (2 / sqrt_c) * tf.atanh(
+        sqrt_c * tf.norm(-poincare_ball_mobius_add(c, x, y), axis=-1)
+    )

--- a/stellargraph/utils/hyperbolic.py
+++ b/stellargraph/utils/hyperbolic.py
@@ -26,7 +26,7 @@ import tensorflow as tf
 
 def poincare_ball_mobius_add(c, x, y):
     r"""
-    Möbius addition of ``x`` and ``y``, on the Poincaré ball with curvature ``c``: :math:`\mathbf{x} \oplus^c \mathbf{y}`.
+    Möbius addition of ``x`` and ``y``, on the Poincaré ball with curvature ``-c``: :math:`\mathbf{x} \oplus^c \mathbf{y}`.
     """
     x_norm2 = tf.reduce_sum(x * x, axis=-1, keepdims=True)
     y_norm2 = tf.reduce_sum(y * y, axis=-1, keepdims=True)
@@ -49,7 +49,7 @@ def _exp_map_multiply(c, v, denom):
 
 def poincare_ball_exp_map(x, c, v):
     r"""
-    The exponential map of ``v`` at ``x`` on the Poincaré ball with curvature ``c``:
+    The exponential map of ``v`` at ``x`` on the Poincaré ball with curvature ``-c``:
     :math:`\exp_{\mathbf{x}}^c(\mathbf{v})`.
     """
 
@@ -68,7 +68,7 @@ def poincare_ball_exp_map0(c, v):
 
 def poincare_ball_distance(c, x, y):
     """
-    Distance between ``x`` and ``y``, on the Poincaré ball with curvature ``c``: :math:`d_c(\mathbf{x}, \mathbf{y})`.
+    Distance between ``x`` and ``y``, on the Poincaré ball with curvature ``-c``: :math:`d_c(\mathbf{x}, \mathbf{y})`.
     """
     sqrt_c = tf.sqrt(c)
     return (2 / sqrt_c) * tf.atanh(

--- a/tests/layer/test_knowledge_graph.py
+++ b/tests/layer/test_knowledge_graph.py
@@ -285,9 +285,7 @@ def test_rote_roth(knowledge_graph, model_class):
     np.testing.assert_array_equal(prediction, prediction2)
 
 
-@pytest.mark.parametrize(
-    "model_maker", [ComplEx, DistMult, RotatE, RotH, RotE]
-)
+@pytest.mark.parametrize("model_maker", [ComplEx, DistMult, RotatE, RotH, RotE])
 def test_model_rankings(model_maker):
     nodes = pd.DataFrame(index=["a", "b", "c", "d"])
     rels = ["W", "X", "Y", "Z"]

--- a/tests/layer/test_knowledge_graph.py
+++ b/tests/layer/test_knowledge_graph.py
@@ -32,6 +32,8 @@ from stellargraph.layer.knowledge_graph import (
     ComplEx,
     DistMult,
     RotatE,
+    RotationE,
+    RotationH,
     _ranks_from_score_columns,
 )
 
@@ -218,7 +220,74 @@ def test_rotate(knowledge_graph):
     assert np.array_equal(prediction, prediction2)
 
 
-@pytest.mark.parametrize("model_maker", [ComplEx, DistMult, RotatE])
+@pytest.mark.parametrize("model_class", [RotationE, RotationH])
+def test_rotationhe(knowledge_graph, model_class):
+    # this test creates a random untrained model and predicts every possible edge in the graph, and
+    # compares that to a direct implementation of the scoring method in the paper
+    gen = KGTripleGenerator(knowledge_graph, 3)
+
+    # use a random initializer with a large range, so that any differences are obvious
+    init = initializers.RandomUniform(-1, 1)
+    rotation_model = model_class(gen, 6, embeddings_initializer=init)
+    x_inp, x_out = rotation_model.in_out_tensors()
+
+    model = Model(x_inp, x_out)
+    model.summary()
+    model.compile(loss=losses.BinaryCrossentropy(from_logits=True))
+
+    every_edge = itertools.product(
+        knowledge_graph.nodes(),
+        knowledge_graph._edges.types.pandas_index,
+        knowledge_graph.nodes(),
+    )
+    df = triple_df(*every_edge)
+
+    # check the model can be trained on a few (uneven) batches
+    model.fit(
+        gen.flow(df.iloc[:7], negative_samples=2),
+        validation_data=gen.flow(df.iloc[7:14], negative_samples=3),
+    )
+
+    # predict every edge using the model
+    prediction = model.predict(gen.flow(df))
+
+    (node_emb, node_bias), (et_emb, et_theta) = rotation_model.embedding_arrays()
+
+    if model_class is RotationE:
+        # compute the exact values based on the model, for RotationE (the RotationH model is too
+        # hard to test directly)
+        s_idx = knowledge_graph.node_ids_to_ilocs(df.source)
+        r_idx = knowledge_graph.edge_type_names_to_ilocs(df.label)
+        o_idx = knowledge_graph.node_ids_to_ilocs(df.target)
+
+        # the rows correspond to the embeddings for the given edge, so we can do bulk operations
+        e_s = node_emb[s_idx, :]
+        b_s = node_bias[s_idx, 0]
+
+        r_r = et_emb[r_idx, :]
+        theta_r = et_theta[r_idx, :]
+
+        e_o = node_emb[o_idx, :]
+        b_o = node_bias[o_idx, 0]
+
+        rot_r = np.cos(theta_r) + 1j * np.sin(theta_r)
+
+        assert e_s.dtype == np.float32
+        rotated = (e_s.view(np.complex64) * rot_r).view(np.float32)
+        actual = -np.linalg.norm(rotated + r_r - e_o, axis=-1) ** 2 + b_s + b_o
+
+        np.testing.assert_allclose(prediction[:, 0], actual, rtol=1e-3, atol=1e-14)
+
+    # the model is stateful (i.e. it holds the weights permanently) so the predictions with a second
+    # 'build' should be the same as the original one
+    model2 = Model(*rotation_model.in_out_tensors())
+    prediction2 = model2.predict(gen.flow(df))
+    np.testing.assert_array_equal(prediction, prediction2)
+
+
+@pytest.mark.parametrize(
+    "model_maker", [ComplEx, DistMult, RotatE, RotationH, RotationE]
+)
 def test_model_rankings(model_maker):
     nodes = pd.DataFrame(index=["a", "b", "c", "d"])
     rels = ["W", "X", "Y", "Z"]
@@ -252,7 +321,7 @@ def test_model_rankings(model_maker):
     )
 
     gen = KGTripleGenerator(all_edges, 3)
-    sg_model = model_maker(gen, embedding_dimension=5)
+    sg_model = model_maker(gen, embedding_dimension=6)
     x_inp, x_out = sg_model.in_out_tensors()
     model = Model(x_inp, x_out)
 

--- a/tests/utils/test_hyperbolic.py
+++ b/tests/utils/test_hyperbolic.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2020 Data61, CSIRO
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+import numpy as np
+from stellargraph.utils.hyperbolic import *
+
+
+@pytest.fixture
+def seeded():
+    seed = np.random.randint(2 ** 32)
+    # log for reproducibility
+    print("seed:", seed)
+    np.random.seed(seed)
+
+
+def _generate(num_vectors, norm_range=(0, 1)):
+    c = np.random.random() * 10
+    n = np.random.choice([1, 2, 5, 10, 30, 100])
+    extra_axes = np.random.choice([0, 1, 3])
+
+    small, big = norm_range
+    norms = (small + np.random.random(size=num_vectors) * (big - small)) / c ** 0.5
+
+    raws = 2 * np.random.random(size=(num_vectors, n)) - 1
+    scale = norms / np.linalg.norm(raws, axis=1)
+    vs = raws * scale[:, None]
+    return c, vs.astype(np.float32)[(None,) * extra_axes]
+
+
+def test_poincare_ball_exp_map0_specialisation(seeded):
+    for _ in range(100):
+        c, vs = _generate(17)
+
+        specialised = poincare_ball_exp_map0(c, vs)
+        assert specialised.shape == vs.shape
+
+        actual = poincare_ball_exp_map(np.zeros_like(vs), c, vs)
+        np.testing.assert_allclose(specialised.numpy(), actual.numpy())
+
+
+def test_poincare_ball_distance_vs_euclidean(seeded):
+    for _ in range(100):
+        # d_c(0, x) is approximtely 2||x||_2 for sufficiently small x
+        c, vs = _generate(17, norm_range=(0, 0.01))
+        zeros = np.zeros_like(vs)
+        hyperbolic = poincare_ball_distance(c, zeros, vs)
+        assert hyperbolic.shape == vs.shape[:-1]
+
+        euclidean = np.linalg.norm(vs, axis=-1)
+        np.testing.assert_allclose(hyperbolic, 2 * euclidean, rtol=1e-3, atol=1e-15)
+
+        # d_c(0, x) is much larger than 2||x||_2 for sufficiently large x
+        c, vs = _generate(17, norm_range=(0.99, 1))
+        zeros = np.zeros_like(vs)
+        hyperbolic = poincare_ball_distance(c, zeros, vs)
+        assert hyperbolic.shape == vs.shape[:-1]
+
+        euclidean = np.linalg.norm(vs, axis=-1)
+        np.testing.assert_array_less(4 * euclidean, hyperbolic)

--- a/tests/utils/test_hyperbolic.py
+++ b/tests/utils/test_hyperbolic.py
@@ -28,35 +28,75 @@ def seeded():
     np.random.seed(seed)
 
 
-def _generate(num_vectors, norm_range=(0, 1)):
-    c = np.random.random() * 10
+def _generate(num_vectors, norm_range=(0, 1), euclidean_max_norm=None):
+    if euclidean_max_norm:
+        c = None
+        normaliser = euclidean_max_norm
+    else:
+        c = np.random.random() * 10
+        normaliser = c ** -0.5
+
     n = np.random.choice([1, 2, 5, 10, 30, 100])
     extra_axes = np.random.choice([0, 1, 3])
 
     small, big = norm_range
-    norms = (small + np.random.random(size=num_vectors) * (big - small)) / c ** 0.5
-
+    norms = (small + np.random.random(size=num_vectors) * (big - small)) * normaliser
     raws = 2 * np.random.random(size=(num_vectors, n)) - 1
     scale = norms / np.linalg.norm(raws, axis=1)
     vs = raws * scale[:, None]
+
     return c, vs.astype(np.float32)[(None,) * extra_axes]
 
 
-def test_poincare_ball_exp_map0_specialisation(seeded):
+def test_poincare_ball_exp_specialisation(seeded):
+    for _ in range(100):
+        # curvature
+        c, _vs = _generate(0)
+        # tangent space (Euclidean) vectors
+        _c, vs = _generate(17, euclidean_max_norm=1000)
+
+        specialised = poincare_ball_exp(c, None, vs)
+        assert specialised.shape == vs.shape
+
+        actual = poincare_ball_exp(c, np.zeros_like(vs), vs)
+        np.testing.assert_allclose(specialised.numpy(), actual.numpy())
+
+
+def test_poincare_ball_distance_self(seeded):
+    # the distance between a point and itself should be 0
     for _ in range(100):
         c, vs = _generate(17)
 
-        specialised = poincare_ball_exp_map0(c, vs)
-        assert specialised.shape == vs.shape
+        d = poincare_ball_distance(c, vs, vs)
+        assert d.shape == vs.shape[:-1]
+        np.testing.assert_allclose(d, 0, atol=1e-5)
 
-        actual = poincare_ball_exp_map(np.zeros_like(vs), c, vs)
-        np.testing.assert_allclose(specialised.numpy(), actual.numpy())
+
+def test_poincare_ball_distance_exp(seeded):
+    # d(0, exp_0(v)) is approximately 2||v||_2, for sufficiently short v
+    for _ in range(100):
+        c, _vs = _generate(0)
+        _c, tangents = _generate(17, euclidean_max_norm=1e-10)
+
+        tangent_lengths = np.linalg.norm(tangents, axis=-1)
+
+        def check(x, y):
+            d = poincare_ball_distance(c, x, y)
+            assert d.shape == tangents.shape[:-1]
+            np.testing.assert_allclose(d, 2 * tangent_lengths, rtol=1e-3)
+
+        zeros = np.zeros_like(tangents)
+        zero_moved = poincare_ball_exp(c, None, tangents)
+        assert zero_moved.shape == tangents.shape
+        check(zeros, zero_moved)
+        check(zero_moved, zeros)
 
 
 def test_poincare_ball_distance_vs_euclidean(seeded):
     for _ in range(100):
         # d_c(0, x) is approximtely 2||x||_2 for sufficiently small x
         c, vs = _generate(17, norm_range=(0, 0.01))
+
         zeros = np.zeros_like(vs)
         hyperbolic = poincare_ball_distance(c, zeros, vs)
         assert hyperbolic.shape == vs.shape[:-1]


### PR DESCRIPTION
This implements the RotationE and RotationH algorithms from [1], aka the RotE and RotH from [2]. After doing this I realised that [1] was probably a very-preprint, and it's now a preprint in [2]. The latter expands the algorithm slightly to include reflections in addition to rotations, but still explicitly discusses the rotation-only model (under a very slightly different name). The RotE/RotH algorithm performs similarly (or better than) the full AttE/AttH algorithm.

1. Chami I, Wolf A, Sala F, Ré C. Low-Dimensional Knowledge Graph Embeddings via Hyperbolic Rotations. http://stanford.edu/~fredsala/Hazy-HyperbolicKGs.pdf
2. Chami I, Wolf A, Juan D-C, Sala F, Ravi S, Ré C. Low-Dimensional Hyperbolic Knowledge Graph Embeddings. http://arxiv.org/abs/2005.00545

RotE is effectively a generalisation/combination of RotatE and TransE, and so future work could be combining them all to have a single shared/configurable model (including emergent models like hyperbolic TransE).

As somewhat of an implementation detail, this adds a `utils.hyperbolic` module with the various functions required for the hyperbolic RotH. This allows them to have some basic tests, as well as potentially making it easier to implement other hyperbolic models, e.g.:

- https://cs.stanford.edu/people/jure/pubs/hgcn-neurips19.pdf
- https://arxiv.org/abs/1910.12892

Related discussion of RotationH/RotH and RotationE/RotE, including a comparison to TransE, RotatE, etc.: https://nbviewer.jupyter.org/gist/huonw/52d585e571fde62e252c54fbe668faa3

Follow up: #1664 adding a demo.

See: #1540 