### PR TITLE
Feature/1531 generalize cluster gcn

### DIFF
--- a/stellargraph/layer/appnp.py
+++ b/stellargraph/layer/appnp.py
@@ -250,15 +250,13 @@ class APPNP:
         # Copy required information from generator
         self.method = generator.method
         self.multiplicity = generator.multiplicity
-        self.n_nodes = (
-            generator.features.shape[0]
-            if isinstance(generator, FullBatchGenerator)
-            else None
-        )
         self.n_features = generator.features.shape[1]
-
-        # Check if the generator is producing a sparse matrix
         self.use_sparse = generator.use_sparse
+        if isinstance(generator, FullBatchGenerator):
+            self.n_nodes = generator.features.shape[0]
+        else:
+            self.n_nodes = None
+
         if self.method == "none":
             self.graph_norm_layer = GraphPreProcessingLayer(num_of_nodes=self.n_nodes)
 

--- a/stellargraph/layer/appnp.py
+++ b/stellargraph/layer/appnp.py
@@ -304,7 +304,7 @@ class APPNP:
 
         # Otherwise, create dense matrix from input tensor
         else:
-            Ainput = As  # [Lambda(lambda A: K.squeeze(A, 0))(A) for A in As]
+            Ainput = As
 
         # TODO: Support multiple matrices?
         if len(Ainput) != 1:

--- a/stellargraph/layer/appnp.py
+++ b/stellargraph/layer/appnp.py
@@ -18,7 +18,7 @@ import warnings
 from tensorflow.keras.layers import Dense, Lambda, Dropout, Input, Layer, InputLayer
 import tensorflow.keras.backend as K
 
-from ..mapper import FullBatchGenerator
+from ..mapper import FullBatchGenerator, ClusterNodeGenerator
 from .preprocessing_layer import GraphPreProcessingLayer
 from .misc import SqueezedSparseConversion, deprecated_model_function, GatherIndices
 
@@ -55,7 +55,7 @@ class APPNPPropagationLayer(Layer):
         teleport_probability=0.1,
         final_layer=None,
         input_dim=None,
-        **kwargs
+        **kwargs,
     ):
         if "input_shape" not in kwargs and input_dim is not None:
             kwargs["input_shape"] = (input_dim,)
@@ -219,9 +219,10 @@ class APPNP:
         approx_iter=10,
     ):
 
-        if not isinstance(generator, FullBatchGenerator):
+        if not isinstance(generator, (FullBatchGenerator, ClusterNodeGenerator)):
             raise TypeError(
-                "Generator should be a instance of FullBatchNodeGenerator or FullBatchLinkGenerator"
+                f"Generator should be a instance of FullBatchNodeGenerator, "
+                f"FullBatchLinkGenerator or ClusterNodeGenerator"
             )
 
         if not len(layer_sizes) == len(activations):
@@ -249,7 +250,11 @@ class APPNP:
         # Copy required information from generator
         self.method = generator.method
         self.multiplicity = generator.multiplicity
-        self.n_nodes = generator.features.shape[0]
+        self.n_nodes = (
+            generator.features.shape[0]
+            if isinstance(generator, FullBatchGenerator)
+            else None
+        )
         self.n_features = generator.features.shape[1]
 
         # Check if the generator is producing a sparse matrix

