### PR TITLE
Allow multidimensional features in StellarGraph

### DIFF
--- a/stellargraph/core/element_data.py
+++ b/stellargraph/core/element_data.py
@@ -225,12 +225,12 @@ class NodeData(ElementData):
                     f"features[{key!r}]: expected numpy or scipy array, found {type(data).__name__}"
                 )
 
-            if len(data.shape) != 2:
+            if len(data.shape) < 2:
                 raise ValueError(
-                    f"features[{key!r}]: expected 2 dimensions, found {len(data.shape)}"
+                    f"features[{key!r}]: expected at least 2 dimensions, found {len(data.shape)}"
                 )
 
-            rows, _columns = data.shape
+            rows = data.shape[0]
             expected = len(self._type_element_ilocs[key])
             if rows != expected:
                 raise ValueError(
@@ -280,7 +280,7 @@ class NodeData(ElementData):
              features of that type, and the dtype of the features.
         """
         return {
-            type_name: (type_features.shape[1], type_features.dtype)
+            type_name: (type_features.shape[1:], type_features.dtype)
             for type_name, type_features in self._features.items()
         }
 

--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -1007,12 +1007,41 @@ class StellarGraph:
         """
         Get the feature sizes for the specified node types.
 
+        .. seealso:: :meth:`node_feature_shapes`
+
         Args:
             node_types (list, optional): A list of node types. If None all current node types
                 will be used.
 
         Returns:
             A dictionary of node type and integer feature size.
+        """
+
+        def get(name, shape):
+            if len(shape) != 1:
+                raise ValueError(
+                    f"node_feature_sizes expects node types that have feature vectors (rank 1), found type {name!r} with feature shape {shape}"
+                )
+
+            return shape[0]
+
+        return {
+            name: get(name, shape)
+            for name, shape in self.node_feature_shapes(node_types).items()
+        }
+
+    def node_feature_shapes(self, node_types=None):
+        """
+        Get the feature shapes for the specified node types.
+
+        .. seealso:: :meth:`node_feature_sizes`
+
+        Args:
+            node_types (list, optional): A list of node types. If None all current node types
+                will be used.
+
+        Returns:
+            A dictionary of node type and tuple feature shapes.
         """
         all_sizes = self._nodes.feature_info()
 
@@ -1261,11 +1290,13 @@ class StellarGraph:
             return f"{n1}-{rel}->{n2}"
 
         def str_node_type(count, nt):
-            feature_size, feature_dtype = feature_info[nt]
-            if feature_size > 0:
-                feature_text = f"{feature_dtype.name} vector, length {feature_size}"
-            else:
+            feature_shape, feature_dtype = feature_info[nt]
+            if len(feature_shape) > 1:
+                feature_text = f"{feature_dtype.name} tensor, shape {feature_shape}"
+            elif feature_shape[0] == 0:
                 feature_text = "none"
+            else:
+                feature_text = f"{feature_dtype.name} vector, length {feature_shape[0]}"
 
             edges = gs.schema[nt]
             if edges:

--- a/tests/core/test_graph.py
+++ b/tests/core/test_graph.py
@@ -470,26 +470,24 @@ def test_feature_conversion_from_nodes():
 
 
 def test_node_feature_sizes_shapes():
-    arr1 = RowFrame(np.ones((3, 4)), index=range(3))
-    arr2 = RowFrame(np.ones((5, 6, 7)), index=range(3, 3 + 5))
-    g = StellarGraph({"a": arr1, "b": arr2})
+    g = example_hin_1(feature_sizes={"A": 4, "B": (6, 7)})
 
-    assert g.node_feature_shapes() == {"a": (4,), "b": (6, 7)}
+    assert g.node_feature_shapes() == {"A": (4,), "B": (6, 7)}
     with pytest.raises(
         ValueError,
-        match=r"node_feature_sizes expects node types .* found type 'b' with feature shape \(6, 7\)",
+        match=r"node_feature_sizes expects node types .* found type 'B' with feature shape \(6, 7\)",
     ):
         g.node_feature_sizes()
 
-    assert g.node_feature_shapes(node_types=["a"]) == {"a": (4,)}
-    assert g.node_feature_sizes(node_types=["a"]) == {"a": 4}
+    assert g.node_feature_shapes(node_types=["A"]) == {"A": (4,)}
+    assert g.node_feature_sizes(node_types=["A"]) == {"A": 4}
 
-    assert g.node_feature_shapes(node_types=["b"]) == {"b": (6, 7)}
+    assert g.node_feature_shapes(node_types=["B"]) == {"B": (6, 7)}
     with pytest.raises(
         ValueError,
-        match=r"node_feature_sizes expects node types .* found type 'b' with feature shape \(6, 7\)",
+        match=r"node_feature_sizes expects node types .* found type 'B' with feature shape \(6, 7\)",
     ):
-        g.node_feature_sizes(node_types=["b"])
+        g.node_feature_sizes(node_types=["B"])
 
 
 def test_node_features():

--- a/tests/test_utils/graphs.py
+++ b/tests/test_utils/graphs.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 
-from stellargraph import StellarGraph, StellarDiGraph
+from stellargraph import StellarGraph, StellarDiGraph, RowFrame
 import networkx as nx
 import pandas as pd
 import numpy as np
@@ -65,10 +65,14 @@ def example_graph_nx(
 
 def repeated_features(values_to_repeat, width):
     if width is None:
-        return []
+        return None
 
-    column = np.expand_dims(values_to_repeat, axis=1)
-    return column.repeat(width, axis=1)
+    if isinstance(width, int):
+        width = (width,)
+
+    values = np.asarray(values_to_repeat, dtype=np.float32)
+    column = values.reshape(values.shape + (1,) * len(width))
+    return np.tile(column, width)
 
 
 def example_graph(
@@ -82,7 +86,7 @@ def example_graph(
     nodes = [1, 2, 3, 4]
     features = repeated_features(nodes, feature_size)
 
-    nodes = pd.DataFrame(features, index=nodes)
+    nodes = RowFrame(features, index=nodes)
 
     cls = StellarDiGraph if is_directed else StellarGraph
     return cls(nodes={node_label: nodes}, edges={edge_label: elist})
@@ -115,7 +119,7 @@ def example_hin_1(
 ) -> StellarGraph:
     def features(label, ids):
         if feature_sizes is None:
-            return []
+            return None
         else:
             feature_size = feature_sizes.get(label, 10)
             return repeated_features(ids, feature_size)
@@ -123,12 +127,12 @@ def example_hin_1(
     a_ids = [0, 1, 2, 3]
     if reverse_order:
         a_ids = a_ids[::-1]
-    a = pd.DataFrame(features("A", a_ids), index=a_ids)
+    a = RowFrame(features("A", a_ids), index=a_ids)
 
     b_ids = [4, 5, 6]
     if reverse_order:
         b_ids = b_ids[::-1]
-    b = pd.DataFrame(features("B", b_ids), index=b_ids)
+    b = RowFrame(features("B", b_ids), index=b_ids)
 
     r_edges = [(4, 0), (1, 5), (1, 4), (2, 4), (5, 3)]
     f_edges, f_index = [(4, 5)], [100]

--- a/tests/test_utils/graphs.py
+++ b/tests/test_utils/graphs.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 
-from stellargraph import StellarGraph, StellarDiGraph, RowFrame
+from stellargraph import StellarGraph, StellarDiGraph, IndexedArray
 import networkx as nx
 import pandas as pd
 import numpy as np
@@ -86,7 +86,7 @@ def example_graph(
     nodes = [1, 2, 3, 4]
     features = repeated_features(nodes, feature_size)
 
-    nodes = RowFrame(features, index=nodes)
+    nodes = IndexedArray(features, index=nodes)
 
     cls = StellarDiGraph if is_directed else StellarGraph
     return cls(nodes={node_label: nodes}, edges={edge_label: elist})
@@ -127,12 +127,12 @@ def example_hin_1(
     a_ids = [0, 1, 2, 3]
     if reverse_order:
         a_ids = a_ids[::-1]
-    a = RowFrame(features("A", a_ids), index=a_ids)
+    a = IndexedArray(features("A", a_ids), index=a_ids)
 
     b_ids = [4, 5, 6]
     if reverse_order:
         b_ids = b_ids[::-1]
-    b = RowFrame(features("B", b_ids), index=b_ids)
+    b = IndexedArray(features("B", b_ids), index=b_ids)
 
     r_edges = [(4, 0), (1, 5), (1, 4), (2, 4), (5, 3)]
     f_edges, f_index = [(4, 5)], [100]


### PR DESCRIPTION
This builds on the construct-from-NumPy support in #1556 to allow node features to be multidimensional. That is, instead of just a 2D matrix of size N &times; F, corresponding to feature vectors of length F for each of the N nodes, a `StellarGraph` object can now have a feature array of shape N &times; F<sub>1</sub> &times; F<sub>2</sub> &times; ..., corresponding to feature tensors of shape F<sub>1</sub> &times; F<sub>2</sub> &times; ... for each node.

This is useful for multivariate time series, where the most natural modelling of the data is a time_steps &times; num_variates matrix (or the transpose) for each node.

None of our models will likely do anything useful with higher rank feature tensors, at the moment (#1527). They'll all throw errors because `StellarGraph.check_graph_for_ml` calls `StellarGraph.node_feature_sizes` which emits an error for node types with complicated shapes, for backwards compatibility.

See: #1524