### PR TITLE
Add star button and "fork me" banner to HTML docs

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -3,9 +3,17 @@
 }
 
 .sg-fork-me-banner {
-    position: absolute;
-    top: 0;
-    right: 0;
+    display: none;
+}
+
+/* only show the fork-me banner if the screen is wide enough */
+@media screen and (min-width: 768px) {
+    .sg-fork-me-banner {
+        display: block;
+        position: absolute;
+        top: 0;
+        right: 0;
+    }
 }
 
 div.wy-nav-content {

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,3 +1,13 @@
+.sg-star-button {
+    margin-top: 1em;
+}
+
+.sg-fork-me-banner {
+    position: absolute;
+    top: 0;
+    right: 0;
+}
+
 div.wy-nav-content {
     /* make the main content wider, for wider tables */
     max-width: 1000px;

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,0 +1,16 @@
+{% extends '!layout.html' %}
+
+{# Customise some aspects of the sphinx-rtd-theme to insert github links #}
+
+{% block sidebartitle %}
+{{ super() }}
+  <iframe src="https://ghbtns.com/github-btn.html?user=stellargraph&repo=stellargraph&type=star&count=true&size=large&v=2"
+          class="sg-star-button" allowtransparency="true" frameborder="0" scrolling="0" width="200px" height="35px"></iframe>
+{% endblock %}
+
+{% block document %}
+{{super()}}
+    <a class="sg-fork-me-banner" href="https://github.com/stellargraph/stellargraph">
+        <img src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub">
+    </a>
+{% endblock %}


### PR DESCRIPTION
This extends the Jinja2 template used for our pages to insert two links to GitHub:

- A star button near the title in the sidebar
- A "fork me" banner in the top right of the page

The button is shown always, while the banner is only shown on sufficiently wide screens.

Rendered: https://stellargraph--1605.org.readthedocs.build/en/1605/

See: #1552 