### PR TITLE
Fix indexing with empty array with default type np.float

### DIFF
--- a/stellargraph/mapper/mini_batch_node_generators.py
+++ b/stellargraph/mapper/mini_batch_node_generators.py
@@ -341,7 +341,8 @@ class ClusterNodeSequence(Sequence):
             # Dictionary to store node indices for quicker node index lookups
             # The list of indices of the target nodes in self.node_list
             cluster_target_indices = np.array(
-                [self.target_node_lookup[n] for n in target_nodes_in_cluster]
+                [self.target_node_lookup[n] for n in target_nodes_in_cluster],
+                dtype=np.int64,
             )
             cluster_targets = self.targets[cluster_target_indices]
             cluster_targets = cluster_targets.reshape((1,) + cluster_targets.shape)

--- a/tests/mapper/test_cluster_gcn_node_mapper.py
+++ b/tests/mapper/test_cluster_gcn_node_mapper.py
@@ -205,3 +205,10 @@ def test_benchmark_ClusterGCN_generator(benchmark, q):
 
     # iterate over all the batches
     benchmark(lambda: list(seq))
+
+
+def test_ClusterNodeSequence_cluster_without_targets():
+    G = create_stellargraph()
+    generator = ClusterNodeGenerator(G, clusters=2, q=1)
+    seq = generator.flow(node_ids=["a"], targets=[0])
+    _ = list(seq)


### PR DESCRIPTION
This fixes a bug, where previously if a cluster had no targets `cluster_target_indfices` would an empty array with default type np.float64. This caused an error when trying to index with this array.