### PR TITLE
Allow specifying property names for id and features

### DIFF
--- a/stellargraph/connector/neo4j/graph.py
+++ b/stellargraph/connector/neo4j/graph.py
@@ -347,7 +347,7 @@ class Neo4jStellarGraph:
                 relationshipQuery: 'MATCH (n)-->(m) RETURN id(n) AS source, id(m) AS target'
             }})
             YIELD nodeId, communityId
-            RETURN communityId, collect(gds.util.asNode(nodeId).ID) AS node_ids
+            RETURN communityId, collect(gds.util.asNode(nodeId).{self.cypher_id_property}) AS node_ids
         """
         clusters = [row[1] for row in self.graph_db.run(cluster_query)]
         return clusters

--- a/stellargraph/connector/neo4j/graph.py
+++ b/stellargraph/connector/neo4j/graph.py
@@ -386,5 +386,13 @@ class Neo4jStellarGraph:
 
 # A convenience class that merely specifies that edges have direction.
 class Neo4jStellarDiGraph(Neo4jStellarGraph):
-    def __init__(self, graph_db, node_label=None):
-        super().__init__(graph_db, node_label=node_label, is_directed=True)
+    def __init__(
+        self, graph_db, node_label=None, id_property="ID", features_property="features"
+    ):
+        super().__init__(
+            graph_db,
+            node_label=node_label,
+            id_property=id_property,
+            features_property=features_property,
+            is_directed=True,
+        )

--- a/stellargraph/connector/neo4j/graph.py
+++ b/stellargraph/connector/neo4j/graph.py
@@ -54,8 +54,8 @@ class Neo4jStellarGraph:
         self,
         graph_db,
         node_label=None,
-        id_property="ID",
-        features_property="features",
+        id_property=globalvar.NEO4J_ID_PROPERTY,
+        features_property=globalvar.NEO4J_FEATURES_PROPERTY,
         is_directed=False,
     ):
 
@@ -387,7 +387,11 @@ class Neo4jStellarGraph:
 # A convenience class that merely specifies that edges have direction.
 class Neo4jStellarDiGraph(Neo4jStellarGraph):
     def __init__(
-        self, graph_db, node_label=None, id_property="ID", features_property="features"
+        self,
+        graph_db,
+        node_label=None,
+        id_property=globalvar.NEO4J_ID_PROPERTY,
+        features_property=globalvar.NEO4J_FEATURES_PROPERTY,
     ):
         super().__init__(
             graph_db,

--- a/stellargraph/connector/neo4j/graph.py
+++ b/stellargraph/connector/neo4j/graph.py
@@ -81,7 +81,7 @@ class Neo4jStellarGraph:
                 CALL db.constraints
                 """
             constraint_regex = re.compile(
-                rf"^CONSTRAINT ON \( \w+:{node_label} \) ASSERT \(\w+.ID\) IS UNIQUE$"
+                rf"^CONSTRAINT ON \( \w+:{node_label} \) ASSERT \(\w+.{id_property}\) IS UNIQUE$"
             )
             constraint_exists = False
             for c in graph_db.run(constraint_query).data():

--- a/stellargraph/globalvar.py
+++ b/stellargraph/globalvar.py
@@ -26,3 +26,6 @@ EDGE_TYPE_DEFAULT = "default"
 SOURCE = "source"
 TARGET = "target"
 WEIGHT = "weight"
+
+NEO4J_ID_PROPERTY = "ID"
+NEO4J_FEATURES_PROPERTY = "features"


### PR DESCRIPTION
This adds two more optional parameters to neo4jstellargraph to allow users to specify the name of the node properties to use as ID and features. 

I've verified manually by running the neo4j graphsage notebooks with different ID and feature properties, but otherwise this change isn't really being exercised as much as we'd want in CI until we have tests.

See #1592 