### PR TITLE
Add support for edge weights to GraphSAGE sampling

### DIFF
--- a/demos/README.md
+++ b/demos/README.md
@@ -172,7 +172,7 @@ These demos are displayed with detailed descriptions in the documentation: https
     <td>GraphSAGE</td>
     <td>see HinSAGE</td>
     <td><a href='node-classification/directed-graphsage-node-classification.ipynb'>demo</a></td>
-    <td></td>
+    <td>yes</td>
     <td></td>
     <td>yes</td>
     <td><a href='node-classification/graphsage-node-classification.ipynb'>demo</a></td>

--- a/docs/demos/index.rst
+++ b/docs/demos/index.rst
@@ -176,7 +176,7 @@ Find a demo for an algorithm
      - GraphSAGE
      - see HinSAGE
      - :any:`demo <node-classification/directed-graphsage-node-classification>`
-     -
+     - yes
      -
      - yes
      - :any:`demo <node-classification/graphsage-node-classification>`

--- a/scripts/demo_indexing.py
+++ b/scripts/demo_indexing.py
@@ -450,6 +450,7 @@ ALGORITHMS = [
         "GraphSAGE",
         heterogeneous="see HinSAGE",
         directed=T(link="node-classification/directed-graphsage-node-classification"),
+        weighted=True,
         features=True,
         nc=T(link="node-classification/graphsage-node-classification"),
         lp=T(link="link-prediction/graphsage-link-prediction"),

--- a/stellargraph/data/explorer.py
+++ b/stellargraph/data/explorer.py
@@ -721,7 +721,7 @@ class SampledHeterogeneousBreadthFirstWalk(GraphWalk):
                 q.extend([(node, node_type, 0)])
 
                 # add the root node to the walks
-                walk.append([node])
+                walk.append(np.array([node]))
                 while len(q) > 0:
                     # remove the top element in the queue and pop the item from the front of the list
                     frontier = q.pop(0)
@@ -746,7 +746,7 @@ class SampledHeterogeneousBreadthFirstWalk(GraphWalk):
                                 samples = rs.choice(neigh_et, size=n_size[depth - 1])
                             else:  # this doesn't happen anymore, see the comment above
                                 _size = n_size[depth - 1]
-                                samples = [-1] * _size
+                                samples = np.full(_size, -1)
 
                             walk.append(samples)
                             q.extend(

--- a/stellargraph/data/explorer.py
+++ b/stellargraph/data/explorer.py
@@ -60,7 +60,7 @@ class RandomWalk(ABC):
             raise TypeError("Graph must be a StellarGraph or StellarDiGraph.")
 
         self.graph = graph
-        self._random_state, self._np_random_state = random_state(seed)
+        _, self._np_random_state = random_state(seed)
 
     def _get_random_state(self, seed):
         """
@@ -72,10 +72,10 @@ class RandomWalk(ABC):
         """
         if seed is None:
             # Restore the random state
-            return self._random_state
+            return self._np_random_state
         # seed the random number generator
         require_integer_in_range(seed, "seed", min_val=0)
-        rs, _ = random_state(seed)
+        _, rs = random_state(seed)
         return rs
 
     @staticmethod
@@ -107,7 +107,7 @@ class GraphWalk(object):
 
         # Initialize the random state
         self._check_seed(seed)
-        self._random_state, self._np_random_state = random_state(seed)
+        _, self._np_random_state = random_state(seed)
 
         # We require a StellarGraph for this
         if not isinstance(graph, StellarGraph):
@@ -154,9 +154,9 @@ class GraphWalk(object):
         """
         if seed is None:
             # Use the class's random state
-            return self._random_state
+            return self._np_random_state
         # seed the random number generator
-        rs, _ = random_state(seed)
+        _, rs = random_state(seed)
         return rs
 
     def neighbors(self, node):
@@ -669,7 +669,7 @@ class SampledBreadthFirstWalk(GraphWalk):
                         neighbours = [-1] * _size
                     else:
                         # sample with replacement
-                        neighbours = rs.choices(neighbours, k=n_size[cur_depth])
+                        neighbours = rs.choice(neighbours, size=n_size[cur_depth])
 
                     # add them to the back of the queue
                     q.extend((sampled_node, depth) for sampled_node in neighbours)
@@ -743,7 +743,7 @@ class SampledHeterogeneousBreadthFirstWalk(GraphWalk):
                             # In case of no neighbours of the current node for et, neigh_et == [None],
                             # and samples automatically becomes [None]*n_size[depth-1]
                             if len(neigh_et) > 0:
-                                samples = rs.choices(neigh_et, k=n_size[depth - 1])
+                                samples = rs.choice(neigh_et, size=n_size[depth - 1])
                             else:  # this doesn't happen anymore, see the comment above
                                 _size = n_size[depth - 1]
                                 samples = [-1] * _size
@@ -886,7 +886,7 @@ class DirectedBreadthFirstNeighbours(GraphWalk):
             # Sampling from empty neighbourhood
             return [-1] * size
         # Sample with replacement
-        return rs.choices(neighbours, k=size)
+        return rs.choice(neighbours, size=size)
 
     def _check_neighbourhood_sizes(self, in_size, out_size):
         """
@@ -1034,7 +1034,7 @@ class TemporalRandomWalk(GraphWalk):
                 f"max_walk_length: maximum walk length should not be less than the context window size, found {max_walk_length}"
             )
 
-        np_rs = self._np_random_state if seed is None else np.random.RandomState(seed)
+        np_rs = self._get_random_state(seed)
         walks = []
         num_cw_curr = 0
 

--- a/stellargraph/data/explorer.py
+++ b/stellargraph/data/explorer.py
@@ -231,7 +231,9 @@ class GraphWalk(object):
             if type(d) != int or d < 0:
                 self._raise_error(err_msg)
 
-    def _sample_neighbours_untyped(self, neigh_func, py_and_np_rs, cur_node, size, weighted):
+    def _sample_neighbours_untyped(
+        self, neigh_func, py_and_np_rs, cur_node, size, weighted
+    ):
         """
         Sample ``size`` neighbours of ``cur_node`` without checking node types or edge types, optionally
         using edge weights.

--- a/stellargraph/data/explorer.py
+++ b/stellargraph/data/explorer.py
@@ -329,7 +329,8 @@ def naive_weighted_choices(rs, weights, size=None):
     does a lot of conversions/checks/preprocessing internally.
     """
     probs = np.cumsum(weights)
-    idx = np.searchsorted(probs, rs.random(size) * probs[-1], side="left")
+    thresholds = rs.random() if size is None else rs.random(size)
+    idx = np.searchsorted(probs, thresholds * probs[-1], side="left")
 
     return idx
 

--- a/stellargraph/mapper/sampled_link_generators.py
+++ b/stellargraph/mapper/sampled_link_generators.py
@@ -439,11 +439,11 @@ class HinSAGELinkGenerator(BatchedLinkGenerator):
                 [
                     (
                         nt,
-                        reduce(
-                            operator.concat,
-                            (samples[ks] for samples in node_samples for ks in indices),
-                            [],
-                        ),
+                        np.concatenate(
+                            [samples[ks] for samples in node_samples for ks in indices]
+                        )
+                        if indices
+                        else np.array([], dtype=np.uint8),
                     )
                     for nt, indices in self._sampling_schema[ii]
                 ]
@@ -451,7 +451,7 @@ class HinSAGELinkGenerator(BatchedLinkGenerator):
 
         # Interlace the two lists, nodes_by_type[0] (for src head nodes) and nodes_by_type[1] (for dst head nodes)
         nodes_by_type = [
-            tuple((ab[0][0], reduce(operator.concat, (ab[0][1], ab[1][1]))))
+            (ab[0][0], np.concatenate([ab[0][1], ab[1][1]]))
             for ab in zip(nodes_by_type[0], nodes_by_type[1])
         ]
 

--- a/stellargraph/mapper/sampled_link_generators.py
+++ b/stellargraph/mapper/sampled_link_generators.py
@@ -439,11 +439,11 @@ class HinSAGELinkGenerator(BatchedLinkGenerator):
                 [
                     (
                         nt,
-                        np.concatenate(
-                            [samples[ks] for samples in node_samples for ks in indices]
-                        )
-                        if indices
-                        else np.array([], dtype=np.uint8),
+                        reduce(
+                            operator.concat,
+                            (samples[ks] for samples in node_samples for ks in indices),
+                            [],
+                        ),
                     )
                     for nt, indices in self._sampling_schema[ii]
                 ]
@@ -451,7 +451,7 @@ class HinSAGELinkGenerator(BatchedLinkGenerator):
 
         # Interlace the two lists, nodes_by_type[0] (for src head nodes) and nodes_by_type[1] (for dst head nodes)
         nodes_by_type = [
-            (ab[0][0], np.concatenate([ab[0][1], ab[1][1]]))
+            tuple((ab[0][0], reduce(operator.concat, (ab[0][1], ab[1][1]))))
             for ab in zip(nodes_by_type[0], nodes_by_type[1])
         ]
 

--- a/stellargraph/mapper/sampled_link_generators.py
+++ b/stellargraph/mapper/sampled_link_generators.py
@@ -221,13 +221,17 @@ class GraphSAGELinkGenerator(BatchedLinkGenerator):
         batch_size (int): Size of batch of links to return.
         num_samples (list): List of number of neighbour node samples per GraphSAGE layer (hop) to take.
         seed (int or str), optional: Random seed for the sampling methods.
+        weighted (bool, optional): If True, sample neighbours using the edge weights in the graph.
     """
 
-    def __init__(self, G, batch_size, num_samples, seed=None, name=None):
+    def __init__(
+        self, G, batch_size, num_samples, seed=None, name=None, weighted=False
+    ):
         super().__init__(G, batch_size)
 
         self.num_samples = num_samples
         self.name = name
+        self.weighted = weighted
 
         # Check that there is only a single node type for GraphSAGE
         if len(self.schema.node_types) > 1:
@@ -285,7 +289,7 @@ class GraphSAGELinkGenerator(BatchedLinkGenerator):
         batch_feats = []
         for hns in zip(*head_links):
             node_samples = self._samplers[batch_num].run(
-                nodes=hns, n=1, n_size=self.num_samples
+                nodes=hns, n=1, n_size=self.num_samples, weighted=self.weighted
             )
 
             nodes_per_hop = get_levels(0, 1, self.num_samples, node_samples)
@@ -582,14 +586,25 @@ class DirectedGraphSAGELinkGenerator(BatchedLinkGenerator):
         out_samples (list): The number of out-node samples per layer (hop) to take.
         seed (int or str), optional: Random seed for the sampling methods.
         name, optional: Name of generator.
+        weighted (bool, optional): If True, sample neighbours using the edge weights in the graph.
     """
 
-    def __init__(self, G, batch_size, in_samples, out_samples, seed=None, name=None):
+    def __init__(
+        self,
+        G,
+        batch_size,
+        in_samples,
+        out_samples,
+        seed=None,
+        name=None,
+        weighted=False,
+    ):
         super().__init__(G, batch_size)
 
         self.in_samples = in_samples
         self.out_samples = out_samples
         self._name = name
+        self.weighted = weighted
 
         # Check that there is only a single node type for GraphSAGE
         if len(self.schema.node_types) > 1:
@@ -631,7 +646,11 @@ class DirectedGraphSAGELinkGenerator(BatchedLinkGenerator):
         for hns in zip(*head_links):
 
             node_samples = self._samplers[batch_num].run(
-                nodes=hns, n=1, in_size=self.in_samples, out_size=self.out_samples
+                nodes=hns,
+                n=1,
+                in_size=self.in_samples,
+                out_size=self.out_samples,
+                weighted=self.weighted,
             )
 
             # Reshape node samples to sensible format

--- a/stellargraph/mapper/sampled_node_generators.py
+++ b/stellargraph/mapper/sampled_node_generators.py
@@ -476,11 +476,11 @@ class HinSAGENodeGenerator(BatchedNodeGenerator):
         nodes_by_type = [
             (
                 nt,
-                np.concatenate(
-                    [samples[ks] for samples in node_samples for ks in indices]
-                )
-                if indices
-                else np.array([], dtype=np.uint8),
+                reduce(
+                    operator.concat,
+                    (samples[ks] for samples in node_samples for ks in indices),
+                    [],
+                ),
             )
             for nt, indices in self._sampling_schema[0]
         ]

--- a/stellargraph/mapper/sampled_node_generators.py
+++ b/stellargraph/mapper/sampled_node_generators.py
@@ -478,7 +478,9 @@ class HinSAGENodeGenerator(BatchedNodeGenerator):
                 nt,
                 np.concatenate(
                     [samples[ks] for samples in node_samples for ks in indices]
-                ),
+                )
+                if indices
+                else np.array([], dtype=np.uint8),
             )
             for nt, indices in self._sampling_schema[0]
         ]

