### PR TITLE
Replace all Neo4J with Neo4j

### DIFF
--- a/demos/connector/neo4j/directed-graphsage-on-cora-neo4j-example.ipynb
+++ b/demos/connector/neo4j/directed-graphsage-on-cora-neo4j-example.ipynb
@@ -190,8 +190,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To feed data from the graph to the Keras model we need a data generator
-    that feeds data from the graph to the model. The generators are specialized to the model and the learning task so we choose the `Neo4jDirectedGraphSAGENodeGenerator` as we are predicting node attributes with a `DirectedGraphSAGE` model, sampling directly from Neo4j database.\n",
+    "To feed data from the graph to the Keras model we need a data generator that feeds data from the graph to the model. The generators are specialized to the model and the learning task so we choose the `Neo4jDirectedGraphSAGENodeGenerator` as we are predicting node attributes with a `DirectedGraphSAGE` model, sampling directly from Neo4j database.\n",
     "\n",
     "We need two other parameters, the `batch_size` to use for training and the number of nodes to sample at each level of the model. Here we choose a two-level model with 10 nodes sampled in the first layer (5 in-nodes and 5 out-nodes), and 4 in the second layer (2 in-nodes and 2 out-nodes)."
    ]

--- a/demos/connector/neo4j/directed-graphsage-on-cora-neo4j-example.ipynb
+++ b/demos/connector/neo4j/directed-graphsage-on-cora-neo4j-example.ipynb
@@ -78,7 +78,7 @@
     "import os\n",
     "\n",
     "import stellargraph as sg\n",
-    "from stellargraph.connector.neo4j import Neo4JDirectedGraphSAGENodeGenerator, Neo4jStellarDiGraph\n",
+    "from stellargraph.connector.neo4j import Neo4jDirectedGraphSAGENodeGenerator, Neo4jStellarDiGraph\n",
     "from stellargraph.layer import DirectedGraphSAGE\n",
     "\n",
     "from tensorflow.keras import layers, optimizers, losses, metrics, Model\n",
@@ -190,7 +190,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To feed data from the graph to the Keras model we need a data generator that feeds data from the graph to the model. The generators are specialized to the model and the learning task so we choose the `Neo4JDirectedGraphSAGENodeGenerator` as we are predicting node attributes with a `DirectedGraphSAGE` model, sampling directly from Neo4j database.\n",
+    "To feed data from the graph to the Keras model we need a data generator
+    that feeds data from the graph to the model. The generators are specialized to the model and the learning task so we choose the `Neo4jDirectedGraphSAGENodeGenerator` as we are predicting node attributes with a `DirectedGraphSAGE` model, sampling directly from Neo4j database.\n",
     "\n",
     "We need two other parameters, the `batch_size` to use for training and the number of nodes to sample at each level of the model. Here we choose a two-level model with 10 nodes sampled in the first layer (5 in-nodes and 5 out-nodes), and 4 in the second layer (2 in-nodes and 2 out-nodes)."
    ]
@@ -215,7 +216,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A `Neo4JDirectedGraphSAGENodeGenerator` object is required to send the node features in sampled subgraphs to Keras."
+    "A `Neo4jDirectedGraphSAGENodeGenerator` object is required to send the node features in sampled subgraphs to Keras."
    ]
   },
   {
@@ -224,7 +225,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "generator = Neo4JDirectedGraphSAGENodeGenerator(\n",
+    "generator = Neo4jDirectedGraphSAGENodeGenerator(\n",
     "    neo4j_sg, batch_size, in_samples, out_samples\n",
     ")"
    ]

--- a/demos/connector/neo4j/undirected-graphsage-on-cora-neo4j-example.ipynb
+++ b/demos/connector/neo4j/undirected-graphsage-on-cora-neo4j-example.ipynb
@@ -77,7 +77,7 @@
     "import os\n",
     "\n",
     "import stellargraph as sg\n",
-    "from stellargraph.connector.neo4j import Neo4JGraphSAGENodeGenerator, Neo4jStellarGraph\n",
+    "from stellargraph.connector.neo4j import Neo4jGraphSAGENodeGenerator, Neo4jStellarGraph\n",
     "from stellargraph.layer import GraphSAGE\n",
     "\n",
     "import numpy as np\n",
