### PR TITLE
Reduce chance of disconnected components in random graph test

### DIFF
--- a/tests/mapper/test_node_mappers.py
+++ b/tests/mapper/test_node_mappers.py
@@ -296,8 +296,9 @@ def test_nodemapper_isolated_nodes():
     n_feat = 4
     n_batch = 2
 
-    # test graph
-    G = example_graph_random(feature_size=n_feat, n_nodes=6, n_isolates=1, n_edges=20)
+    # test graph (a lot of edges between the 5 non-isolated nodes, to ensure they're a single
+    # connected component)
+    G = example_graph_random(feature_size=n_feat, n_nodes=6, n_isolates=1, n_edges=1000)
 
     # Check connectedness
     Gnx = G.to_networkx()


### PR DESCRIPTION
This `test_nodemapper_isolated_nodes` test creates a graph with 5 nodes (0, 1, 2, 3, 4) being connected by 20 edges and a single isolated node (5). The test checks that the graph has 2 connected components, that is, the first 5 nodes are connected and the last node is separate. With only 20 edges, this fails very occasionally, because the randomness will sometimes miss a node or have separate clumps.

This PR ups the number of edges to 1000 to exponentially reduce the chance of the graph having more than 2 connected components.

See: #1569