--- a/stellargraph/mapper/sampled_node_generators.py
+++ b/stellargraph/mapper/sampled_node_generators.py
@@ -476,10 +476,8 @@ class HinSAGENodeGenerator(BatchedNodeGenerator):
         nodes_by_type = [
             (
                 nt,
-                reduce(
-                    operator.concat,
-                    (samples[ks] for samples in node_samples for ks in indices),
-                    [],
+                np.concatenate(
+                    [samples[ks] for samples in node_samples for ks in indices]
                 ),
             )
             for nt, indices in self._sampling_schema[0]

--- a/stellargraph/mapper/sampled_node_generators.py
+++ b/stellargraph/mapper/sampled_node_generators.py
@@ -200,14 +200,18 @@ class GraphSAGENodeGenerator(BatchedNodeGenerator):
         batch_size (int): Size of batch to return.
         num_samples (list): The number of samples per layer (hop) to take.
         seed (int): [Optional] Random seed for the node sampler.
+        weighted (bool, optional): If True, sample neighbours using the edge weights in the graph.
     """
 
-    def __init__(self, G, batch_size, num_samples, seed=None, name=None):
+    def __init__(
+        self, G, batch_size, num_samples, seed=None, name=None, weighted=False
+    ):
         super().__init__(G, batch_size)
 
         self.num_samples = num_samples
         self.head_node_types = self.schema.node_types
         self.name = name
+        self.weighted = weighted
 
         # Check that there is only a single node type for GraphSAGE
         if len(self.head_node_types) > 1:
@@ -241,7 +245,7 @@ class GraphSAGENodeGenerator(BatchedNodeGenerator):
             for that layer.
         """
         node_samples = self._samplers[batch_num].run(
-            nodes=head_nodes, n=1, n_size=self.num_samples
+            nodes=head_nodes, n=1, n_size=self.num_samples, weighted=self.weighted
         )
 
         # The number of samples for each head node (not including itself)
@@ -304,9 +308,19 @@ class DirectedGraphSAGENodeGenerator(BatchedNodeGenerator):
         in_samples (list): The number of in-node samples per layer (hop) to take.
         out_samples (list): The number of out-node samples per layer (hop) to take.
         seed (int): [Optional] Random seed for the node sampler.
+        weighted (bool, optional): If True, sample neighbours using the edge weights in the graph.
     """
 
-    def __init__(self, G, batch_size, in_samples, out_samples, seed=None, name=None):
+    def __init__(
+        self,
+        G,
+        batch_size,
+        in_samples,
+        out_samples,
+        seed=None,
+        name=None,
+        weighted=False,
+    ):
         super().__init__(G, batch_size)
 
         # TODO Add checks for in- and out-nodes sizes
@@ -314,6 +328,7 @@ class DirectedGraphSAGENodeGenerator(BatchedNodeGenerator):
         self.out_samples = out_samples
         self.head_node_types = self.schema.node_types
         self.name = name
+        self.weighted = weighted
 
         # Check that there is only a single node type for GraphSAGE
         if len(self.head_node_types) > 1:
@@ -350,7 +365,11 @@ class DirectedGraphSAGENodeGenerator(BatchedNodeGenerator):
             given the sequence of in/out directions.
         """
         node_samples = self.sampler.run(
-            nodes=head_nodes, n=1, in_size=self.in_samples, out_size=self.out_samples
+            nodes=head_nodes,
+            n=1,
+            in_size=self.in_samples,
+            out_size=self.out_samples,
+            weighted=self.weighted,
         )
 
         # Reshape node samples to sensible format

--- a/tests/data/test_biased_random_walker.py
+++ b/tests/data/test_biased_random_walker.py
@@ -150,6 +150,14 @@ class TestBiasedWeightedRandomWalk(object):
             == 4
         )
 
+        # all zero-weight edges
+        g = weighted(0, 0, 0, 0)
+        biasedrw = BiasedRandomWalk(g)
+        walks = biasedrw.run(nodes=nodes, n=2, p=p, q=q, length=3, weighted=True)
+        assert len(walks) == 8
+        for walk in walks:
+            assert len(walk) == 1
+
         # negative edge
         g = weighted(1, -2, 3, 4)
 

--- a/tests/data/test_breadth_first_walker.py
+++ b/tests/data/test_breadth_first_walker.py
@@ -18,8 +18,13 @@ import pandas as pd
 import pytest
 import numpy as np
 from stellargraph.data.explorer import SampledBreadthFirstWalk
-from stellargraph.core.graph import StellarDiGraph
-from ..test_utils.graphs import create_test_graph, tree_graph, example_graph_random
+from stellargraph.core.graph import StellarGraph, StellarDiGraph
+from ..test_utils.graphs import (
+    create_test_graph,
+    tree_graph,
+    example_graph_random,
+    weighted_tree,
+)
 
 
 def expected_bfw_size(n_size):
@@ -539,7 +544,8 @@ class TestBreadthFirstWalk(object):
         assert len(w0) == len(w1)
         assert w0 == w1
 
-    def test_benchmark_bfs_walk(self, benchmark):
+    @pytest.mark.parametrize("weighted", [False, True])
+    def test_benchmark_bfs_walk(self, benchmark, weighted):
         g = example_graph_random(n_nodes=100, n_edges=500)
         bfw = SampledBreadthFirstWalk(g)
 
@@ -547,4 +553,11 @@ class TestBreadthFirstWalk(object):
         n = 5
         n_size = [5, 5]
 
-        benchmark(lambda: bfw.run(nodes=nodes, n=n, n_size=n_size))
+        benchmark(lambda: bfw.run(nodes=nodes, n=n, n_size=n_size, weighted=weighted))
+
+    def test_weighted(self):
+        g, checker = weighted_tree()
+        bfw = SampledBreadthFirstWalk(g)
+        walks = bfw.run(nodes=[0], n=10, n_size=[20, 20], weighted=True)
+
+        checker(node_id for walk in walks for node_id in walk)

--- a/tests/data/test_breadth_first_walker.py
+++ b/tests/data/test_breadth_first_walker.py
@@ -561,3 +561,18 @@ class TestBreadthFirstWalk(object):
         walks = bfw.run(nodes=[0], n=10, n_size=[20, 20], weighted=True)
 
         checker(node_id for walk in walks for node_id in walk)
+
+    def test_weighted_all_zero(self):
+        edges = pd.DataFrame({"source": [0, 0], "target": [1, 2], "weight": [0.0, 0]})
+
+        g = StellarGraph(edges=edges)
+        bfw = SampledBreadthFirstWalk(g)
+        walks = bfw.run(
+            nodes=[0], n=10, n_size=[20, 20], weighted=True
+        )
+
+        assert len(walks) == 10
+        for walk in walks:
+            assert len(walk) == 1 + 20 + 20 * 20
+            assert walk[0] == 0
+            np.testing.assert_array_equal(walk[1:], -1)

--- a/tests/data/test_breadth_first_walker.py
+++ b/tests/data/test_breadth_first_walker.py
@@ -567,9 +567,7 @@ class TestBreadthFirstWalk(object):
 
         g = StellarGraph(edges=edges)
         bfw = SampledBreadthFirstWalk(g)
-        walks = bfw.run(
-            nodes=[0], n=10, n_size=[20, 20], weighted=True
-        )
+        walks = bfw.run(nodes=[0], n=10, n_size=[20, 20], weighted=True)
 
         assert len(walks) == 10
         for walk in walks:

--- a/tests/data/test_directed_breadth_first_sampler.py
+++ b/tests/data/test_directed_breadth_first_sampler.py
@@ -16,6 +16,7 @@
 
 import random
 import pytest
+import pandas as pd
 import numpy as np
 from stellargraph.data.explorer import DirectedBreadthFirstNeighbours
 from stellargraph.core.graph import StellarDiGraph
@@ -259,3 +260,19 @@ class TestDirectedBreadthFirstNeighbours(object):
         )
 
         checker(node_id for walk in walks for hop in walk for node_id in hop)