@@ -190,7 +190,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To feed data from the graph to the Keras model we need a data generator that feeds data from the graph to the model. The generators are specialized to the model and the learning task so we choose the `Neo4JGraphSAGENodeGenerator` as we are predicting node attributes with a GraphSAGE model, sampling directly from Neo4j database.\n",
+    "To feed data from the graph to the Keras model we need a data generator that feeds data from the graph to the model. The generators are specialized to the model and the learning task so we choose the `Neo4jGraphSAGENodeGenerator` as we are predicting node attributes with a GraphSAGE model, sampling directly from Neo4j database.\n",
     "\n",
     "We need two other parameters, the `batch_size` to use for training and the number of nodes to sample at each level of the model. Here we choose a two-level model with 10 nodes sampled in the first layer, and 5 in the second."
    ]
@@ -214,7 +214,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A `Neo4JGraphSAGENodeGenerator` object is required to send the node features in sampled subgraphs to Keras."
+    "A `Neo4jGraphSAGENodeGenerator` object is required to send the node features in sampled subgraphs to Keras."
    ]
   },
   {
@@ -223,7 +223,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "generator = Neo4JGraphSAGENodeGenerator(neo4j_sg, batch_size, num_samples)"
+    "generator = Neo4jGraphSAGENodeGenerator(neo4j_sg, batch_size, num_samples)"
    ]
   },
   {

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -222,7 +222,7 @@ Neo4j Connector
 ----------------
 
 .. automodule:: stellargraph.connector.neo4j
-  :members: Neo4jStellarGraph, Neo4jStellarDiGraph, Neo4JGraphSAGENodeGenerator, Neo4JDirectedGraphSAGENodeGenerator, Neo4JSampledBreadthFirstWalk, Neo4JDirectedBreadthFirstNeighbors
+  :members: Neo4jStellarGraph, Neo4jStellarDiGraph, Neo4jGraphSAGENodeGenerator, Neo4jDirectedGraphSAGENodeGenerator, Neo4jSampledBreadthFirstWalk, Neo4jDirectedBreadthFirstNeighbors
 
 
 Utilities

--- a/stellargraph/connector/neo4j/mapper.py
+++ b/stellargraph/connector/neo4j/mapper.py
@@ -15,16 +15,16 @@
 # limitations under the License.
 
 __all__ = [
-    "Neo4JGraphSAGENodeGenerator",
-    "Neo4JDirectedGraphSAGENodeGenerator",
+    "Neo4jGraphSAGENodeGenerator",
+    "Neo4jDirectedGraphSAGENodeGenerator",
 ]
 
 import numpy as np
 import random
 
 from .sampler import (
-    Neo4JDirectedBreadthFirstNeighbors,
-    Neo4JSampledBreadthFirstWalk,
+    Neo4jDirectedBreadthFirstNeighbors,
+    Neo4jSampledBreadthFirstWalk,
 )
 
 from ...core.graph import GraphSchema
@@ -35,7 +35,7 @@ from .graph import Neo4jStellarGraph
 
 
 @experimental(reason="the class is not fully tested")
-class Neo4JBatchedNodeGenerator:
+class Neo4jBatchedNodeGenerator:
     """
     Abstract base class for graph data generators from Neo4j.
 
@@ -77,7 +77,7 @@ class Neo4JBatchedNodeGenerator:
 
 
 @experimental(reason="the class is not fully tested")
-class Neo4JGraphSAGENodeGenerator(Neo4JBatchedNodeGenerator):
+class Neo4jGraphSAGENodeGenerator(Neo4jBatchedNodeGenerator):
     """
     A data generator for node prediction with Homogeneous GraphSAGE models
 
@@ -110,7 +110,7 @@ class Neo4JGraphSAGENodeGenerator(Neo4JBatchedNodeGenerator):
 
         # check that there is only a single node type for GraphSAGE
 
-        self.sampler = Neo4JSampledBreadthFirstWalk(graph)
+        self.sampler = Neo4jSampledBreadthFirstWalk(graph)
 
     def sample_features(self, head_nodes, batch_num):
         """
@@ -151,7 +151,7 @@ class Neo4JGraphSAGENodeGenerator(Neo4JBatchedNodeGenerator):
 
 
 @experimental(reason="the class is not fully tested")
-class Neo4JDirectedGraphSAGENodeGenerator(Neo4JBatchedNodeGenerator):
+class Neo4jDirectedGraphSAGENodeGenerator(Neo4jBatchedNodeGenerator):
     """
     A data generator for node prediction with homogeneous GraphSAGE models
     on directed graphs.
@@ -190,7 +190,7 @@ class Neo4JDirectedGraphSAGENodeGenerator(Neo4JBatchedNodeGenerator):
         self.name = name
 
         # Create sampler for GraphSAGE
-        self.sampler = Neo4JDirectedBreadthFirstNeighbors(graph)
+        self.sampler = Neo4jDirectedBreadthFirstNeighbors(graph)
 
     def sample_features(self, head_nodes, batch_num):
         """

--- a/stellargraph/connector/neo4j/sampler.py
+++ b/stellargraph/connector/neo4j/sampler.py
@@ -15,8 +15,8 @@
 # limitations under the License.
 
 __all__ = [
-    "Neo4JSampledBreadthFirstWalk",
-    "Neo4JDirectedBreadthFirstNeighbors",
+    "Neo4jSampledBreadthFirstWalk",
+    "Neo4jDirectedBreadthFirstNeighbors",
 ]
 
 from ...core.experimental import experimental
@@ -67,7 +67,7 @@ def _bfs_neighbor_query(sampling_direction, id_property, node_label=None):
 
 
 @experimental(reason="the class is not fully tested")
-class Neo4JSampledBreadthFirstWalk:
+class Neo4jSampledBreadthFirstWalk:
     """
     Breadth First Walk that generates a sampled number of paths from a starting node.
     It can be used to extract a random sub-graph starting from a set of initial nodes from Neo4j database.
@@ -116,7 +116,7 @@ class Neo4JSampledBreadthFirstWalk:
 
 
 @experimental(reason="the class is not fully tested")
-class Neo4JDirectedBreadthFirstNeighbors:
+class Neo4jDirectedBreadthFirstNeighbors:
     """
     Breadth First Walk that generates a sampled number of paths from a starting node.
     It can be used to extract a random sub-graph starting from a set of initial nodes from Neo4j database.

--- a/stellargraph/layer/graphsage.py
+++ b/stellargraph/layer/graphsage.py
@@ -48,8 +48,8 @@ from ..mapper import (
 
 from .misc import deprecated_model_function
 from ..connector.neo4j.mapper import (
-    Neo4JGraphSAGENodeGenerator,
-    Neo4JDirectedGraphSAGENodeGenerator,
+    Neo4jGraphSAGENodeGenerator,
+    Neo4jDirectedGraphSAGENodeGenerator,
 )
 
 
@@ -891,7 +891,7 @@ class GraphSAGE:
             (
                 GraphSAGENodeGenerator,
                 GraphSAGELinkGenerator,
-                Neo4JGraphSAGENodeGenerator,
+                Neo4jGraphSAGENodeGenerator,
             ),
         ):
             errmsg = "Generator should be an instance of GraphSAGENodeGenerator or GraphSAGELinkGenerator"
@@ -1132,7 +1132,7 @@ class DirectedGraphSAGE(GraphSAGE):
             (
                 DirectedGraphSAGENodeGenerator,
                 DirectedGraphSAGELinkGenerator,
-                Neo4JDirectedGraphSAGENodeGenerator,
+                Neo4jDirectedGraphSAGENodeGenerator,
             ),
         ):
             errmsg = "Generator should be an instance of DirectedGraphSAGENodeGenerator"


### PR DESCRIPTION
This replaces instances of Neo4J spelt with a capital "J" with the lowercase "j" version for neo4j-related components in the library.

docs: https://stellargraph--1651.org.readthedocs.build/en/1651/api.html#module-stellargraph.connector.neo4j

See #1637 