### PR TITLE
Rename GraphConvolutionLSTM to GCN_LSTM

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ The StellarGraph library currently includes the following algorithms for graph m
 | Continuous-Time Dynamic Network Embeddings (CTDNE) [16] | Supports time-respecting random walks which can be used in a similar way as in Node2Vec for unsupervised representation learning. |
 | DistMult [17] | The DistMult algorithm computes embeddings for nodes (entities) and edge types (relations) in knowledge graphs, and can use these for link prediction |
 | DGCNN [18] | The Deep Graph Convolutional Neural Network (DGCNN) algorithm for supervised graph classification. |
-| TGCN [19] | The GraphConvolutionLSTM model in StellarGraph follows the Temporal Graph Convolutional Network architecture proposed in the TGCN paper with a few enhancements in the layers architecture. |
+| TGCN [19] | The GCN_LSTM model in StellarGraph follows the Temporal Graph Convolutional Network architecture proposed in the TGCN paper with a few enhancements in the layers architecture. |
 
 ## Installation
 

--- a/demos/time-series/gcn-lstm-time-series.ipynb
+++ b/demos/time-series/gcn-lstm-time-series.ipynb
@@ -30,9 +30,9 @@
     "The architecture of the gcn-lstm model is inpired by the paper: [T-GCN: A Temporal Graph Convolutional Network for Traffic Prediction](https://ieeexplore.ieee.org/document/8809901).\n",
     "\n",
     "The authors have made available the implementation of their model in their github [repo](https://github.com/lehaifeng/T-GCN).\n",
-    "There has been a few differences in the architecture proposed in the paper and the implementation of the graph convolution component, these issues have been documented [here](https://github.com/lehaifeng/T-GCN/issues/18) and [here](https://github.com/lehaifeng/T-GCN/issues/14). The `GraphConvolutionLSTM` model in `StellarGraph`  emulates the model as explained in the paper while giving additional flexibility of adding any number of `graph convolution` and `LSTM` layers. \n",
+    "There has been a few differences in the architecture proposed in the paper and the implementation of the graph convolution component, these issues have been documented [here](https://github.com/lehaifeng/T-GCN/issues/18) and [here](https://github.com/lehaifeng/T-GCN/issues/14). The `GCN_LSTM` model in `StellarGraph`  emulates the model as explained in the paper while giving additional flexibility of adding any number of `graph convolution` and `LSTM` layers. \n",
     "\n",
-    "Concretely, the architecture of `GraphConvolutionLSTM` is as follows:\n",
+    "Concretely, the architecture of `GCN_LSTM` is as follows:\n",
     "\n",
     "1. User defined number of  graph convolutional layers (Reference: [Kipf & Welling (ICLR 2017)](http://arxiv.org/abs/1609.02907)).\n",
     "2. User defined number of  LSTM layers. The [TGCN](https://ieeexplore.ieee.org/document/8809901) uses GRU instead of LSTM. In practice there are not any remarkable differences between the two types of layers. We use LSTM as they are more frequently used.\n",
