### PR TITLE
Sort edge type triple for undirected graph info

### DIFF
--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -1344,6 +1344,14 @@ class StellarGraph:
                 "weight": self._edges.weights,
             }
         )
+
+        # if graph is undirected and edges exist, we want to sort the triple
+        if not self.is_directed() and len(df):
+            sorted_types = df.apply(
+                lambda r: sorted([r.src_ty, r.tgt_ty]) + [r.rel_ty], axis=1
+            )
+            df[["src_ty", "tgt_ty", "rel_ty"]] = pd.DataFrame(sorted_types.tolist())
+
         return df.groupby(["src_ty", "rel_ty", "tgt_ty"]).agg(metrics)["weight"]
 
     def info(self, show_attributes=None, sample=None, truncate=20):

--- a/stellargraph/core/graph.py
+++ b/stellargraph/core/graph.py
@@ -1345,12 +1345,11 @@ class StellarGraph:
             }
         )
 
-        # if graph is undirected and edges exist, we want to sort the triple
-        if not self.is_directed() and len(df):
-            sorted_types = df.apply(
-                lambda r: sorted([r.src_ty, r.tgt_ty]) + [r.rel_ty], axis=1
-            )
-            df[["src_ty", "tgt_ty", "rel_ty"]] = pd.DataFrame(sorted_types.tolist())
+        # if graph is undirected, we want to sort the triple
+        if not self.is_directed():
+            sorted_types = df[["src_ty", "tgt_ty"]].to_numpy()
+            sorted_types.sort(axis=1)
+            df[["src_ty", "tgt_ty"]] = sorted_types
 
         return df.groupby(["src_ty", "rel_ty", "tgt_ty"]).agg(metrics)["weight"]
 

--- a/tests/core/test_graph.py
+++ b/tests/core/test_graph.py
@@ -1393,10 +1393,7 @@ StellarGraph: Undirected multigraph
     Edge types: B-F->B, B-R->A
 
  Edge types:
-    A-R->B: [3]
-        Weights: all 1 (default)
-        Features: float32 vector, length 56
-    B-R->A: [2]
+    A-R->B: [5]
         Weights: all 1 (default)
         Features: float32 vector, length 56
     B-F->B: [1]
@@ -1422,11 +1419,11 @@ StellarGraph: Undirected multigraph
     Edge types: B-T->A, B-U->A
 
  Edge types:
+    A-U->B: [3]
+        Weights: range=[4, 5], mean=4.66667, std=0.57735
+        Features: none
     A-T->B: [3]
         Weights: all 2
-        Features: none
-    A-U->B: [2]
-        Weights: range=[4, 5], mean=4.5, std=0.707107
         Features: none
     A-U->A: [2]
         Weights: range=[2, 3], mean=2.5, std=0.707107
@@ -1436,9 +1433,6 @@ StellarGraph: Undirected multigraph
         Features: none
     A-R->A: [2]
         Weights: all 1 (default)
-        Features: none
-    B-U->A: [1]
-        Weights: all 5
         Features: none"""
     )
 


### PR DESCRIPTION
This adds a check when collecting metrics for edge type triples for graph info, so that if the graph is undirected, we sort each type triple. 

~I think the edge types in the "Node types" section might still be incorrect~ NVM seems it was already doing the right thing. So in the "Node types" section, the arrow is always pointing outward from the node type.

See #1312 