### PR TITLE
enable container logs for neo4j notebook tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -139,6 +139,8 @@ steps:
         run: runner-3_6
         env:
           - STELLARGRAPH_NEO4J_HOST=neo4j
+        upload-container-logs: always
+
     env:
       RUNNER_DEPENDS_ON: neo4j
       NEO4J_VERSION: "4.0"


### PR DESCRIPTION
Enable container logs to aid Neo4j troubleshooting in CI, eg: https://buildkite.com/stellar/stellargraph-public/builds/4597#0535365a-98da-4459-90e0-1f200b8e0608

See: #1648