+
+    def test_weighted_all_zero(self):
+        edges = pd.DataFrame({"source": [0, 0], "target": [1, 2], "weight": [0.0, 0]})
+
+        g = StellarDiGraph(edges=edges)
+        bfw = DirectedBreadthFirstNeighbours(g)
+        walks = bfw.run(
+            nodes=[0], n=10, in_size=[20, 20], out_size=[20, 20], weighted=True
+        )
+
+        assert len(walks) == 10
+        for walk in walks:
+            assert len(walk) == 7
+            assert walk[0] == [0]
+            for hop in walk:
+                np.testing.assert_array_equal(hop[1:], -1)

--- a/tests/data/test_directed_breadth_first_sampler.py
+++ b/tests/data/test_directed_breadth_first_sampler.py
@@ -19,7 +19,12 @@ import pytest
 import numpy as np
 from stellargraph.data.explorer import DirectedBreadthFirstNeighbours
 from stellargraph.core.graph import StellarDiGraph
-from ..test_utils.graphs import create_test_graph, tree_graph, example_graph_random
+from ..test_utils.graphs import (
+    create_test_graph,
+    tree_graph,
+    example_graph_random,
+    weighted_tree,
+)
 
 
 class TestDirectedBreadthFirstNeighbours(object):
@@ -229,7 +234,8 @@ class TestDirectedBreadthFirstNeighbours(object):
             assert len(subgraph[0][13]) == out_size[0] * out_size[1] * in_size[2]
             assert len(subgraph[0][14]) == out_size[0] * out_size[1] * out_size[2]
 
