### PR TITLE
xfail flaky tests for more reliable CI

### DIFF
--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -23,6 +23,7 @@ import pytest
 import numpy as np
 
 from stellargraph.core.utils import *
+from ..test_utils import flaky_xfail_mark
 from ..test_utils.graphs import example_graph_random
 
 
@@ -198,6 +199,7 @@ def test_normalize_adj(example_graph):
     assert csr.get_shape() == Aadj.get_shape()
 
 
+@flaky_xfail_mark(AssertionError, 1160)
 def test_normalized_laplacian(example_graph):
     Aadj = example_graph.to_adjacency_matrix()
     laplacian = normalized_laplacian(Aadj).todense()

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -184,6 +184,7 @@ def test_smart_array_concatenate_broadcast():
         _check_smart_concatenate([a0, c43])
 
 
+@flaky_xfail_mark(AssertionError, 1678)
 def test_normalize_adj(example_graph):
     node_list = list(example_graph.nodes())
     Aadj = example_graph.to_adjacency_matrix()

--- a/tests/data/test_edge_splitter.py
+++ b/tests/data/test_edge_splitter.py
@@ -25,6 +25,7 @@ import random
 import datetime
 from datetime import datetime, timedelta
 
+from ..test_utils import flaky_xfail_mark
 from ..test_utils.graphs import example_graph_random
 
 
@@ -283,6 +284,7 @@ class TestEdgeSplitterHomogeneous(object):
 
 
 class TestEdgeSplitterHeterogeneous(object):
+    @flaky_xfail_mark(ValueError, 585)
     def test_split_data_by_edge_type_and_attribute(self, heterogeneous_graph):
         g, es_obj = heterogeneous_graph
         # test global method for negative edge sampling
@@ -444,6 +446,7 @@ class TestEdgeSplitterHeterogeneous(object):
                 edge_attribute_threshold="01/01/2008",
             )
 
+    @flaky_xfail_mark(ValueError, 585)
     def test_split_data_by_edge_type(self, heterogeneous_graph):
         g, es_obj = heterogeneous_graph
         # test global method for negative edge sampling

--- a/tests/layer/test_knowledge_graph.py
+++ b/tests/layer/test_knowledge_graph.py
@@ -158,6 +158,7 @@ def test_distmult(knowledge_graph):
     assert np.array_equal(prediction, prediction2)
 
 
+@test_utils.flaky_xfail_mark(AssertionError, 1623)
 def test_rotate(knowledge_graph):
     margin = 2.34
     norm_order = 1.234

--- a/tests/layer/test_knowledge_graph.py
+++ b/tests/layer/test_knowledge_graph.py
@@ -286,7 +286,16 @@ def test_rote_roth(knowledge_graph, model_class):
     np.testing.assert_array_equal(prediction, prediction2)
 
 
-@pytest.mark.parametrize("model_maker", [ComplEx, DistMult, RotatE, RotH, RotE])
+@pytest.mark.parametrize(
+    "model_maker",
+    [
+        ComplEx,
+        DistMult,
+        RotatE,
+        pytest.param(RotH, marks=test_utils.flaky_xfail_mark(AssertionError, 1675)),
+        RotE,
+    ],
+)
 def test_model_rankings(model_maker):
     nodes = pd.DataFrame(index=["a", "b", "c", "d"])
     rels = ["W", "X", "Y", "Z"]

--- a/tests/layer/test_knowledge_graph.py
+++ b/tests/layer/test_knowledge_graph.py
@@ -291,7 +291,7 @@ def test_rote_roth(knowledge_graph, model_class):
     [
         ComplEx,
         DistMult,
-        RotatE,
+        pytest.param(RotatE, marks=test_utils.flaky_xfail_mark(AssertionError, 1623)),
         pytest.param(RotH, marks=test_utils.flaky_xfail_mark(AssertionError, 1675)),
         RotE,
     ],

--- a/tests/reproducibility/test_graphsage.py
+++ b/tests/reproducibility/test_graphsage.py
@@ -25,6 +25,7 @@ from stellargraph.mapper.sampled_link_generators import GraphSAGELinkGenerator
 from stellargraph.layer.graphsage import GraphSAGE
 from stellargraph.layer.link_inference import link_classification
 from stellargraph.random import set_seed
+from ..test_utils import flaky_xfail_mark
 from ..test_utils.graphs import petersen_graph
 from .fixtures import assert_reproducible
 from .. import require_gpu
@@ -208,6 +209,7 @@ def gs_link_prediction(
 
 
 @pytest.mark.parametrize("shuffle", [True, False])
+@flaky_xfail_mark(AssertionError, 1115)
 def test_unsupervised(petersen_graph, shuffle):
     assert_reproducible(
         lambda: unsup_gs(
@@ -222,7 +224,9 @@ def test_unsupervised(petersen_graph, shuffle):
     )
 
 
-@pytest.mark.parametrize("shuffle", [True, False])
+@pytest.mark.parametrize(
+    "shuffle", [pytest.param(True, marks=flaky_xfail_mark(AssertionError, 1115)), False],
+)
 @pytest.mark.skipif(require_gpu, reason="tf on GPU is non-deterministic")
 def test_nai(petersen_graph, shuffle):
     target_size = 10
@@ -233,9 +237,8 @@ def test_nai(petersen_graph, shuffle):
         )
     )
 