@@ -612,7 +612,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from stellargraph.layer import GraphConvolutionLSTM"
+    "from stellargraph.layer import GCN_LSTM"
    ]
   },
   {
@@ -621,7 +621,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gcn_lstm = GraphConvolutionLSTM(\n",
+    "gcn_lstm = GCN_LSTM(\n",
     "    seq_len=seq_len,\n",
     "    adj=sensor_dist_adj,\n",
     "    gc_layer_sizes=[16, 10],\n",

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -178,7 +178,7 @@ Deep Graph Convolutional Neural Network
 Graph Convolution LSTM
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. autoclass:: GraphConvolutionLSTM
+.. autoclass:: GCN_LSTM
   :members:
 
 .. autoclass:: FixedAdjacencyGraphConvolution

--- a/docs/demos/time-series/index.rst
+++ b/docs/demos/time-series/index.rst
@@ -19,7 +19,7 @@ This table lists all representation learning demos, including the algorithms tra
      - algorithm(s)
      - task
    * - :doc:`Graph Convolution + LSTM <gcn-lstm-time-series>`
-     - GraphConvolutionLSTM (T-GCN)
+     - GCN_LSTM (T-GCN)
      - traffic prediction
 
 See :doc:`the root README <../../README>` or each algorithm's documentation for the relevant citation(s). See :doc:`the demo index <../index>` for more tasks, and a summary of each algorithm.

--- a/stellargraph/layer/gcn_lstm.py
+++ b/stellargraph/layer/gcn_lstm.py
@@ -194,10 +194,10 @@ class FixedAdjacencyGraphConvolution(Layer):
 @experimental(
     reason="Lack of unit tests and code refinement", issues=[1132, 1526, 1564]
 )
-class GraphConvolutionLSTM:
+class GCN_LSTM:
 
     """
-    GraphConvolutionLSTM is a univariate timeseries forecasting method. The architecture  comprises of a stack of N1 Graph Convolutional layers followed by N2 LSTM layers, a Dropout layer, and  a Dense layer.
+    GCN_LSTM is a univariate timeseries forecasting method. The architecture  comprises of a stack of N1 Graph Convolutional layers followed by N2 LSTM layers, a Dropout layer, and  a Dense layer.
     This main components of GNN architecture is inspired by: T-GCN: A Temporal Graph Convolutional Network for Traffic Prediction (https://arxiv.org/abs/1811.05320).
     The implementation of the above paper is based on one graph convolution layer stacked with a GRU layer.
     The StellarGraph implementation is built as a stack of the following set of layers:
@@ -258,7 +258,7 @@ class GraphConvolutionLSTM:
         else:
             variates = None
 
-        super(GraphConvolutionLSTM, self).__init__()
+        super(GCN_LSTM, self).__init__()
 
         n_gc_layers = len(gc_layer_sizes)
         n_lstm_layers = len(lstm_layer_sizes)

--- a/tests/layer/test_gcn_lstm.py
+++ b/tests/layer/test_gcn_lstm.py
@@ -19,7 +19,7 @@ import pandas as pd
 import pytest
 from tensorflow.keras import Model
 from stellargraph import StellarGraph, IndexedArray
-from stellargraph.layer import GraphConvolutionLSTM
+from stellargraph.layer import GCN_LSTM
 from stellargraph.layer import FixedAdjacencyGraphConvolution
 from stellargraph.mapper import SlidingFeaturesNodeGenerator
 
@@ -52,7 +52,7 @@ def test_GraphConvolution_config():
 def test_gcn_lstm_model_parameters():
     fx, fy, a = get_timeseries_graph_data()
 
-    gcn_lstm_model = GraphConvolutionLSTM(
+    gcn_lstm_model = GCN_LSTM(
         seq_len=fx.shape[-2],
         adj=a,
         gc_layer_sizes=[2, 2],
@@ -70,7 +70,7 @@ def test_gcn_lstm_model_parameters():
 def test_gcn_lstm_activations():
     fx, fy, a = get_timeseries_graph_data()
 
-    gcn_lstm_model = GraphConvolutionLSTM(
+    gcn_lstm_model = GCN_LSTM(
         seq_len=fx.shape[-2],
         adj=a,
         gc_layer_sizes=[10, 10, 10, 10, 10],
@@ -80,7 +80,7 @@ def test_gcn_lstm_activations():
     assert gcn_lstm_model.gc_activations == ["relu", "relu", "relu", "relu", "relu"]
     assert gcn_lstm_model.lstm_activations == ["tanh", "tanh", "tanh", "tanh"]
 
-    gcn_lstm_model = GraphConvolutionLSTM(
+    gcn_lstm_model = GCN_LSTM(
         seq_len=fx.shape[-2],
         adj=a,
         gc_layer_sizes=[10],
@@ -94,7 +94,7 @@ def test_gcn_lstm_activations():
 def test_lstm_return_sequences():
     fx, fy, a = get_timeseries_graph_data()
 
-    gcn_lstm_model = GraphConvolutionLSTM(
+    gcn_lstm_model = GCN_LSTM(
         seq_len=fx.shape[-2],
         adj=a,
         gc_layer_sizes=[16, 16, 16],
@@ -110,7 +110,7 @@ def test_lstm_return_sequences():
 def test_gcn_lstm_layers():
     fx, fy, a = get_timeseries_graph_data()
 
-    gcn_lstm_model = GraphConvolutionLSTM(
+    gcn_lstm_model = GCN_LSTM(
         seq_len=fx.shape[-2],
         adj=a,
         gc_layer_sizes=[8, 8, 16],
@@ -126,7 +126,7 @@ def test_gcn_lstm_layers():
 def test_gcn_lstm_model_input_output():
     fx, fy, a = get_timeseries_graph_data()
 
-    gcn_lstm_model = GraphConvolutionLSTM(
+    gcn_lstm_model = GCN_LSTM(
         seq_len=fx.shape[-1],
         adj=a,
         gc_layer_sizes=[8, 8, 16],
@@ -145,7 +145,7 @@ def test_gcn_lstm_model_input_output():
 def test_gcn_lstm_model():
     fx, fy, a = get_timeseries_graph_data()
 
-    gcn_lstm_model = GraphConvolutionLSTM(
+    gcn_lstm_model = GCN_LSTM(
         seq_len=fx.shape[-1],
         adj=a,
         gc_layer_sizes=[8, 8, 16],
@@ -169,7 +169,7 @@ def test_gcn_lstm_model():
 def test_gcn_lstm_model_prediction():
     fx, fy, a = get_timeseries_graph_data()
 
-    gcn_lstm_model = GraphConvolutionLSTM(
+    gcn_lstm_model = GCN_LSTM(
         seq_len=fx.shape[-1],
         adj=a,
         gc_layer_sizes=[8, 8, 16],
@@ -199,7 +199,7 @@ def test_gcn_lstm_generator(multivariate):
     graph = StellarGraph(nodes, edges)
 
     gen = SlidingFeaturesNodeGenerator(graph, 2, batch_size=3)
-    gcn_lstm = GraphConvolutionLSTM(None, None, [2], [4], generator=gen)
+    gcn_lstm = GCN_LSTM(None, None, [2], [4], generator=gen)
 
     model = Model(*gcn_lstm.in_out_tensors())
 


### PR DESCRIPTION
The GraphConvolutionLSTM class's name is a bit unconventional: it makes it sounds like it's an extension of the GraphConvolution layer, rather than the GCN model.

See: #1642