### PR TITLE
Improve demo indexing for keras Node2Vec notebooks (#1534)

### DIFF
--- a/demos/README.md
+++ b/demos/README.md
@@ -205,12 +205,13 @@ These demos are displayed with detailed descriptions in the documentation: https
     <td></td>
     <td></td>
     <td>
-      <span title='via embedding vectors (keras layer)'><a href='node-classification/keras-node2vec-node-classification.ipynb'>via unsup. keras</a></span>
-      <span title='via embedding vectors (gensim)'><a href='node-classification/node2vec-node-classification.ipynb'>via unsup. gensim</a></span>
+      <span title='via embedding vectors'>via unsup.</span>
+      <span title='keras layer'><a href='node-classification/keras-node2vec-node-classification.ipynb'>keras</a></span>
+      <a href='node-classification/node2vec-node-classification.ipynb'>gensim</a>
     </td>
     <td><span title='via embedding vectors'><a href='link-prediction/node2vec-link-prediction.ipynb'>via unsup.</a></span></td>
     <td>
-      <span title='keras layer'><a href='embeddings/keras-node2vec-embeddings.ipynb'>keras layer</a></span>
+      <span title='keras layer'><a href='embeddings/keras-node2vec-embeddings.ipynb'>keras</a></span>
       <a href='embeddings/node2vec-embeddings.ipynb'>gensim</a>
     </td>
     <td></td>

--- a/demos/README.md
+++ b/demos/README.md
@@ -205,7 +205,7 @@ These demos are displayed with detailed descriptions in the documentation: https
     <td></td>
     <td></td>
     <td>
-      <span title='via embedding vectors'>via unsup.</span>
+      <span title='via embedding vectors'>via</span>
       <span title='keras layer'><a href='node-classification/keras-node2vec-node-classification.ipynb'>keras</a></span>
       <a href='node-classification/node2vec-node-classification.ipynb'>gensim</a>
     </td>

--- a/demos/README.md
+++ b/demos/README.md
@@ -204,22 +204,15 @@ These demos are displayed with detailed descriptions in the documentation: https
     <td><a href='node-classification/node2vec-weighted-node-classification.ipynb'>demo</a></td>
     <td></td>
     <td></td>
-    <td><span title='via embedding vectors'><a href='node-classification/node2vec-node-classification.ipynb'>via unsup.</a></span></td>
+    <td>
+      <span title='via embedding vectors (keras layer)'><a href='node-classification/keras-node2vec-node-classification.ipynb'>via unsup. keras</a></span>
+      <span title='via embedding vectors (gensim)'><a href='node-classification/node2vec-node-classification.ipynb'>via unsup. gensim</a></span>
+    </td>
     <td><span title='via embedding vectors'><a href='link-prediction/node2vec-link-prediction.ipynb'>via unsup.</a></span></td>
-    <td><a href='embeddings/node2vec-embeddings.ipynb'>demo</a></td>
-    <td></td>
-    <td></td>
-  </tr>
-  <tr>
-    <td>Keras-Node2Vec</td>
-    <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
-    <td><span title='via embedding vectors'><a href='node-classification/keras-node2vec-node-classification.ipynb'>via unsup.</a></span></td>
-    <td></td>
-    <td><a href='embeddings/keras-node2vec-embeddings.ipynb'>demo</a></td>
+    <td>
+      <span title='keras layer'><a href='embeddings/keras-node2vec-embeddings.ipynb'>keras layer</a></span>
+      <a href='embeddings/node2vec-embeddings.ipynb'>gensim</a>
+    </td>
     <td></td>
     <td></td>
   </tr>

--- a/docs/demos/index.rst
+++ b/docs/demos/index.rst
@@ -203,7 +203,7 @@ Find a demo for an algorithm
      - :any:`demo <node-classification/node2vec-weighted-node-classification>`
      -
      -
-     - :any:`via embedding vectors (keras layer) <node-classification/keras-node2vec-node-classification>`, :any:`via embedding vectors (gensim) <node-classification/node2vec-node-classification>`
+     - via embedding vectors, :any:`keras layer <node-classification/keras-node2vec-node-classification>`, :any:`gensim <node-classification/node2vec-node-classification>`
      - :any:`via embedding vectors <link-prediction/node2vec-link-prediction>`
      - :any:`keras layer <embeddings/keras-node2vec-embeddings>`, :any:`gensim <embeddings/node2vec-embeddings>`
      -

--- a/docs/demos/index.rst
+++ b/docs/demos/index.rst
@@ -203,21 +203,9 @@ Find a demo for an algorithm
      - :any:`demo <node-classification/node2vec-weighted-node-classification>`
      -
      -
-     - :any:`via embedding vectors <node-classification/node2vec-node-classification>`
+     - :any:`via embedding vectors (keras layer) <node-classification/keras-node2vec-node-classification>`, :any:`via embedding vectors (gensim) <node-classification/node2vec-node-classification>`
      - :any:`via embedding vectors <link-prediction/node2vec-link-prediction>`
-     - :any:`demo <embeddings/node2vec-embeddings>`
-     -
-     -
-   *
-     - Keras-Node2Vec
-     -
-     -
-     -
-     -
-     -
-     - :any:`via embedding vectors <node-classification/keras-node2vec-node-classification>`
-     -
-     - :any:`demo <embeddings/keras-node2vec-embeddings>`
+     - :any:`keras layer <embeddings/keras-node2vec-embeddings>`, :any:`gensim <embeddings/node2vec-embeddings>`
      -
      -
    *

--- a/docs/demos/node-classification/index.rst
+++ b/docs/demos/node-classification/index.rst
@@ -103,7 +103,7 @@ This table lists all node classification demos, including the algorithms trained
      -
      -
      - yes
-   * - :doc:`Node2Vec (keras) <keras-node2vec-node-classification>`,
+   * - :doc:`Node2Vec (keras) <keras-node2vec-node-classification>`
      - Node2Vec
      -
      -

--- a/docs/demos/node-classification/index.rst
+++ b/docs/demos/node-classification/index.rst
@@ -103,8 +103,15 @@ This table lists all node classification demos, including the algorithms trained
      -
      -
      - yes
-   * - :doc:`Node2Vec (keras) <keras-node2vec-node-classification>`
-       :doc:`Node2Vec (gensim) <node2vec-node-classification>`
+   * - :doc:`Node2Vec (keras) <keras-node2vec-node-classification>`,
+     - Node2Vec
+     -
+     -
+     -
+     -
+     -
+     - yes
+   * - :doc:`Node2Vec (gensim) <node2vec-node-classification>`
      - Node2Vec
      -
      -

--- a/docs/demos/node-classification/index.rst
+++ b/docs/demos/node-classification/index.rst
@@ -103,7 +103,8 @@ This table lists all node classification demos, including the algorithms trained
      -
      -
      - yes
-   * - :doc:`Node2Vec <node2vec-node-classification>`
+   * - :doc:`Node2Vec (keras) <keras-node2vec-node-classification>`
+       :doc:`Node2Vec (gensim) <node2vec-node-classification>`
      - Node2Vec
      -
      -

--- a/scripts/demo_indexing.py
+++ b/scripts/demo_indexing.py
@@ -472,21 +472,18 @@ ALGORITHMS = [
         "Node2Vec",
         weighted=T(link="node-classification/node2vec-weighted-node-classification"),
         nc=[
+            T(text="via unsup.", details="via embedding vectors",),
             T(
-                text="via unsup. keras",
+                text="keras",
                 link="node-classification/keras-node2vec-node-classification",
-                details="via embedding vectors (keras layer)",
+                details="keras layer",
             ),
-            T(
-                text="via unsup. gensim",
-                link="node-classification/node2vec-node-classification",
-                details="via embedding vectors (gensim)",
-            ),
+            T(text="gensim", link="node-classification/node2vec-node-classification",),
         ],
         lp=via_rl(link="link-prediction/node2vec-link-prediction"),
         rl=[
             T(
-                text="keras layer",
+                text="keras",
                 link="embeddings/keras-node2vec-embeddings",
                 details="keras layer",
             ),

--- a/scripts/demo_indexing.py
+++ b/scripts/demo_indexing.py
@@ -471,14 +471,27 @@ ALGORITHMS = [
     Algorithm(
         "Node2Vec",
         weighted=T(link="node-classification/node2vec-weighted-node-classification"),
-        nc=via_rl(link="node-classification/node2vec-node-classification"),
+        nc=[
+            T(
+                text="via unsup. keras",
+                link="node-classification/keras-node2vec-node-classification",
+                details="via embedding vectors (keras layer)",
+            ),
+            T(
+                text="via unsup. gensim",
+                link="node-classification/node2vec-node-classification",
+                details="via embedding vectors (gensim)",
+            ),
+        ],
         lp=via_rl(link="link-prediction/node2vec-link-prediction"),
-        rl=T(link="embeddings/node2vec-embeddings"),
-    ),
-    Algorithm(
-        "Keras-Node2Vec",
-        nc=via_rl(link="node-classification/keras-node2vec-node-classification"),
-        rl=T(link="embeddings/keras-node2vec-embeddings"),
+        rl=[
+            T(
+                text="keras layer",
+                link="embeddings/keras-node2vec-embeddings",
+                details="keras layer",
+            ),
+            T(text="gensim", link="embeddings/node2vec-embeddings"),
+        ],
     ),
     Algorithm(
         "Metapath2Vec",

--- a/scripts/demo_indexing.py
+++ b/scripts/demo_indexing.py
@@ -472,7 +472,7 @@ ALGORITHMS = [
         "Node2Vec",
         weighted=T(link="node-classification/node2vec-weighted-node-classification"),
         nc=[
-            T(text="via unsup.", details="via embedding vectors",),
+            T(text="via", details="via embedding vectors",),
             T(
                 text="keras",
                 link="node-classification/keras-node2vec-node-classification",


### PR DESCRIPTION
see #1534

build docs for demo table:
  * https://stellargraph--1632.org.readthedocs.build/en/1632/demos/index.html

and demo node classification table:
  * https://stellargraph--1632.org.readthedocs.build/en/1632/demos/node-classification/index.html (here it gets a row for each, as the table is demo-centric)