-    def test_benchmark_bfs_walk(self, benchmark):
+    @pytest.mark.parametrize("weighted", [False, True])
+    def test_benchmark_bfs_walk(self, benchmark, weighted):
         g = example_graph_random(n_nodes=100, n_edges=500, is_directed=True)
         bfw = DirectedBreadthFirstNeighbours(g)
 
@@ -238,4 +244,18 @@ class TestDirectedBreadthFirstNeighbours(object):
         in_size = [5, 5]
         out_size = [5, 5]
 
-        benchmark(lambda: bfw.run(nodes=nodes, n=n, in_size=in_size, out_size=out_size))
+        benchmark(
+            lambda: bfw.run(
+                nodes=nodes, n=n, in_size=in_size, out_size=out_size, weighted=weighted
+            )
+        )
+
+    def test_weighted(self):
+        g, checker = weighted_tree(is_directed=True)
+
+        bfw = DirectedBreadthFirstNeighbours(g)
+        walks = bfw.run(
+            nodes=[0], n=10, in_size=[20, 20], out_size=[20, 20], weighted=True
+        )
+
+        checker(node_id for walk in walks for hop in walk for node_id in hop)

--- a/tests/data/test_heterogeneous_breadth_first_walker.py
+++ b/tests/data/test_heterogeneous_breadth_first_walker.py
@@ -199,7 +199,7 @@ class TestSampledHeterogeneousBreadthFirstWalk(object):
         assert len(subgraphs) == 1
         assert len(subgraphs[0]) == 9
         for level in subgraphs[0]:
-            assert type(level) == np.ndarray
+            assert type(level) == list
             if len(level) > 0:
                 # All values should be rood_node_id or None
                 for value in level:
@@ -219,7 +219,7 @@ class TestSampledHeterogeneousBreadthFirstWalk(object):
         )
 
         for level in subgraphs2[0]:
-            assert type(level) == np.ndarray
+            assert type(level) == list
             if len(level) > 0:
                 for value in level:
                     assert (value == nodes[0]) or (value == -1)

--- a/tests/data/test_heterogeneous_breadth_first_walker.py
+++ b/tests/data/test_heterogeneous_breadth_first_walker.py
@@ -199,7 +199,7 @@ class TestSampledHeterogeneousBreadthFirstWalk(object):
         assert len(subgraphs) == 1
         assert len(subgraphs[0]) == 9
         for level in subgraphs[0]:
-            assert type(level) == list
+            assert type(level) == np.ndarray
             if len(level) > 0:
                 # All values should be rood_node_id or None
                 for value in level:
@@ -219,7 +219,7 @@ class TestSampledHeterogeneousBreadthFirstWalk(object):
         )
 
         for level in subgraphs2[0]:
-            assert type(level) == list
+            assert type(level) == np.ndarray
             if len(level) > 0:
                 for value in level:
                     assert (value == nodes[0]) or (value == -1)

