### PR TITLE
use git revision in readthedocs notebook links (#1538)

### DIFF
--- a/RELEASE_PROCEDURE.md
+++ b/RELEASE_PROCEDURE.md
@@ -151,7 +151,7 @@
       - Wait for the "Starting repository: stellargraph/stellargraph" loading screen to switch to a Jupyter environment
    
    2. For the release tag:
-      - Find the [specific release version](https://readthedocs.org/projects/stellargraph/versions/) of documentation just build on readthedocs (eg: `v1.0.0`, not the `stable` or `latest` version).
+      - Find the [specific release version](https://readthedocs.org/projects/stellargraph/versions/) of documentation just built on readthedocs (eg: `v1.0.0`, not the `stable` or `latest` version).
       - Navigate to any demo notebook in this documentation
       - Click the "launch binder" button
       - Wait for the "Starting repository: stellargraph/stellargraph" loading screen to switch to a Jupyter environment     

--- a/RELEASE_PROCEDURE.md
+++ b/RELEASE_PROCEDURE.md
@@ -145,15 +145,16 @@
 
     [Binder](https://mybinder.org) uses a docker image to package up the state of a repository. It takes a long time to build, and is only built lazily, for the first user to click one of our "launch binder" buttons. It is your job to do this:
 
-   1. for the `master` branch:
-     - Find [any demo notebook](https://github.com/stellargraph/stellargraph/blob/master/demos/basics/loading-pandas.ipynb) on the `master` branch
-     - Click [the "launch binder" button](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/basics/loading-pandas.ipynb) (or just click this link)
-     - Wait for the "Starting repository: stellargraph/stellargraph" loading screen to switch to a Jupyter environment
-   2. for the release tag:
-     - Find the [specific release version](https://readthedocs.org/projects/stellargraph/versions/) of documentation just build on readthedocs (eg: `v1.0.0`, not the `stable` or `latest` version).
-     - Navigate to any demo notebook in this documentation
-     - Click the "launch binder" button
-     - Wait for the "Starting repository: stellargraph/stellargraph" loading screen to switch to a Jupyter environment     
+   1. For the `master` branch:
+      - Find [any demo notebook](https://github.com/stellargraph/stellargraph/blob/master/demos/basics/loading-pandas.ipynb) on the `master` branch
+      - Click [the "launch binder" button](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/basics/loading-pandas.ipynb) (or just click this link)
+      - Wait for the "Starting repository: stellargraph/stellargraph" loading screen to switch to a Jupyter environment
+   
+   2. For the release tag:
+      - Find the [specific release version](https://readthedocs.org/projects/stellargraph/versions/) of documentation just build on readthedocs (eg: `v1.0.0`, not the `stable` or `latest` version).
+      - Navigate to any demo notebook in this documentation
+      - Click the "launch binder" button
+      - Wait for the "Starting repository: stellargraph/stellargraph" loading screen to switch to a Jupyter environment     
 
 ## More Information
 

--- a/RELEASE_PROCEDURE.md
+++ b/RELEASE_PROCEDURE.md
@@ -149,12 +149,12 @@
       - Find [any demo notebook](https://github.com/stellargraph/stellargraph/blob/master/demos/basics/loading-pandas.ipynb) on the `master` branch
       - Click [the "launch binder" button](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/basics/loading-pandas.ipynb) (or just click this link)
       - Wait for the "Starting repository: stellargraph/stellargraph" loading screen to switch to a Jupyter environment
-   
+
    2. For the release tag:
       - Find the [specific release version](https://readthedocs.org/projects/stellargraph/versions/) of documentation just built on readthedocs (eg: `v1.0.0`, not the `stable` or `latest` version).
       - Navigate to any demo notebook in this documentation
       - Click the "launch binder" button
-      - Wait for the "Starting repository: stellargraph/stellargraph" loading screen to switch to a Jupyter environment     
+      - Wait for the "Starting repository: stellargraph/stellargraph" loading screen to switch to a Jupyter environment
 
 ## More Information
 

--- a/RELEASE_PROCEDURE.md
+++ b/RELEASE_PROCEDURE.md
@@ -141,13 +141,19 @@
      ```
    - Turn branch protection back on.
 
-7. **Prompt Binder to generate the docker image**
+7. **Prompt Binder to generate the docker images**
 
-   [Binder](https://mybinder.org) uses a docker image to package up the state of a repository. It takes a long time to build, and is only built lazily, for the first user to click one of our "launch binder" buttons. It is your job to do this:
+    [Binder](https://mybinder.org) uses a docker image to package up the state of a repository. It takes a long time to build, and is only built lazily, for the first user to click one of our "launch binder" buttons. It is your job to do this:
 
-   - Find [any demo notebook](https://github.com/stellargraph/stellargraph/blob/master/demos/basics/loading-pandas.ipynb) on the `master` branch
-   - Click [the "launch binder" button](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/basics/loading-pandas.ipynb) (or just click this link)
-   - Wait for the "Starting repository: stellargraph/stellargraph" loading screen to switch to a Jupyter environment
+   1. for the `master` branch:
+     - Find [any demo notebook](https://github.com/stellargraph/stellargraph/blob/master/demos/basics/loading-pandas.ipynb) on the `master` branch
+     - Click [the "launch binder" button](https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/demos/basics/loading-pandas.ipynb) (or just click this link)
+     - Wait for the "Starting repository: stellargraph/stellargraph" loading screen to switch to a Jupyter environment
+   2. for the release tag:
+     - Find the [specific release version](https://readthedocs.org/projects/stellargraph/versions/) of documentation just build on readthedocs (eg: `v1.0.0`, not the `stable` or `latest` version).
+     - Navigate to any demo notebook in this documentation
+     - Click the "launch binder" button
+     - Wait for the "Starting repository: stellargraph/stellargraph" loading screen to switch to a Jupyter environment     
 
 ## More Information
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -206,20 +206,14 @@ nbsphinx_prolog = r"""
     <div class="admonition info">
       <p>
         Execute this notebook:
-        <a href="https://mybinder.org/v2/gh/stellargraph/stellargraph/{{ env.config.release|e }}?urlpath=lab/tree/{{ env.docname }}.ipynb" alt="Open In Binder"><img src="https://mybinder.org/badge_logo.svg"/></a>
-        <a href="https://colab.research.google.com/github/stellargraph/stellargraph/blob/{{ env.config.release|e }}/{{ env.docname }}.ipynb" alt="Open In Colab"><img src="https://colab.research.google.com/assets/colab-badge.svg"/></a>
-        <a href="{{ env.docname.rsplit('/', 1).pop() }}.ipynb" class="btn">Download locally</a>
-        {{ docname }}
-        <br>
-        {{ env.commit }}
-        <br>
-        {{ env.config.release|e }}
-        <br>
-        {{ env.config.html_context }}
-        <br>
-        {% if check_meta and 'github_url' in meta %}
-        <a href="https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/{{ theme_vcs_pageview_mode|default("blob") }}/{{ github_version }}{{ conf_py_path }}{{ pagename }}{{ suffix }}" class="fa fa-github"> {{ _('Edit on GitHub') }}</a>
+        {% if env.config.html_context.github_version % }
+          <a href="https://mybinder.org/v2/gh/stellargraph/stellargraph/{{ env.config.html_context.github_version }}?urlpath=lab/tree/{{ env.docname }}.ipynb" alt="Open In Binder"><img src="https://mybinder.org/badge_logo.svg"/></a>
+        <a href="https://colab.research.google.com/github/stellargraph/stellargraph/blob/{{ env.config.html_context.github_version }}/{{ env.docname }}.ipynb" alt="Open In Colab"><img src="https://colab.research.google.com/assets/colab-badge.svg"/></a>
+        {% else %}
+          <a href="https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/{{ env.docname }}.ipynb" alt="Open In Binder"><img src="https://mybinder.org/badge_logo.svg"/></a>
+          <a href="https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/{{ env.docname }}.ipynb" alt="Open In Colab"><img src="https://colab.research.google.com/assets/colab-badge.svg"/></a>
         {% endif %}
+        <a href="{{ env.docname.rsplit('/', 1).pop() }}.ipynb" class="btn">Download locally</a>
       </p>
     </div>
 """

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -204,9 +204,9 @@ texinfo_documents = [
 # https://github.com/readthedocs/readthedocs.org/blob/master/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
 nbsphinx_prolog = r"""
 {% if env.config.html_context.github_version is defined and env.config.html_context.current_version != "stable" %}
-    {% set github_version = env.config.html_context.github_version %}
+    {% set git_revision = env.config.html_context.github_version %}
 {% else %}
-    {% set github_version = "master" %}
+    {% set git_revision = "master" %}
 {% endif %}
 
 .. raw:: html
@@ -214,8 +214,8 @@ nbsphinx_prolog = r"""
     <div class="admonition info">
       <p>
         Execute this notebook:
-        <a href="https://mybinder.org/v2/gh/stellargraph/stellargraph/{{ github_version }}?urlpath=lab/tree/{{ env.docname }}.ipynb" alt="Open In Binder"><img src="https://mybinder.org/badge_logo.svg"/></a>
-        <a href="https://colab.research.google.com/github/stellargraph/stellargraph/blob/{{ github_version }}/{{ env.docname }}.ipynb" alt="Open In Colab"><img src="https://colab.research.google.com/assets/colab-badge.svg"/></a>
+        <a href="https://mybinder.org/v2/gh/stellargraph/stellargraph/{{ git_revision }}?urlpath=lab/tree/{{ env.docname }}.ipynb" alt="Open In Binder"><img src="https://mybinder.org/badge_logo.svg"/></a>
+        <a href="https://colab.research.google.com/github/stellargraph/stellargraph/blob/{{ git_revision }}/{{ env.docname }}.ipynb" alt="Open In Colab"><img src="https://colab.research.google.com/assets/colab-badge.svg"/></a>
         <a href="{{ env.docname.rsplit('/', 1).pop() }}.ipynb" class="btn">Download locally</a>
       </p>
     </div>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -196,8 +196,6 @@ texinfo_documents = [
     ),
 ]
 
-tim = "test"
-
 # -- Extension configuration -------------------------------------------------
 
 # This is processed by Jinja2 and inserted before each notebook
@@ -213,7 +211,15 @@ nbsphinx_prolog = r"""
         <a href="{{ env.docname.rsplit('/', 1).pop() }}.ipynb" class="btn">Download locally</a>
         {{ docname }}
         <br>
+        {{ git }}
+        <br>
+        {{ commit }}
+        <br>
         {{ env.config.release|e }}
+        <br>
+        {% if check_meta and 'github_url' in meta %}
+        <a href="https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/{{ theme_vcs_pageview_mode|default("blob") }}/{{ github_version }}{{ conf_py_path }}{{ pagename }}{{ suffix }}" class="fa fa-github"> {{ _('Edit on GitHub') }}</a>
+        {% endif %}
       </p>
     </div>
 """

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -211,9 +211,7 @@ nbsphinx_prolog = r"""
         <a href="{{ env.docname.rsplit('/', 1).pop() }}.ipynb" class="btn">Download locally</a>
         {{ docname }}
         <br>
-        {{ git }}
-        <br>
-        {{ commit }}
+        {{ env.commit }}
         <br>
         {{ env.config.release|e }}
         <br>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -212,7 +212,8 @@ nbsphinx_prolog = r"""
         <a href="https://colab.research.google.com/github/stellargraph/stellargraph/blob/{{ env.config.release|e }}/{{ env.docname }}.ipynb" alt="Open In Colab"><img src="https://colab.research.google.com/assets/colab-badge.svg"/></a>
         <a href="{{ env.docname.rsplit('/', 1).pop() }}.ipynb" class="btn">Download locally</a>
         {{ docname }}
-        {{ env.config.tim }}
+        <br>
+        {{ env.config.release|e }}
       </p>
     </div>
 """

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -215,7 +215,9 @@ nbsphinx_prolog = r"""
         <br>
         {{ env.config.release|e }}
         <br>
-        {{ env.config.context.using_theme }}
+        {{ readthedocs.v1.vcs.type }}
+        <br>
+        {{ env.project.using_theme }}
         <br>
         {% if check_meta and 'github_url' in meta %}
         <a href="https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/{{ theme_vcs_pageview_mode|default("blob") }}/{{ github_version }}{{ conf_py_path }}{{ pagename }}{{ suffix }}" class="fa fa-github"> {{ _('Edit on GitHub') }}</a>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -199,10 +199,11 @@ texinfo_documents = [
 # -- Extension configuration -------------------------------------------------
 
 # This is processed by Jinja2 and inserted before each notebook
-# Uses an internal readthedocs variable to get the git commit if available - note that this is undocumented and
-# don't match those listed for future at https://docs.readthedocs.io/en/stable/development/design/theme-context.html
+# We use internal readthedocs variables to get the git version if available. Note that this is undocumented, however it
+# is shown in our readthedocs build logs, and is generated from a template:
+# https://github.com/readthedocs/readthedocs.org/blob/master/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
 nbsphinx_prolog = r"""
-{% if env.config.html_context.github_version is defined and env.config.release != "master" %}
+{% if env.config.html_context.github_version is defined and env.config.html_context.current_version != "stable" %}
     {% set github_version = env.config.html_context.github_version %}
 {% else %}
     {% set github_version = "master" %}
@@ -216,12 +217,6 @@ nbsphinx_prolog = r"""
         <a href="https://mybinder.org/v2/gh/stellargraph/stellargraph/{{ github_version }}?urlpath=lab/tree/{{ env.docname }}.ipynb" alt="Open In Binder"><img src="https://mybinder.org/badge_logo.svg"/></a>
         <a href="https://colab.research.google.com/github/stellargraph/stellargraph/blob/{{ github_version }}/{{ env.docname }}.ipynb" alt="Open In Colab"><img src="https://colab.research.google.com/assets/colab-badge.svg"/></a>
         <a href="{{ env.docname.rsplit('/', 1).pop() }}.ipynb" class="btn">Download locally</a>
-        <br>
-        Github version: {{ env.config.html_context.github_version }}
-        <br>
-        Release: {{ env.config.release }} 
-        <br>
-        Current version: {{ env.config.html_context.current_version }}
       </p>
     </div>
 """

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -215,6 +215,8 @@ nbsphinx_prolog = r"""
         <br>
         {{ env.config.release|e }}
         <br>
+        {{ env.config.context.using_theme }}
+        <br>
         {% if check_meta and 'github_url' in meta %}
         <a href="https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/{{ theme_vcs_pageview_mode|default("blob") }}/{{ github_version }}{{ conf_py_path }}{{ pagename }}{{ suffix }}" class="fa fa-github"> {{ _('Edit on GitHub') }}</a>
         {% endif %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -215,9 +215,7 @@ nbsphinx_prolog = r"""
         <br>
         {{ env.config.release|e }}
         <br>
-        {{ readthedocs.v1.vcs.type }}
-        <br>
-        {{ env.project.using_theme }}
+        {{ env.config.html_context.readthedocs.v1.vcs.type }}
         <br>
         {% if check_meta and 'github_url' in meta %}
         <a href="https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/{{ theme_vcs_pageview_mode|default("blob") }}/{{ github_version }}{{ conf_py_path }}{{ pagename }}{{ suffix }}" class="fa fa-github"> {{ _('Edit on GitHub') }}</a>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -216,6 +216,12 @@ nbsphinx_prolog = r"""
         <a href="https://mybinder.org/v2/gh/stellargraph/stellargraph/{{ github_version }}?urlpath=lab/tree/{{ env.docname }}.ipynb" alt="Open In Binder"><img src="https://mybinder.org/badge_logo.svg"/></a>
         <a href="https://colab.research.google.com/github/stellargraph/stellargraph/blob/{{ github_version }}/{{ env.docname }}.ipynb" alt="Open In Colab"><img src="https://colab.research.google.com/assets/colab-badge.svg"/></a>
         <a href="{{ env.docname.rsplit('/', 1).pop() }}.ipynb" class="btn">Download locally</a>
+        <br>
+        Github version: {{ env.config.html_context.github_version }}
+        <br>
+        Release: {{ env.config.release }} 
+        <br>
+        Current version: {{ env.config.html_context.current_version }}
       </p>
     </div>
 """

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -213,7 +213,7 @@ nbsphinx_prolog = r"""
 
     <div class="admonition info">
       <p>
-        Execute this notebook: 
+        Execute this notebook:
         <a href="https://mybinder.org/v2/gh/stellargraph/stellargraph/{{ github_version }}?urlpath=lab/tree/{{ env.docname }}.ipynb" alt="Open In Binder"><img src="https://mybinder.org/badge_logo.svg"/></a>
         <a href="https://colab.research.google.com/github/stellargraph/stellargraph/blob/{{ github_version }}/{{ env.docname }}.ipynb" alt="Open In Colab"><img src="https://colab.research.google.com/assets/colab-badge.svg"/></a>
         <a href="{{ env.docname.rsplit('/', 1).pop() }}.ipynb" class="btn">Download locally</a>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -199,20 +199,22 @@ texinfo_documents = [
 # -- Extension configuration -------------------------------------------------
 
 # This is processed by Jinja2 and inserted before each notebook
+# Uses an internal readthedocs variable to get the git commit if available - note that this is undocumented and
+# don't match those listed for future at https://docs.readthedocs.io/en/stable/development/design/theme-context.html
 nbsphinx_prolog = r"""
-{% set docname = env.doc2path(env.docname, base=None) %}
+{% if env.config.html_context.github_version is defined and env.config.release != "master" %}
+    {% set github_version = env.config.html_context.github_version %}
+{% else %}
+    {% set github_version = "master" %}
+{% endif %}
+
 .. raw:: html
 
     <div class="admonition info">
       <p>
-        Execute this notebook:
-        {% if env.config.html_context.github_version is defined and env.config.release != "master" %}
-          <a href="https://mybinder.org/v2/gh/stellargraph/stellargraph/{{ env.config.html_context.github_version }}?urlpath=lab/tree/{{ env.docname }}.ipynb" alt="Open In Binder"><img src="https://mybinder.org/badge_logo.svg"/></a>
-        <a href="https://colab.research.google.com/github/stellargraph/stellargraph/blob/{{ env.config.html_context.github_version }}/{{ env.docname }}.ipynb" alt="Open In Colab"><img src="https://colab.research.google.com/assets/colab-badge.svg"/></a>
-        {% else %}
-          <a href="https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/{{ env.docname }}.ipynb" alt="Open In Binder"><img src="https://mybinder.org/badge_logo.svg"/></a>
-          <a href="https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/{{ env.docname }}.ipynb" alt="Open In Colab"><img src="https://colab.research.google.com/assets/colab-badge.svg"/></a>
-        {% endif %}
+        Execute this notebook: 
+        <a href="https://mybinder.org/v2/gh/stellargraph/stellargraph/{{ github_version }}?urlpath=lab/tree/{{ env.docname }}.ipynb" alt="Open In Binder"><img src="https://mybinder.org/badge_logo.svg"/></a>
+        <a href="https://colab.research.google.com/github/stellargraph/stellargraph/blob/{{ github_version }}/{{ env.docname }}.ipynb" alt="Open In Colab"><img src="https://colab.research.google.com/assets/colab-badge.svg"/></a>
         <a href="{{ env.docname.rsplit('/', 1).pop() }}.ipynb" class="btn">Download locally</a>
       </p>
     </div>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -206,7 +206,7 @@ nbsphinx_prolog = r"""
     <div class="admonition info">
       <p>
         Execute this notebook:
-        {% if env.config.html_context.github_version is defined %}
+        {% if env.config.html_context.github_version is defined and env.config.release != "master" %}
           <a href="https://mybinder.org/v2/gh/stellargraph/stellargraph/{{ env.config.html_context.github_version }}?urlpath=lab/tree/{{ env.docname }}.ipynb" alt="Open In Binder"><img src="https://mybinder.org/badge_logo.svg"/></a>
         <a href="https://colab.research.google.com/github/stellargraph/stellargraph/blob/{{ env.config.html_context.github_version }}/{{ env.docname }}.ipynb" alt="Open In Colab"><img src="https://colab.research.google.com/assets/colab-badge.svg"/></a>
         {% else %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -206,7 +206,7 @@ nbsphinx_prolog = r"""
     <div class="admonition info">
       <p>
         Execute this notebook:
-        {% if env.config.html_context.github_version % }
+        {% if env.config.html_context.github_version is defined% }
           <a href="https://mybinder.org/v2/gh/stellargraph/stellargraph/{{ env.config.html_context.github_version }}?urlpath=lab/tree/{{ env.docname }}.ipynb" alt="Open In Binder"><img src="https://mybinder.org/badge_logo.svg"/></a>
         <a href="https://colab.research.google.com/github/stellargraph/stellargraph/blob/{{ env.config.html_context.github_version }}/{{ env.docname }}.ipynb" alt="Open In Colab"><img src="https://colab.research.google.com/assets/colab-badge.svg"/></a>
         {% else %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -206,8 +206,8 @@ nbsphinx_prolog = r"""
     <div class="admonition info">
       <p>
         Execute this notebook:
-        <a href="https://mybinder.org/v2/gh/stellargraph/stellargraph/master?urlpath=lab/tree/{{ env.docname }}.ipynb" alt="Open In Binder"><img src="https://mybinder.org/badge_logo.svg"/></a>
-        <a href="https://colab.research.google.com/github/stellargraph/stellargraph/blob/master/{{ env.docname }}.ipynb" alt="Open In Colab"><img src="https://colab.research.google.com/assets/colab-badge.svg"/></a>
+        <a href="https://mybinder.org/v2/gh/stellargraph/stellargraph/{{ env.config.release|e }}?urlpath=lab/tree/{{ env.docname }}.ipynb" alt="Open In Binder"><img src="https://mybinder.org/badge_logo.svg"/></a>
+        <a href="https://colab.research.google.com/github/stellargraph/stellargraph/blob/{{ env.config.release|e }}/{{ env.docname }}.ipynb" alt="Open In Colab"><img src="https://colab.research.google.com/assets/colab-badge.svg"/></a>
         <a href="{{ env.docname.rsplit('/', 1).pop() }}.ipynb" class="btn">Download locally</a>
       </p>
     </div>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -206,7 +206,7 @@ nbsphinx_prolog = r"""
     <div class="admonition info">
       <p>
         Execute this notebook:
-        {% if env.config.html_context.github_version is defined% }
+        {% if env.config.html_context.github_version is defined %}
           <a href="https://mybinder.org/v2/gh/stellargraph/stellargraph/{{ env.config.html_context.github_version }}?urlpath=lab/tree/{{ env.docname }}.ipynb" alt="Open In Binder"><img src="https://mybinder.org/badge_logo.svg"/></a>
         <a href="https://colab.research.google.com/github/stellargraph/stellargraph/blob/{{ env.config.html_context.github_version }}/{{ env.docname }}.ipynb" alt="Open In Colab"><img src="https://colab.research.google.com/assets/colab-badge.svg"/></a>
         {% else %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -215,7 +215,7 @@ nbsphinx_prolog = r"""
         <br>
         {{ env.config.release|e }}
         <br>
-        {{ env.config.html_context.readthedocs.v1.vcs.type }}
+        {{ env.config.html_context }}
         <br>
         {% if check_meta and 'github_url' in meta %}
         <a href="https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/{{ theme_vcs_pageview_mode|default("blob") }}/{{ github_version }}{{ conf_py_path }}{{ pagename }}{{ suffix }}" class="fa fa-github"> {{ _('Edit on GitHub') }}</a>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -196,11 +196,13 @@ texinfo_documents = [
     ),
 ]
 
+tim = "test"
 
 # -- Extension configuration -------------------------------------------------
 
 # This is processed by Jinja2 and inserted before each notebook
 nbsphinx_prolog = r"""
+{% set docname = env.doc2path(env.docname, base=None) %}
 .. raw:: html
 
     <div class="admonition info">
@@ -209,6 +211,8 @@ nbsphinx_prolog = r"""
         <a href="https://mybinder.org/v2/gh/stellargraph/stellargraph/{{ env.config.release|e }}?urlpath=lab/tree/{{ env.docname }}.ipynb" alt="Open In Binder"><img src="https://mybinder.org/badge_logo.svg"/></a>
         <a href="https://colab.research.google.com/github/stellargraph/stellargraph/blob/{{ env.config.release|e }}/{{ env.docname }}.ipynb" alt="Open In Colab"><img src="https://colab.research.google.com/assets/colab-badge.svg"/></a>
         <a href="{{ env.docname.rsplit('/', 1).pop() }}.ipynb" class="btn">Download locally</a>
+        {{ docname }}
+        {{ env.config.tim }}
       </p>
     </div>
 """


### PR DESCRIPTION
See #1538 - Our google colab and binder links inside readthedocs demo notebooks don't currently work on PR's, and when they do work for 'stable', 'latest' and release versions, always point to master.

This PR gets the git commit from readthedocs internal variables and uses that to link to the actual commit.  Readthedocs sets a variable `github_version` that gives:
* commit hash for PR's and 'stable' (eg: https://readthedocs.org/projects/stellargraph/builds/10970680/)
* develop for 'latest'. (eg: https://readthedocs.org/projects/stellargraph/builds/11012887/)
* the tag for specific release versions (eg: https://readthedocs.org/projects/stellargraph/builds/10970681/)

If rendering outside readthedocs (eg a local sphinx build), or for 'stable', we substitute this with 'master'.

All builds on readthedocs should now point to the correct demo notebooks for colab or binder.






