### PR TITLE
delay Neo4j notebooks in CI to wait for Neo4j startup with graphdatascience plugin (#1648)

### DIFF
--- a/.buildkite/steps/test-neo4j-notebooks.sh
+++ b/.buildkite/steps/test-neo4j-notebooks.sh
@@ -21,6 +21,7 @@ notebooks=(
   "cluster-gcn-on-cora-neo4j-example.ipynb"
 )
 
+echo "--- :hourglass::neo4j: waiting for neo4j startup"
 # delay to wait for Neo4j startup with plugins (fix for #1648)
 sleep 10s
 

--- a/.buildkite/steps/test-neo4j-notebooks.sh
+++ b/.buildkite/steps/test-neo4j-notebooks.sh
@@ -21,6 +21,9 @@ notebooks=(
   "cluster-gcn-on-cora-neo4j-example.ipynb"
 )
 
+# delay to wait for Neo4j startup with plugins (fix for #1648)
+sleep 10s
+
 for name in "${notebooks[@]}"; do
   .buildkite/steps/test-single-notebook.sh "$directory/$name" " using Neo4j ${NEO4J_VERSION}"
 done


### PR DESCRIPTION
Delay the start of Neo4J notebooks to allow extra Neo4j startup time with the graphdatascience plugin

See: #1648