### PR TITLE
Remove unused "nodes_from_edges" computation

### DIFF
--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -319,10 +319,6 @@ class StellarGraph:
             nodes=self._nodes,
         )
 
-        nodes_from_edges = pd.unique(
-            np.concatenate([self._edges.targets, self._edges.sources])
-        )
-
     @staticmethod
     def _infer_nodes_from_edges(edges, source_column, target_column):
         # `convert_edges` nicely flags any errors in edges; inference here is lax rather than duplicate that


### PR DESCRIPTION
This was left over from earlier refactoring. It's no longer used and so is just wasted time and peak memory.



According the microbenchmarks and notebook in #1547, this has no effect on the memory of the final `StellarGraph` object but does change the peak memory usage and the time required:

The `test_allocation_benchmark_creation_peak[None-None-1000-5000]` benchmark goes from 181486 bytes to 84357 (-54%), while the equivalent long-term usage one (`test_allocation_benchmark_creation[None-None-1000-5000]`) remains unchanged. The `test_benchmark_creation[None-None-20000-100000]` time benchmark goes from 6.96ms to 5.88 (1.2&times; speedup), although there's more noise on this one.

| dataset | nodes? | time before (s) | time after (s) | speedup | peak before (MB) | peak after (MB) | change (MB) |
|---|---|---|---|---|---|---|---|
| Cora | inferred | 0.00309 | 0.00290 | 1.07&times; | 0.374 | 0.251 | -0.123 (-33%)
| BlogCatalog3 | explicit | 0.0323 | 0.0228 | 1.4× | 21.8 | 17.0 | -4.8 (-22%) |
| FB15k (no edge types) | explicit | 0.132 | 0.105 | 1.3× | 33.2 | 25.8 | -7.8 (-22%) |
| reddit | inferred | 0.663 | 0.471 | 1.4× | 622 | 375 | -247 (-40%) |

The memory reductions seem to be fairly proportional to the size of the now-removed `pd.concatenate([source, target])` array, e.g. Cora array 87KB, BlogCatalog3 array 5.6MB, FB15k (no edge types) array 9.5MB, reddit array 190MB.