--- a/tests/mapper/test_directed_node_generator.py
+++ b/tests/mapper/test_directed_node_generator.py
@@ -19,6 +19,8 @@ import pandas as pd
 from stellargraph.mapper import DirectedGraphSAGENodeGenerator
 from stellargraph.core.graph import StellarDiGraph
 
+from ..test_utils.graphs import weighted_tree
+
 
 # FIXME (#535): Consider using graph fixtures
 def create_simple_graph():
@@ -228,3 +230,11 @@ class TestDirectedNodeGenerator(object):
                 assert out_features[idx, 0, 0] == 0.0
             else:
                 assert False
+
+    def test_weighted(self):
+        g, checker = weighted_tree(is_directed=True)
+
+        gen = DirectedGraphSAGENodeGenerator(g, 7, [5, 3], [5, 3], weighted=True)
+        samples = gen.flow([0] * 10)
+
+        checker(node_id for array in samples[0][0] for node_id in array.ravel())

--- a/tests/mapper/test_link_mappers.py
+++ b/tests/mapper/test_link_mappers.py
@@ -41,6 +41,7 @@ from ..test_utils.graphs import (
     example_graph_random,
     example_hin_1,
     repeated_features,
+    weighted_tree,
 )
 from .. import test_utils
 
@@ -408,6 +409,13 @@ class Test_GraphSAGELinkGenerator:
 
         with pytest.raises(IndexError):
             nf, nl = mapper[8]
