### PR TITLE
Add neo4j components to api docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -222,7 +222,7 @@ Neo4j Connector
 ----------------
 
 .. automodule:: stellargraph.connector.neo4j
-  :members: Neo4jStellarGraph, Neo4jStellarDiGraph, Neo4JGraphSAGENodeGenerator, Neo4JDirectedGraphSAGENodeGenerator, Neo4jSampledBreadthFirstWalk, Neo4jDirectedBreadthFirstNeighbors
+  :members: Neo4jStellarGraph, Neo4jStellarDiGraph, Neo4JGraphSAGENodeGenerator, Neo4JDirectedGraphSAGENodeGenerator, Neo4JSampledBreadthFirstWalk, Neo4JDirectedBreadthFirstNeighbors
 
 
 Utilities

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -217,6 +217,14 @@ Calibration
 .. automodule:: stellargraph.calibration
   :members: expected_calibration_error, plot_reliability_diagram, TemperatureCalibration, IsotonicCalibration
 
+
+Neo4j Connector
+----------------
+
+.. automodule:: stellargraph.connector.neo4j
+  :members: Neo4jStellarGraph, Neo4jStellarDiGraph, Neo4jGraphSAGENodeGenerator, Neo4jDirectedGraphSAGENodeGenerator, Neo4jSampledBreadthFirstWalk, Neo4jDirectedBreadthFirstNeighbors
+
+
 Utilities
 ------------------------
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -222,7 +222,7 @@ Neo4j Connector
 ----------------
 
 .. automodule:: stellargraph.connector.neo4j
-  :members: Neo4jStellarGraph, Neo4jStellarDiGraph, Neo4jGraphSAGENodeGenerator, Neo4jDirectedGraphSAGENodeGenerator, Neo4jSampledBreadthFirstWalk, Neo4jDirectedBreadthFirstNeighbors
+  :members: Neo4jStellarGraph, Neo4jStellarDiGraph, Neo4JGraphSAGENodeGenerator, Neo4JDirectedGraphSAGENodeGenerator, Neo4jSampledBreadthFirstWalk, Neo4jDirectedBreadthFirstNeighbors
 
 
 Utilities

--- a/stellargraph/connector/neo4j/graph.py
+++ b/stellargraph/connector/neo4j/graph.py
@@ -357,9 +357,11 @@ class Neo4jStellarGraph:
     def unique_node_type(self, error_message=None):
         """
         Return the unique node type, for a homogeneous-node graph.
+
         Args:
             error_message (str, optional): a custom message to use for the exception; this can use
                 the ``%(found)s`` placeholder to insert the real sequence of node types.
+
         Returns:
             If this graph has only one node type, this returns that node type, otherwise it raises a
             ``ValueError`` exception.


### PR DESCRIPTION
This adds a section in our API docs to include all Neo4j related components.

Also only just realised the inconsistent upper/lowercase J for these classes https://github.com/stellargraph/stellargraph/issues/1637 - I can fix it here or in a separate PR after this

Docs for this PR: https://stellargraph--1636.org.readthedocs.build/en/1636/api.html#module-stellargraph.connector.neo4j

See #1635 