### PR TITLE
Delete existing constraints and indexes in neo4j

### DIFF
--- a/demos/connector/neo4j/load-cora-into-neo4j.ipynb
+++ b/demos/connector/neo4j/load-cora-into-neo4j.ipynb
@@ -409,12 +409,34 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Load all nodes to the graph database."
+    "Delete any existing constraints or indexes in the current database."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "constraints = graph.run(\"CALL db.constraints\").data()\n",
+    "for constraint in constraints:\n",
+    "    graph.run(f\"DROP CONSTRAINT {constraint['name']}\")\n",
+    "\n",
+    "indexes = graph.run(\"CALL db.indexes\").data()\n",
+    "for index in indexes:\n",
+    "    graph.run(f\"DROP INDEX {index['name']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Load all nodes to the graph database."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -447,7 +469,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -479,7 +501,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
With #1595 the Neo4j cora loading notebook now creates a uniqueness constraint on node IDs, but this doesn't get cleaned up when rerunning the notebook, so the constraint creating cell will fail. This adds a new cell to check for any existing constraints and indexes and remove them.

See #1633
