### PR TITLE
Split StellarGraph benchmarks into creation and adj list ones

### DIFF
--- a/stellargraph/core/element_data.py
+++ b/stellargraph/core/element_data.py
@@ -335,6 +335,9 @@ class EdgeData(ElementData):
         self._empty_ilocs = np.array([], dtype=np.uint8)
 
     def _init_directed_adj_lists(self):
+        self._edges_in_dict, self._edges_out_dict = self._create_directed_adj_lists()
+
+    def _create_directed_adj_lists(self):
         # record the edge ilocs of incoming, outgoing and both-direction edges
         in_dict = {}
         out_dict = {}
@@ -344,10 +347,12 @@ class EdgeData(ElementData):
             out_dict.setdefault(src, []).append(i)
 
         dtype = np.min_scalar_type(len(self.sources))
-        self._edges_in_dict = _numpyise(in_dict, dtype=dtype)
-        self._edges_out_dict = _numpyise(out_dict, dtype=dtype)
+        return _numpyise(in_dict, dtype=dtype), _numpyise(out_dict, dtype=dtype)
 
     def _init_undirected_adj_lists(self):
+        self._edges_dict = self._create_undirected_adj_lists()
+
+    def _create_undirected_adj_lists(self):
         # record the edge ilocs of incoming, outgoing and both-direction edges
         undirected = {}
 
@@ -357,7 +362,7 @@ class EdgeData(ElementData):
                 undirected.setdefault(src, []).append(i)
 
         dtype = np.min_scalar_type(len(self.sources))
-        self._edges_dict = _numpyise(undirected, dtype=dtype)
+        return _numpyise(undirected, dtype=dtype)
 
     def _adj_lookup(self, *, ins, outs):
         if ins and outs:

--- a/tests/core/test_graph.py
+++ b/tests/core/test_graph.py
@@ -755,6 +755,15 @@ def test_benchmark_get_features(
     benchmark(f)
 
 
+
+def _run_creation_benchmark(benchmarker, feature_size, num_nodes, num_edges, force_adj_lists):
+    nodes, edges = example_benchmark_graph(feature_size=feature_size, n_nodes=num_nodes, n_edges=num_edges)
+
+    def f():
+        return StellarGraph(nodes=nodes, edges=edges)
+
+    benchmarker(f)
+
 @pytest.mark.benchmark(group="StellarGraph creation (time)")
 # various element counts, to give an indication of the relationship
 # between those and memory use (0,0 gives the overhead of the
@@ -762,84 +771,74 @@ def test_benchmark_get_features(
 @pytest.mark.parametrize("num_nodes,num_edges", [(0, 0), (1000, 5000), (20000, 100000)])
 # features or not, to capture their cost
 @pytest.mark.parametrize("feature_size", [None, 100])
-@pytest.mark.parametrize("force_adj_lists", [None, "directed", "undirected", "both"])
 def test_benchmark_creation(
-    benchmark, feature_size, num_nodes, num_edges, force_adj_lists
+    benchmark, feature_size, num_nodes, num_edges
 ):
-    nodes, edges = example_benchmark_graph(
-        feature_size, num_nodes, num_edges, features_in_nodes=True
-    )
-
-    def f():
-        sg = StellarGraph(nodes=nodes, edges=edges)
-        if force_adj_lists == "directed":
-            sg._edges._init_directed_adj_lists()
-        elif force_adj_lists == "undirected":
-            sg._edges._init_undirected_adj_lists()
-        elif force_adj_lists == "both":
-            sg._edges._init_undirected_adj_lists()
-            sg._edges._init_directed_adj_lists()
-        return sg
-
-    benchmark(f)
+    _run_creation_benchmark(benchmark, feature_size, num_nodes, num_edges)
 
 
 @pytest.mark.benchmark(group="StellarGraph creation (size)", timer=snapshot)
-# various element counts, to give an indication of the relationship
-# between those and memory use (0,0 gives the overhead of the
-# StellarGraph object itself, without any data)
 @pytest.mark.parametrize("num_nodes,num_edges", [(0, 0), (100, 200), (1000, 5000)])
-# features or not, to capture their cost
 @pytest.mark.parametrize("feature_size", [None, 100])
-@pytest.mark.parametrize("force_adj_lists", [None, "directed", "undirected", "both"])
 def test_allocation_benchmark_creation(
-    allocation_benchmark, feature_size, num_nodes, num_edges, force_adj_lists
+    allocation_benchmark, feature_size, num_nodes, num_edges
 ):
-    nodes, edges = example_benchmark_graph(
-        feature_size, num_nodes, num_edges, features_in_nodes=True
-    )
-
-    def f():
-        sg = StellarGraph(nodes=nodes, edges=edges)
-        if force_adj_lists == "directed":
-            sg._edges._init_directed_adj_lists()
-        elif force_adj_lists == "undirected":
-            sg._edges._init_undirected_adj_lists()
-        elif force_adj_lists == "both":
-            sg._edges._init_undirected_adj_lists()
-            sg._edges._init_directed_adj_lists()
-        return sg
-
-    allocation_benchmark(f)
+    _run_creation_benchmark(allocation_benchmark, feature_size, num_nodes, num_edges)
 
 
 @pytest.mark.benchmark(group="StellarGraph creation (peak)", timer=peak)
-# various element counts, to give an indication of the relationship
-# between those and memory use (0,0 gives the overhead of the
-# StellarGraph object itself, without any data)
 @pytest.mark.parametrize("num_nodes,num_edges", [(0, 0), (100, 200), (1000, 5000)])
-# features or not, to capture their cost
 @pytest.mark.parametrize("feature_size", [None, 100])
-@pytest.mark.parametrize("force_adj_lists", [None, "directed", "undirected", "both"])
 def test_allocation_benchmark_creation_peak(
-    allocation_benchmark, feature_size, num_nodes, num_edges, force_adj_lists
+    allocation_benchmark, feature_size, num_nodes, num_edges
 ):
-    nodes, edges = example_benchmark_graph(
-        feature_size, num_nodes, num_edges, features_in_nodes=True
-    )
+    _run_creation_benchmark(allocation_benchmark, feature_size, num_nodes, num_edges)
 
-    def f():
-        sg = StellarGraph(nodes=nodes, edges=edges)
+
+def _run_adj_list_benchmark(benchmarker, num_nodes, num_edges, force_adj_lists):
+    nodes, edges = example_benchmark_graph(n_nodes=num_nodes, n_edges=num_edges)
+
+    def setup():
+        return (StellarGraph(nodes=nodes, edges=edges),), {}
+
+    def f(sg):
         if force_adj_lists == "directed":
-            sg._edges._init_directed_adj_lists()
-        elif force_adj_lists == "undirected":
             sg._edges._init_undirected_adj_lists()
+        elif force_adj_lists == "undirected":
+            sg._edges._init_directed_adj_lists()
         elif force_adj_lists == "both":
             sg._edges._init_undirected_adj_lists()
             sg._edges._init_directed_adj_lists()
         return sg
 
-    allocation_benchmark(f)
+    benchmarker(f, setup=setup)
+
+@pytest.mark.benchmark(group="StellarGraph adjacency lists (time)")
+@pytest.mark.parametrize("num_nodes,num_edges", [(100, 200), (1000, 5000), (20000, 100000)])
+@pytest.mark.parametrize("force_adj_lists", ["directed", "undirected"])
+def test_benchmark_adj_list(
+    benchmark, num_nodes, num_edges, force_adj_lists
+):
+    def benchmarker(f, setup):
+        benchmark.pedantic(f, setup=setup, iterations=1, rounds=10, warmup_rounds=3)
+
+    _run_adj_list_benchmark(benchmarker, num_nodes, num_edges, force_adj_lists)
+
+@pytest.mark.benchmark(group="StellarGraph adjacency lists (size)", timer=snapshot)
+@pytest.mark.parametrize("num_nodes,num_edges", [(100, 200), (1000, 5000)])
+@pytest.mark.parametrize("force_adj_lists", ["directed", "undirected"])
+def test_allocation_benchmark_adj_list(
+    allocation_benchmark, num_nodes, num_edges, force_adj_lists
+): 
+    _run_adj_list_benchmark(allocation_benchmark, num_nodes, num_edges, force_adj_lists)
+
+@pytest.mark.benchmark(group="StellarGraph adjacency lists (peak)", timer=peak) 
+@pytest.mark.parametrize("num_nodes,num_edges", [(100, 200), (1000, 5000)])
+@pytest.mark.parametrize("force_adj_lists", ["directed", "undirected"])
+def test_allocation_benchmark_adj_list_peak( 
+    allocation_benchmark, num_nodes, num_edges, force_adj_lists
+): 
+    _run_adj_list_benchmark(allocation_benchmark, num_nodes, num_edges, force_adj_lists)
 
 
 def example_weighted_hin(is_directed=True):

--- a/tests/test_utils/alloc.py
+++ b/tests/test_utils/alloc.py
@@ -95,8 +95,8 @@ def allocation_benchmark(request, benchmark):
     # and the "times" aren't actually times.
     benchmark.extra_info["allocation_benchmark"] = True
 
-    def run_it(f):
-        result = benchmark.pedantic(f, iterations=1, rounds=20, warmup_rounds=3)
+    def run_it(f, setup=None):
+        result = benchmark.pedantic(f, setup=setup, iterations=1, rounds=20, warmup_rounds=3)
         if result is None and timer is snapshot:
             raise ValueError(
                 "benchmark function returned None: allocation benchmarking with 'snapshot' is only reliable if the object(s) of interest is created inside and returned from the function being benchmarked"

--- a/tests/test_utils/alloc.py
+++ b/tests/test_utils/alloc.py
@@ -95,8 +95,8 @@ def allocation_benchmark(request, benchmark):
     # and the "times" aren't actually times.
     benchmark.extra_info["allocation_benchmark"] = True
 
-    def run_it(f, setup=None):
-        result = benchmark.pedantic(f, setup=setup, iterations=1, rounds=20, warmup_rounds=3)
+    def run_it(f):
+        result = benchmark.pedantic(f, iterations=1, rounds=20, warmup_rounds=3)
         if result is None and timer is snapshot:
             raise ValueError(
                 "benchmark function returned None: allocation benchmarking with 'snapshot' is only reliable if the object(s) of interest is created inside and returned from the function being benchmarked"


### PR DESCRIPTION
This splits up the `StellarGraph` creation benchmarks into two sets of new benchmarks:

- creation: measures metrics for only the creation of a `StellarGraph`, without any adjacency lists
- adjacency lists: measures metrics for only the creation of the adjacency lists, ignoring the cost of the main `StellarGraph` object (by splitting adjacency list creation into a "create" function that returns the adjacency lists, and then calling that for assignment in a separate function)

This has several benefits:

- The adjacency list benchmarks show the actual cost of the individual adjacency list components. This means there's no need to have `both` independent of `directed` and `undirected`: `both` is now just `directed` + `undirected` (except for the peak memory usage, but I think that's ok).
- We can do fewer pointless things like measure the cost of adjacency lists on an empty graph, and measure the cost of adjacency lists with or without node features. (This is a long term benefit too, e.g. #1556 adds more parameters that only affect creation, and so only need to increase the number of creation benchmarks we run.)
- We run fewer tests overall, and they run faster.
  - Previously we ran each of time, memory and peak-memory benchmarks 24 sets of parameters (3 `num_nodes,num_edges` * 2 `feature_size` * 4 `force_adj_lists`), taking ~55s.
  - Now this runs each with 12 sets (3 `num_nodes,num_edges` * 2 `feature_size` for creation, plus 3 `num_nodes,num_edges` * 2 `force_adj_lists`), taking ~25s.

Current results of the new benchmarks:

```
---------------------------------------------------------------------------------------------- benchmark 'StellarGraph adjacency lists (peak)': 4 tests ----------------------------------------------------------------------------------------------
Name (time in s)                                                           Min                     Max                    Mean              StdDev                  Median               IQR            Outliers     OPS            Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_allocation_benchmark_adj_list_peak[directed-100-200]          28,357.0000 (1.0)       28,663.0000 (1.0)       28,498.3000 (1.0)       78.7007 (1.19)      28,525.0000 (1.0)      0.0000 (1.0)           5;5  0.0000 (1.0)          20           1
test_allocation_benchmark_adj_list_peak[undirected-100-200]        47,156.0000 (1.66)      47,559.0000 (1.66)      47,327.3500 (1.66)      66.1834 (1.0)       47,324.0000 (1.66)     0.0000 (1.0)           2;2  0.0000 (0.60)         20           1
test_allocation_benchmark_adj_list_peak[directed-1000-5000]       511,347.0000 (18.03)    513,851.0000 (17.93)    511,598.2000 (17.95)    534.6591 (8.08)     511,515.0000 (17.93)    0.0000 (1.0)           1;5  0.0000 (0.06)         20           1
test_allocation_benchmark_adj_list_peak[undirected-1000-5000]     767,841.0000 (27.08)    769,295.0000 (26.84)    768,064.9000 (26.95)    291.9556 (4.41)     768,009.0000 (26.92)    0.0000 (1.0)           1;2  0.0000 (0.04)         20           1
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

-------------------------------------------------------------------------------------------- benchmark 'StellarGraph adjacency lists (size)': 4 tests -------------------------------------------------------------------------------------------
Name (time in s)                                                      Min                     Max                    Mean              StdDev                  Median               IQR            Outliers     OPS            Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_allocation_benchmark_adj_list[directed-100-200]          16,819.0000 (1.0)       17,133.0000 (1.0)       16,834.7000 (1.0)       70.2125 (1.10)      16,819.0000 (1.0)      0.0000 (1.0)           1;1  0.0001 (1.0)          20           1
test_allocation_benchmark_adj_list[undirected-100-200]        28,100.0000 (1.67)      28,381.0000 (1.66)      28,117.2500 (1.67)      63.7040 (1.0)       28,100.0000 (1.67)     0.0000 (1.0)           1;2  0.0000 (0.60)         20           1
test_allocation_benchmark_adj_list[directed-1000-5000]       174,552.0000 (10.38)    177,016.0000 (10.33)    174,675.2000 (10.38)    550.9671 (8.65)     174,552.0000 (10.38)    0.0000 (1.0)           1;1  0.0000 (0.10)         20           1
test_allocation_benchmark_adj_list[undirected-1000-5000]     330,442.0000 (19.65)    331,592.0000 (19.35)    330,502.7000 (19.63)    256.7926 (4.03)     330,442.0000 (19.65)    0.0000 (1.0)           1;2  0.0000 (0.05)         20           1
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

---------------------------------------------------------------------------------------------- benchmark 'StellarGraph adjacency lists (time)': 6 tests ---------------------------------------------------------------------------------------------
Name (time in us)                                             Min                     Max                    Mean                 StdDev                  Median                    IQR            Outliers         OPS            Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_benchmark_adj_list[directed-100-200]                218.0180 (1.0)          648.6560 (1.0)          256.3025 (1.0)          46.8476 (1.0)          240.6080 (1.0)          16.6795 (1.0)       193;347  3,901.6402 (1.0)        2348           1
test_benchmark_adj_list[undirected-100-200]              292.6340 (1.34)         981.2630 (1.51)         341.7082 (1.33)         62.2886 (1.33)         324.6060 (1.35)         34.6393 (2.08)      195;215  2,926.4732 (0.75)       2367           1
test_benchmark_adj_list[directed-1000-5000]            4,304.8820 (19.75)      8,303.4690 (12.80)      5,004.7979 (19.53)       551.2970 (11.77)      4,963.8490 (20.63)       369.6533 (22.16)       28;12    199.8083 (0.05)        177           1
test_benchmark_adj_list[undirected-1000-5000]          5,200.1760 (23.85)     66,677.5710 (102.79)     6,434.9782 (25.11)     4,848.7385 (103.50)     5,807.9975 (24.14)       892.3245 (53.50)         1;8    155.4007 (0.04)        160           1
test_benchmark_adj_list[directed-20000-100000]       101,960.4110 (467.67)   179,572.2210 (276.84)   130,404.6673 (508.79)   27,297.1350 (582.68)   124,843.7710 (518.87)   34,023.2100 (>1000.0)       3;0      7.6684 (0.00)         10           1
test_benchmark_adj_list[undirected-20000-100000]     125,579.2560 (576.00)   212,588.5620 (327.74)   165,922.4471 (647.37)   42,058.3978 (897.77)   145,034.7940 (602.78)   81,068.2240 (>1000.0)       3;0      6.0269 (0.00)          7           1
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

------------------------------------------------------------------------------------------------ benchmark 'StellarGraph creation (peak)': 6 tests -------------------------------------------------------------------------------------------------
Name (time in s)                                                     Min                     Max                    Mean                StdDev                  Median                 IQR            Outliers     OPS            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_allocation_benchmark_creation_peak[None-0-0]             9,193.0000 (1.0)       14,897.0000 (1.0)       10,173.0000 (1.0)      2,022.1652 (1.82)       9,193.0000 (1.0)        0.0000 (1.0)           4;4  0.0001 (1.0)          20           1
test_allocation_benchmark_creation_peak[None-100-200]        10,385.0000 (1.13)      15,017.0000 (1.01)      11,368.8500 (1.12)     1,886.5664 (1.70)      10,385.0000 (1.13)     586.0000 (inf)           4;4  0.0001 (0.89)         20           1
test_allocation_benchmark_creation_peak[100-0-0]             12,473.0000 (1.36)      17,129.0000 (1.15)      13,428.5000 (1.32)     1,796.2142 (1.62)      12,497.0000 (1.36)     536.0000 (inf)           4;4  0.0001 (0.76)         20           1
test_allocation_benchmark_creation_peak[100-100-200]         73,481.0000 (7.99)      78,137.0000 (5.25)      73,867.0000 (7.26)     1,164.4412 (1.05)      73,505.0000 (8.00)       0.0000 (1.0)           2;3  0.0000 (0.14)         20           1
test_allocation_benchmark_creation_peak[None-1000-5000]      84,357.0000 (9.18)      88,989.0000 (5.97)      84,692.2000 (8.33)     1,112.1678 (1.0)       84,357.0000 (9.18)       0.0000 (1.0)           2;2  0.0000 (0.12)         20           1
test_allocation_benchmark_creation_peak[100-1000-5000]      703,481.0000 (76.52)    708,137.0000 (47.54)    704,018.6000 (69.20)    1,427.1936 (1.28)     703,505.0000 (76.53)      0.0000 (1.0)           2;4  0.0000 (0.01)         20           1
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--------------------------------------------------------------------------------------------- benchmark 'StellarGraph creation (size)': 6 tests ----------------------------------------------------------------------------------------------
Name (time in s)                                                Min                     Max                    Mean                StdDev                  Median                IQR            Outliers     OPS            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_allocation_benchmark_creation[None-0-0]             6,985.0000 (1.0)        8,193.0000 (1.0)        7,079.0000 (1.0)        271.0059 (1.00)       6,985.0000 (1.0)      84.0000 (inf)           1;1  0.0001 (1.0)          20           1
test_allocation_benchmark_creation[None-100-200]         7,353.0000 (1.05)      13,893.0000 (1.70)       7,680.0000 (1.08)     1,462.3885 (5.41)       7,353.0000 (1.05)      0.0000 (1.0)           1;1  0.0001 (0.92)         20           1
test_allocation_benchmark_creation[100-0-0]              8,081.0000 (1.16)      12,689.0000 (1.55)       8,371.8000 (1.18)     1,051.3559 (3.89)       8,081.0000 (1.16)      0.0000 (1.0)           1;2  0.0001 (0.85)         20           1
test_allocation_benchmark_creation[100-100-200]         46,441.0000 (6.65)      49,873.0000 (6.09)      46,634.2000 (6.59)       762.3533 (2.82)      46,465.0000 (6.65)      0.0000 (1.0)           1;2  0.0000 (0.15)         20           1
test_allocation_benchmark_creation[None-1000-5000]      64,093.0000 (9.18)      66,301.0000 (8.09)      64,203.4000 (9.07)       493.7238 (1.83)      64,093.0000 (9.18)      0.0000 (1.0)           1;1  0.0000 (0.11)         20           1
test_allocation_benchmark_creation[100-1000-5000]      459,581.0000 (65.80)    460,813.0000 (56.24)    459,664.2000 (64.93)      270.4526 (1.0)      459,605.0000 (65.80)     0.0000 (1.0)           1;2  0.0000 (0.02)         20           1
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

------------------------------------------------------------------------------ benchmark 'StellarGraph creation (time)': 6 tests ------------------------------------------------------------------------------
Name (time in ms)                                  Min                Max               Mean            StdDev             Median               IQR            Outliers       OPS            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_benchmark_creation[None-0-0]               2.2361 (1.0)       3.0911 (1.0)       2.4360 (1.0)      0.1136 (1.0)       2.4380 (1.0)      0.1206 (1.0)         77;16  410.5174 (1.0)         333           1
test_benchmark_creation[None-1000-5000]         2.3293 (1.04)      5.0693 (1.64)      2.6583 (1.09)     0.3411 (3.00)      2.5390 (1.04)     0.3101 (2.57)        51;20  376.1843 (0.92)        407           1
test_benchmark_creation[100-0-0]                3.2786 (1.47)      6.3897 (2.07)      3.8240 (1.57)     0.5104 (4.49)      3.6334 (1.49)     0.3201 (2.65)        31;30  261.5097 (0.64)        277           1
test_benchmark_creation[100-1000-5000]          3.5594 (1.59)      7.2669 (2.35)      4.0533 (1.66)     0.3434 (3.02)      3.9731 (1.63)     0.1298 (1.08)        35;44  246.7104 (0.60)        256           1
test_benchmark_creation[None-20000-100000]      3.6114 (1.62)      7.0057 (2.27)      4.2369 (1.74)     0.5953 (5.24)      4.0401 (1.66)     0.5146 (4.27)        26;13  236.0199 (0.57)        186           1
test_benchmark_creation[100-20000-100000]      15.6611 (7.00)     24.0597 (7.78)     18.2645 (7.50)     1.7575 (15.47)    17.7642 (7.29)     1.1253 (9.33)          8;6   54.7510 (0.13)         49           1
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

See: #1557