+
+    def test_weighted(self):
+        g, checker = weighted_tree()
+
+        gen = GraphSAGELinkGenerator(g, 7, [10, 5], weighted=True)
+        samples = gen.flow([(0, 0)] * 10)
+        checker(node_id for array in samples[0][0] for node_id in array.ravel())
 
 
 class Test_HinSAGELinkGenerator(object):
@@ -1231,3 +1239,10 @@ class Test_DirectedGraphSAGELinkGenerator:
                     == nf[2 * ii + 1].shape
                     == (min(self.batch_size, mapper.data_size), dim, self.n_feat)
                 )
+
+    def test_weighted(self):
+        g, checker = weighted_tree(is_directed=True)
+
+        gen = DirectedGraphSAGELinkGenerator(g, 7, [5, 3], [5, 3], weighted=True)
+        samples = gen.flow([(0, 0)] * 10)
+        checker(node_id for array in samples[0][0] for node_id in array.ravel())

--- a/tests/mapper/test_node_mappers.py
+++ b/tests/mapper/test_node_mappers.py
@@ -34,6 +34,7 @@ from ..test_utils.graphs import (
     example_hin_1,
     create_graph_features,
     repeated_features,
+    weighted_tree,
 )
 from .. import test_utils
 
@@ -351,6 +352,15 @@ def test_nodemapper_incorrect_targets():
         GraphSAGENodeGenerator(G, batch_size=n_batch, num_samples=[0]).flow(
             list(G.nodes()), targets=[]
         )
