### PR TITLE
Add Neo4j docker image readme

### DIFF
--- a/docker/stellargraph-neo4j/README.md
+++ b/docker/stellargraph-neo4j/README.md
@@ -11,4 +11,3 @@ Run the docker container:
 ```
 docker run -it -e NEO4J_AUTH=none -p 7687:7687 -p 7474:7474 stellargraph_neo4j:latest
 ```
-

--- a/docker/stellargraph-neo4j/README.md
+++ b/docker/stellargraph-neo4j/README.md
@@ -1,0 +1,14 @@
+# Neo4j Docker image
+
+This image is being used in CI for testing our Neo4j functionality, but it can also be used for local development.
+
+You can build the image for Neo4J 4.0 using the build script:
+```
+./build.sh
+```
+
+Run the docker container:
+```
+docker run -it -e NEO4J_AUTH=none -p 7687:7687 -p 7474:7474 stellargraph_neo4j:latest
+```
+

--- a/docker/stellargraph-neo4j/build.sh
+++ b/docker/stellargraph-neo4j/build.sh
@@ -1,1 +1,3 @@
+#!/bin/bash
+
 docker build --build-arg NEO4J_VERSION=4.0 .

--- a/docker/stellargraph-neo4j/build.sh
+++ b/docker/stellargraph-neo4j/build.sh
@@ -1,0 +1,1 @@
+docker build --build-arg NEO4J_VERSION=4.0 .


### PR DESCRIPTION
This adds a build script and readme for our neo4j docker image, so that there's some instructions in the repo if anyone wants to use it for local development (I've been using it).

We don't currently have a "Development" section in any of our READMEs, but that would've been a reasonable place to put these instructions. Instead, I've decided to just create a new README in `docker/stellargraph-neo4j`.

See #1250 