### PR TITLE
cleanup hrefs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,17 @@
 ![StellarGraph Machine Learning library logo](https://raw.githubusercontent.com/stellargraph/stellargraph/develop/stellar-graph-banner.png)
 
 <p align="center">
-  <a href="https://stellargraph.readthedocs.io/" alt="Docs">
-    <img src="https://readthedocs.org/projects/stellargraph/badge/?version=latest"/>
-  </a>
-  <a href="https://community.stellargraph.io" alt="Discourse Forum">
-    <img src="https://img.shields.io/badge/help_forum-discourse-blue.svg"/>
-  </a>
-  <a href="https://pypi.org/project/stellargraph/" alt="PyPI">
-    <img src="https://img.shields.io/pypi/v/stellargraph.svg"/>
-  </a>
-  <a href="https://github.com/stellargraph/stellargraph/blob/develop/LICENSE" alt="license">
-    <img src="https://img.shields.io/github/license/stellargraph/stellargraph.svg"/>
-  </a>
+  <a href="https://stellargraph.readthedocs.io/" alt="Docs"><img src="https://readthedocs.org/projects/stellargraph/badge/?version=latest"/></a>
+  <a href="https://community.stellargraph.io" alt="Discourse Forum"><img src="https://img.shields.io/badge/help_forum-discourse-blue.svg"/></a>
+  <a href="https://pypi.org/project/stellargraph/" alt="PyPI"><img src="https://img.shields.io/pypi/v/stellargraph.svg"/></a>
+  <a href="https://github.com/stellargraph/stellargraph/blob/develop/LICENSE" alt="license"><img src="https://img.shields.io/github/license/stellargraph/stellargraph.svg"/></a>
 </p>
 <p align="center">
-  <a href="https://github.com/stellargraph/stellargraph/blob/develop/CONTRIBUTING.md" alt="contributions welcome">
-    <img src="https://img.shields.io/badge/contributions-welcome-brightgreen.svg"/>
-  </a>
-  <a href="https://buildkite.com/stellar/stellargraph-public?branch=master/" alt="Build status: master">
-    <img src="https://img.shields.io/buildkite/8aa4d147372ccc0153101b50137f5f3439c6038f29b21f78f8/master.svg?label=branch:+master"/>
-  </a>
-  <a href="https://buildkite.com/stellar/stellargraph-public?branch=develop/" alt="Build status: develop">
-    <img src="https://img.shields.io/buildkite/8aa4d147372ccc0153101b50137f5f3439c6038f29b21f78f8/develop.svg?label=branch:+develop"/>
-  </a>
-  <a href="https://codecov.io/gh/stellargraph/stellargraph">
-    <img src="https://codecov.io/gh/stellargraph/stellargraph/branch/develop/graph/badge.svg" />
-  </a>
-  <a href="https://pypi.org/project/stellargraph" alt="pypi downloads">
-    <img alt="pypi downloads" src="https://pepy.tech/badge/stellargraph">
-  </a>
+  <a href="https://github.com/stellargraph/stellargraph/blob/develop/CONTRIBUTING.md" alt="contributions welcome"><img src="https://img.shields.io/badge/contributions-welcome-brightgreen.svg"/></a>
+  <a href="https://buildkite.com/stellar/stellargraph-public?branch=master/" alt="Build status: master"><img src="https://img.shields.io/buildkite/8aa4d147372ccc0153101b50137f5f3439c6038f29b21f78f8/master.svg?label=branch:+master"/></a>
+  <a href="https://buildkite.com/stellar/stellargraph-public?branch=develop/" alt="Build status: develop"><img src="https://img.shields.io/buildkite/8aa4d147372ccc0153101b50137f5f3439c6038f29b21f78f8/develop.svg?label=branch:+develop"/></a>
+  <a href="https://codecov.io/gh/stellargraph/stellargraph"><img src="https://codecov.io/gh/stellargraph/stellargraph/branch/develop/graph/badge.svg" /></a>
+  <a href="https://pypi.org/project/stellargraph" alt="pypi downloads"><img alt="pypi downloads" src="https://pepy.tech/badge/stellargraph"></a>
 </p>
 
 


### PR DESCRIPTION
PR:

* Makes each `<a>` on a single line to make it easier to diff
* Fixes the text-decoration underline visible in some editors (see attached image)

<img width="739" alt="image" src="https://user-images.githubusercontent.com/856001/83228349-83cd7500-a1c9-11ea-96c9-3ff81cb00edf.png">