-
-# FIXME (#970): This test fails intermittently with shuffle=True
-@pytest.mark.parametrize("shuffle", [False])
+@flaky_xfail_mark(AssertionError, [970, 990])
+@pytest.mark.parametrize("shuffle", [True, False])
 def test_link_prediction(petersen_graph, shuffle):
     num_examples = 10
     edge_ids = np.random.choice(petersen_graph.nodes(), size=(num_examples, 2))

--- a/tests/reproducibility/test_graphsage.py
+++ b/tests/reproducibility/test_graphsage.py
@@ -225,7 +225,8 @@ def test_unsupervised(petersen_graph, shuffle):
 
 
 @pytest.mark.parametrize(
-    "shuffle", [pytest.param(True, marks=flaky_xfail_mark(AssertionError, 1115)), False],
+    "shuffle",
+    [pytest.param(True, marks=flaky_xfail_mark(AssertionError, 1115)), False],
 )
 @pytest.mark.skipif(require_gpu, reason="tf on GPU is non-deterministic")
 def test_nai(petersen_graph, shuffle):
@@ -236,6 +237,7 @@ def test_nai(petersen_graph, shuffle):
             petersen_graph, targets, [2, 2], tf.optimizers.Adam(1e-3), shuffle=shuffle
         )
     )
+
 
 @flaky_xfail_mark(AssertionError, [970, 990])
 @pytest.mark.parametrize("shuffle", [True, False])

--- a/tests/reproducibility/test_graphsage.py
+++ b/tests/reproducibility/test_graphsage.py
@@ -224,10 +224,8 @@ def test_unsupervised(petersen_graph, shuffle):
     )
 
 
-@pytest.mark.parametrize(
-    "shuffle",
-    [pytest.param(True, marks=flaky_xfail_mark(AssertionError, 1115)), False],
-)
+@pytest.mark.parametrize("shuffle", [True, False])
+@flaky_xfail_mark(AssertionError, 1115)
 @pytest.mark.skipif(require_gpu, reason="tf on GPU is non-deterministic")
 def test_nai(petersen_graph, shuffle):
     target_size = 10

--- a/tests/test_utils/__init__.py
+++ b/tests/test_utils/__init__.py
@@ -20,3 +20,23 @@ import pytest
 ignore_stellargraph_experimental_mark = pytest.mark.filterwarnings(
     r"ignore:StellarGraph\(nodes=..., edges=...\):stellargraph.core.experimental.ExperimentalWarning"
 )
+
+
+def flaky_xfail_mark(exception, issue_numbers):
+    """
+    A mark for a test that occasionally fails with the given exception, associated with one or more
+    issues in issue_numbers.
+    """
+    if isinstance(issue_numbers, int):
+        issue_numbers = [issue_numbers]
+
+    if not issue_numbers:
+        raise ValueError(
+            "at least one issue must be specified when marking a test as flaky"
+        )
+
+    issues = " ".join(
+        f"<https://github.com/stellargraph/stellargraph/issues/{num}>"
+        for num in issue_numbers
+    )
+    return pytest.mark.xfail(raises=exception, reason=f"flaky: {issues}")


### PR DESCRIPTION
This adds [an xfail marker `pytest.mark.xfail`](https://docs.pytest.org/en/5.4.3/skipping.html#xfail-mark-test-functions-as-expected-to-fail) to several tests that are flaky. These tests fail semi-regularly on CI requiring a lot of retried builds, and, for the most part, don't catch much.

The mark is added using a function that requires that several things are specified:

- issue numbers which are linked in the `reason`; which makes it easier to keep track of why/how things are flaky
- an exception class which is the form of the xfail, so that the test still catches basic problems like invalid code (e.g. renaming functions or properties)

Issues for flaky tests (found by https://github.com/stellargraph/stellargraph/issues?q=is%3Aissue+is%3Aopen+flaky):

- #585: `tests/data/test_edge_splitter.py`: `test_split_data_by_edge_type_and_attribute`, `test_split_data_by_edge_type`
- #970: `tests/reproducibility/test_graphsage.py`: `test_link_prediction[True]`
- #990: `tests/reproducibility/test_graphsage.py`: `test_link_prediction[False]`
- #1115: `tests/reproducibility/test_graphsage.py`: `test_unsupervised[False]`, `test_unsupervised[True]`, `test_nai[True]`, `test_nai[False]`
- #1160: `tests/core/test_utils.py`:`test_normalized_laplacian`
- #1623: `tests/layer/test_knowledge_graph.py`: `test_rotate`, `test_model_rankings[RotatE]`
- #1675: `tests/layer/test_knowledge_graph.py`: `test_model_rankings[RotH]`

This PR doesn't include #1569 (`tests/mapper/test_node_mappers.py`: `test_nodemapper_isolated_nodes`), because that's fixed, not xfailed, independently in #1672.