### PR TITLE
Add custom 404 page

### DIFF
--- a/docs/404.rst
+++ b/docs/404.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Page not found
 ==============
 

--- a/docs/404.rst
+++ b/docs/404.rst
@@ -1,0 +1,24 @@
+Page not found
+==============
+
+.. raw:: html
+
+   <p>Please use the links in the side bar, or <a id="suggested-search">search for potentially-related pages</a>.</p>
+
+   <script>
+   // turn a URL like /<lang>/<version>/some_directory/some-page.html into a search for "some directory some page"
+   let parts = document.location.pathname.split(/\//g);
+
+   // parts = ["", "<lang>", "<version>", ...], and we need /<lang>/<version>/search.html
+   let searchPage = parts.slice(0, 3).join("/") + "/search.html";
+
+   // take the rest of the URL path, remove the file extension (if it exists), and use the alphanumeric components as the search input.
+   val notFound = parts.slice(3, -1);
+   val withoutExtension = parts[parts.length - 1].replace(/\.[^.]*$/, "");
+   notFound.push(withoutExtension);
+   let terms = notFound.join(" ").replace(/[^a-zA-Z0-9]+/g, " ");
+
+   // build and write in the URL
+   let url = searchPage + "?q=" + encodeURIComponent(terms);
+   document.getElementById("suggested-search").href = url;
+   </script>

--- a/docs/404.rst
+++ b/docs/404.rst
@@ -13,8 +13,8 @@ Page not found
    let searchPage = parts.slice(0, 3).join("/") + "/search.html";
 
    // take the rest of the URL path, remove the file extension (if it exists), and use the alphanumeric components as the search input.
-   val notFound = parts.slice(3, -1);
-   val withoutExtension = parts[parts.length - 1].replace(/\.[^.]*$/, "");
+   let notFound = parts.slice(3, -1);
+   let withoutExtension = parts[parts.length - 1].replace(/\.[^.]*$/, "");
    notFound.push(withoutExtension);
    let terms = notFound.join(" ").replace(/[^a-zA-Z0-9]+/g, " ");
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,6 +63,7 @@ extensions = [
     "sphinx_markdown_tables",
     "nbsphinx",
     "nbsphinx_link",
+    "notfound.extension",
 ]
 
 # Add mappings

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,6 +5,8 @@ nbsphinx-link==1.3.0
 # needed for Pygments highlighting in notebooks
 ipython==7.13.0
 
+sphinx-notfound-page==0.4
+
 # dependencies used by RtD, fixed here so that our CI and RtD use the same (newer) versions.
 # https://github.com/readthedocs/readthedocs.org/blob/35b5ca286dff9d3fbcfdf1351e570375cd0c2bd3/readthedocs/doc_builder/python_environments.py#L335-L365
 Pygments==2.6.1


### PR DESCRIPTION
This uses https://sphinx-notfound-page.readthedocs.io to add a custom 404 error page, so that someone landing on our documentation can attempt to find something useful, rather than having the completely link-less default RtD "maze" 404 page (e.g. https://abasdfdas.readthedocs.io).

This gives two pieces of guidance to a user who lands on a page:

- using the sidebar
- doing a search, with a prefilled link by pulling out the alphanumeric parts of the URL path (ignoring the version section), e.g. `/en/1577/demos/graph-classification/gcn.html` like below gets turned into a link to a search for `demos graph classification gcn` (a potential improvement here would be to do that search directly in the 404 page)

Example: https://stellargraph--1577.org.readthedocs.build/en/1577/demos/graph-classification/gcn.html

See: #1576