+
+
+def test_nodemapper_weighted():
+    g, checker = weighted_tree()
+
+    gen = GraphSAGENodeGenerator(g, 7, [10, 6], weighted=True)
+    samples = gen.flow([0] * 10)
+
+    checker(node_id for array in samples[0][0] for node_id in array.ravel())
 
 
 def test_hinnodemapper_constructor():

--- a/tests/test_utils/graphs.py
+++ b/tests/test_utils/graphs.py
@@ -375,3 +375,35 @@ def weighted_hin():
     )
 
     return StellarGraph(nodes={"A": a, "B": b}, edges={"R": r, "S": s, "T": t, "U": u})
+
+
+def weighted_tree(is_directed=False):
+    # a binary tree:
+    # 0---1--3
+    # |   |
+    # |   4
+    # 2--5
+    # |
+    # 6
+    nodes = repeated_features(range(7), 3)
+    edges = pd.DataFrame(
+        {
+            "source": [0, 0, 1, 1, 2, 2],
+            "target": [1, 2, 3, 4, 5, 6],
+            "weight": [1.0, 5, 20, 1, 1, 0],
+        }
+    )
+    cls = StellarDiGraph if is_directed else StellarGraph
+
+    def check_occurrence(sequence):
+        from collections import Counter
+
+        occurrence = Counter(sequence)
+        # 0--2 has higher weight than 0--1
+        assert occurrence[2] > occurrence[1]
+        # 1--3 has higher weight than 1--4
+        assert occurrence[3] > occurrence[4]
+        # 2--6 has 0 weight (i.e. should never be taken)
+        assert 6 not in occurrence
+
+    return cls(nodes, edges), check_occurrence


### PR DESCRIPTION
This expands GraphSAGE (undirected and directed) to support weighted sampling, where edges with higher weights are taken proportionally more often.

For example, suppose there's there's 4 edges from node A:

| source | target | weight |
|---|---|---|
| A | B | 0 |
| A | C | 1 |
| A | D | 2 |
| A | D | 3 |

An unweighed walk starting at A will choose each of the edges with equal propability and so end up on B, C or D in proportion 1:1:2 (edge counts). A weighted walk will choose the edges proportional to the weights, so end up on the vertices in proportion 0:1:5 (sum of edge weight). (Worth specifically highlighting: a weighted walk will never chose the A-B edge because it has weight 0.)

See: #462