### PR TITLE
Use a table to categorise the various "basics" demos

### DIFF
--- a/docs/demos/basics/index.rst
+++ b/docs/demos/basics/index.rst
@@ -16,7 +16,7 @@ Find demos for a format
    * - :doc:`loading-pandas`
      - Anything `supported by Pandas <https://pandas.pydata.org/pandas-docs/stable/user_guide/io.html>`__: CSV, TSV, Excel, JSON, SQL, HDF5, many more
      - Good
-     - Via Pandas and `scikit-learn <http://scikit-learn.github.io/stable>`__ and more
+     - Via Pandas, `scikit-learn <http://scikit-learn.github.io/stable>`__ and more
    * - :doc:`loading-networkx`
      - Anything `supported by NetworkX <https://networkx.github.io/documentation/stable/reference/readwrite/index.html>`__: Adjacency lists, GEXF, GML, GraphML, Shapefiles, many more
      - Poor

--- a/docs/demos/basics/index.rst
+++ b/docs/demos/basics/index.rst
@@ -12,15 +12,19 @@ Find demos for a format
    * - Demo
      - Data formats
      - Performance
+     - Data preprocessing
    * - :doc:`loading-pandas`
      - Anything `supported by Pandas <https://pandas.pydata.org/pandas-docs/stable/user_guide/io.html>`__: CSV, TSV, Excel, JSON, SQL, HDF5, many more
      - Good
+     - Good, using Pandas and `scikit-learn <http://scikit-learn.github.io/stable>`__ and more
    * - :doc:`loading-networkx`
      - Anything `supported by NetworkX <https://networkx.github.io/documentation/stable/reference/readwrite/index.html>`__: GEXF, GML, GraphML, Shapefiles, many more
      - Poor
+     - Good, for graph-related preprocessing
    * - :doc:`loading-saving-neo4j`
      - Any Cypher query supported by `Neo4j <https://neo4j.com>`__
      - Good for subgraphs and other queries
+     - Good, using Cypher functionality
 
 See :doc:`all demos for machine learning algorithms <../index>`.
 

--- a/docs/demos/basics/index.rst
+++ b/docs/demos/basics/index.rst
@@ -16,15 +16,15 @@ Find demos for a format
    * - :doc:`loading-pandas`
      - Anything `supported by Pandas <https://pandas.pydata.org/pandas-docs/stable/user_guide/io.html>`__: CSV, TSV, Excel, JSON, SQL, HDF5, many more
      - Good
-     - Good, using Pandas and `scikit-learn <http://scikit-learn.github.io/stable>`__ and more
+     - Via Pandas and `scikit-learn <http://scikit-learn.github.io/stable>`__ and more
    * - :doc:`loading-networkx`
      - Anything `supported by NetworkX <https://networkx.github.io/documentation/stable/reference/readwrite/index.html>`__: GEXF, GML, GraphML, Shapefiles, many more
      - Poor
-     - Good, for graph-related preprocessing
+     - Via graph-focused transforms and functions in NetworkX
    * - :doc:`loading-saving-neo4j`
      - Any Cypher query supported by `Neo4j <https://neo4j.com>`__
      - Good for subgraphs and other queries
-     - Good, using Cypher functionality
+     - Via Cypher functionality
 
 See :doc:`all demos for machine learning algorithms <../index>`.
 

--- a/docs/demos/basics/index.rst
+++ b/docs/demos/basics/index.rst
@@ -1,15 +1,26 @@
 StellarGraph basics
 ===================
 
-`StellarGraph <https://github.com/stellargraph/stellargraph>`_ has support for loading data via Pandas and NetworkX. This folder contains examples of the loading data into a ``StellarGraph`` object, which is the format used by the machine learning algorithms in this library.
+`StellarGraph <https://github.com/stellargraph/stellargraph>`_ has support for loading data via Pandas, NetworkX and Neo4j. This folder contains examples of the loading data into a ``StellarGraph`` object, which is the format used by the machine learning algorithms in this library.
 
 Find demos for a format
 -----------------------
 
+.. list-table::
+   :header-rows: 1
 
-* :doc:`loading-pandas <loading-pandas>` shows the recommended way to load data, using Pandas (supporting any input format that Pandas supports, including CSV files and SQL databases)
-* :doc:`loading-networkx <loading-networkx>` shows how to load data from a `NetworkX <https://networkx.github.io>`_ graph
-* :doc:`loading-saving-neo4j <loading-saving-neo4j>` shows how to load data from a `Neo4j <https://neo4j.com>`_ database, and save results back to it
+   * - Demo
+     - Data formats
+     - Performance
+   * - :doc:`loading-pandas`
+     - Anything `supported by Pandas <https://pandas.pydata.org/pandas-docs/stable/user_guide/io.html>`__: CSV, TSV, Excel, JSON, SQL, HDF5, many more
+     - Good
+   * - :doc:`loading-networkx`
+     - Anything `supported by NetworkX <https://networkx.github.io/documentation/stable/reference/readwrite/index.html>`__: GEXF, GML, GraphML, Shapefiles, many more
+     - Poor
+   * - :doc:`loading-saving-neo4j`
+     - Any Cypher query supported by `Neo4j <https://neo4j.com>`__
+     - Good for subgraphs and other queries
 
 See :doc:`all demos for machine learning algorithms <../index>`.
 

--- a/docs/demos/basics/index.rst
+++ b/docs/demos/basics/index.rst
@@ -18,7 +18,7 @@ Find demos for a format
      - Good
      - Via Pandas and `scikit-learn <http://scikit-learn.github.io/stable>`__ and more
    * - :doc:`loading-networkx`
-     - Anything `supported by NetworkX <https://networkx.github.io/documentation/stable/reference/readwrite/index.html>`__: GEXF, GML, GraphML, Shapefiles, many more
+     - Anything `supported by NetworkX <https://networkx.github.io/documentation/stable/reference/readwrite/index.html>`__: Adjacency lists, GEXF, GML, GraphML, Shapefiles, many more
      - Poor
      - Via graph-focused transforms and functions in NetworkX
    * - :doc:`loading-saving-neo4j`


### PR DESCRIPTION
A table is a little more structured, and makes it easy to include more info in an easily digestible way, like supported formats and a hint about performance.

I chose the subset of formats to list by searching for the relevant reading function on GitHub (e.g. [Pandas](https://pandas.pydata.org/pandas-docs/stable/user_guide/io.html): [`"pd.read_csv"`](https://github.com/search?q=%22pd.read_csv%22&type=Code), and [NetworkX](https://networkx.github.io/documentation/stable/reference/readwrite/index.html): [`"nx.read_gml"`](https://github.com/search?q=%22nx.read_gml%22&type=Code)) and including the ones that are most common, using this as a proxy for the formats that are encountered the most, in the wild. For NetworkX, I didn't include the edge list format (even though it was common), because that's better done via Pandas.

Caveats: 
- these searches are fairly noisy but it should still be correlated to the frequency of use. For example, it includes results from the repo itself and any duplicates of the source code, and will miss calls with different phrasings like `pandas.read_csv(...)` or `from networkx import read_gml; ... read_gml(...)`.
- these searches aren't limited to just people doing graph work but I'm not sure we can do much better. For example, it might be that people working with graphs use SQL much more than HDF5.

Rendered docs: https://stellargraph--1608.org.readthedocs.build/en/1608/demos/basics/index.html

See: #1270