--- a/stellargraph/layer/graph_attention.py
+++ b/stellargraph/layer/graph_attention.py
@@ -276,7 +276,7 @@ class GraphAttention(Layer):
                   M is the number of output nodes
         """
         X = inputs[0]  # Node features (1 x N x F)
-        A = inputs[1]  # Adjacency matrix (N x N)
+        A = inputs[1]  # Adjacency matrix (1 X N x N)
         N = K.int_shape(A)[-1]
 
         batch_dim, n_nodes, _ = K.int_shape(X)
@@ -288,6 +288,7 @@ class GraphAttention(Layer):
         else:
             # Remove singleton batch dimension
             X = K.squeeze(X, 0)
+            A = K.squeeze(A, 0)
 
         outputs = []
         for head in range(self.attn_heads):
@@ -841,7 +842,7 @@ class GAT:
 
         # Otherwise, create dense matrix from input tensor
         else:
-            Ainput = [Lambda(lambda A: K.squeeze(A, 0))(A) for A in As]
+            Ainput = As
 
         # TODO: Support multiple matrices?
         if len(Ainput) != 1:

--- a/stellargraph/mapper/mini_batch_node_generators.py
+++ b/stellargraph/mapper/mini_batch_node_generators.py
@@ -70,6 +70,9 @@ class ClusterNodeGenerator(Generator):
         self.q = q  # The number of clusters to sample per mini-batch
         self.lam = lam
         self.clusters = clusters
+        self.method = "cluster_gcn"
+        self.multiplicity = 1
+        self.use_sparse = False
 
         if isinstance(clusters, list):
             self.k = len(clusters)

--- a/tests/layer/test_appnp.py
+++ b/tests/layer/test_appnp.py
@@ -45,8 +45,8 @@ def test_APPNP_edge_cases():
     except TypeError as e:
         error = e
     assert (
-        str(error)
-        == "Generator should be a instance of FullBatchNodeGenerator or FullBatchLinkGenerator"
+        str(error) == f"Generator should be a instance of FullBatchNodeGenerator, "
+        f"FullBatchLinkGenerator or ClusterNodeGenerator"
     )
 
     try:

--- a/tests/layer/test_appnp.py
+++ b/tests/layer/test_appnp.py
@@ -252,7 +252,7 @@ def test_APPNP_propagate_model_matches_manual(model_type):
     manual_preds = manual_inp = fully_connected_model.predict(float_feats)
     propagate = APPNPPropagationLayer(dense_size, teleport_probability=0.1)
     for _ in range(10):
-        manual_preds = propagate([manual_preds, manual_inp, adj[0, ...]])
+        manual_preds = propagate([manual_preds, manual_inp, adj])
 
     # select the relevant pieces
     manual_preds = manual_preds.numpy()[:, out_indices.ravel(), :]

--- a/tests/layer/test_cluster_models.py
+++ b/tests/layer/test_cluster_models.py
@@ -1,4 +1,4 @@
-from stellargraph.layer import APPNP, GAT
+from stellargraph.layer import APPNP, GAT, GCN
 from stellargraph.mapper import ClusterNodeGenerator
 import tensorflow as tf
 import numpy as np
@@ -6,7 +6,7 @@ from ..test_utils.graphs import example_graph_random
 import pytest
 
 
-@pytest.mark.parametrize("model_type", [APPNP, GAT])
+@pytest.mark.parametrize("model_type", [APPNP, GAT, GCN])
 def test_fullbatch_cluster_models(model_type):
     G = example_graph_random(n_nodes=50)
     generator = ClusterNodeGenerator(G, clusters=10)

--- a/tests/layer/test_cluster_models.py
+++ b/tests/layer/test_cluster_models.py
@@ -1,0 +1,37 @@
+from stellargraph.layer import APPNP, GAT
+from stellargraph.mapper import ClusterNodeGenerator
+import tensorflow as tf
+import numpy as np
+from ..test_utils.graphs import example_graph_random
+import pytest
+
+
+@pytest.mark.parametrize("model_type", [APPNP, GAT])
+def test_fullbatch_cluster_models(model_type):
+    G = example_graph_random(n_nodes=50)
+    generator = ClusterNodeGenerator(G, clusters=10)
+    nodes = G.nodes()[:40]
+    gen = generator.flow(nodes, targets=np.ones(len(nodes)))
+
+    gnn = model_type(
+        generator=generator,
+        layer_sizes=[16, 16, 1],
+        activations=["relu", "relu", "relu"],
+    )
+
+    model = tf.keras.Model(*gnn.in_out_tensors())
+    model.compile(optimizer="adam", loss="binary_crossentropy")
+    history = model.fit(gen, validation_data=gen, epochs=2)
+    results = model.evaluate(gen)
+
+    # this doesn't work for any cluster models including ClusterGCN
+    # because the model spits out predictions with shapes:
+    # [(1, cluster_1_size, feat_size), (1, cluster_2_size, feat_size)...]
+    # and attempts to concatenate along axis 0
+    # predictions = model.predict(gen)
+    x_in, x_out = gnn.in_out_tensors()
+    x_out_flat = tf.squeeze(x_out, 0)
+    embedding_model = tf.keras.Model(inputs=x_in, outputs=x_out_flat)
+    predictions = embedding_model.predict(gen)
+
+    assert predictions.shape == (len(nodes), 1)

--- a/tests/layer/test_cluster_models.py
+++ b/tests/layer/test_cluster_models.py
@@ -1,3 +1,19 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2020 Data61, CSIRO
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from stellargraph.layer import APPNP, GAT, GCN
 from stellargraph.mapper import ClusterNodeGenerator
 import tensorflow as tf

--- a/tests/layer/test_graph_attention.py
+++ b/tests/layer/test_graph_attention.py
@@ -54,11 +54,8 @@ class Test_GraphAttention:
             Input(batch_shape=(1, self.N, self.N)),
         ]
 
-        # For dense matrix, remove batch dimension
-        A_mat = keras.layers.Lambda(lambda A: K.squeeze(A, 0))(x_inp[1])
-        layer_inp = x_inp[:1] + [A_mat]
-
-        return x_inp, layer_inp
+        # duplicate input here for Test_GraphAttentionSparse to work
+        return x_inp, x_inp
 
     def get_matrix(self, edges=[]):
         # adjacency matrix with self-loops only
@@ -109,7 +106,7 @@ class Test_GraphAttention:
         x_inp, layer_inp = self.get_inputs()
 
         # Instantiate layer with squeezed matrix
-        x_out = gat(layer_inp)
+        x_out = gat(x_inp)
 
         model = keras.Model(inputs=x_inp, outputs=x_out)
 

--- a/tests/layer/test_graph_attention.py
+++ b/tests/layer/test_graph_attention.py
@@ -106,7 +106,7 @@ class Test_GraphAttention:
         x_inp, layer_inp = self.get_inputs()
 
         # Instantiate layer with squeezed matrix
-        x_out = gat(x_inp)
+        x_out = gat(layer_inp)
 
         model = keras.Model(inputs=x_inp, outputs=x_out)
 


### PR DESCRIPTION
This PR generalizes the cluster training method to work for `GCN`, `GAT`, and `APPNP`. To do this `APPNPPropagation` and `GraphAttention` layers had to be changed (for the dense case) to handle adjacency matrices with a batch dimension of 1 to match the new format of `GraphConvolution`. 

I think it's now probably a good idea to deprecate `ClusterGCN` and re-write the demo to use `GCN`, `GAT`, and `APPNP`. I'll do this in a follow up PR :) 

See #1531 