### PR TITLE
Add tests for saving and loading every model

### DIFF
--- a/tests/layer/test_appnp.py
+++ b/tests/layer/test_appnp.py
@@ -291,7 +291,13 @@ def test_APPNP_apply_propagate_model_sparse():
     assert preds_1 == pytest.approx(preds_2)
 
 
-@pytest.mark.parametrize("sparse", [False, True])
+@pytest.mark.parametrize(
+    "sparse",
+    [
+        pytest.param(False, marks=pytest.mark.xfail(reason="FIXME #1680")),
+        pytest.param(True, marks=pytest.mark.xfail(reason="FIXME #1251")),
+    ],
+)
 def test_APPNP_save_load(tmpdir, sparse):
     G, _ = create_graph_features()
     generator = FullBatchNodeGenerator(G, sparse=sparse)

--- a/tests/layer/test_appnp.py
+++ b/tests/layer/test_appnp.py
@@ -25,6 +25,7 @@ import numpy as np
 from tensorflow import keras
 import pytest
 from ..test_utils.graphs import create_graph_features
+from .. import test_utils
 
 
 def test_APPNP_edge_cases():
@@ -288,3 +289,11 @@ def test_APPNP_apply_propagate_model_sparse():
     assert preds_2.shape == (1, 2, 2)
 
     assert preds_1 == pytest.approx(preds_2)
+
+
+@pytest.mark.parametrize("sparse", [False, True])
+def test_APPNP_save_load(tmpdir, sparse):
+    G, _ = create_graph_features()
+    generator = FullBatchNodeGenerator(G, sparse=sparse)
+    appnp = APPNP([2, 3], generator, ["relu", "relu"])
+    test_utils.model_save_load(tmpdir, appnp)

--- a/tests/layer/test_attri2vec.py
+++ b/tests/layer/test_attri2vec.py
@@ -168,3 +168,16 @@ def test_attri2vec_serialize():
 
     actual = model2.predict(x)
     assert expected == pytest.approx(actual)
+
+
+def test_attri2vec_save_load(tmpdir):
+    attri2vec = Attri2Vec(
+        layer_sizes=[4],
+        bias=True,
+        input_dim=2,
+        node_num=4,
+        multiplicity=2,
+        activation="linear",
+        normalize=None,
+    )
+    test_utils.model_save_load(tmpdir, attri2vec)

--- a/tests/layer/test_cluster_gcn.py
+++ b/tests/layer/test_cluster_gcn.py
@@ -30,6 +30,7 @@ from tensorflow import keras
 import tensorflow as tf
 import pytest
 from ..test_utils.graphs import create_graph_features
+from .. import test_utils
 
 
 def test_ClusterGCN_init():
@@ -156,3 +157,12 @@ def test_kernel_and_bias_defaults():
             assert layer.bias_regularizer is None
             assert layer.kernel_constraint is None
             assert layer.bias_constraint is None
+
+
+def test_ClusterGCN_save_load(tmpdir):
+    G, _ = create_graph_features()
+    generator = ClusterNodeGenerator(G)
+    cluster_gcn = ClusterGCN(
+        layer_sizes=[2, 3], activations=["relu", "relu"], generator=generator
+    )
+    test_utils.model_save_load(tmpdir, cluster_gcn)

--- a/tests/layer/test_deep_graph_infomax.py
+++ b/tests/layer/test_deep_graph_infomax.py
@@ -18,7 +18,7 @@ from stellargraph.layer import *
 from stellargraph.mapper import *
 
 from ..test_utils.graphs import example_graph_random
-from .. import require_gpu
+from .. import require_gpu, test_utils
 import tensorflow as tf
 import pytest
 import numpy as np
@@ -162,3 +162,12 @@ def test_dgi_deprecated_no_generator():
         DeepGraphInfomax(
             GCN(generator=generator, activations=["relu"], layer_sizes=[4]),
         )
+
+
+@pytest.mark.parametrize("model_type", [GCN, GraphSAGE, HinSAGE])
+def test_dgi_save_load(tmpdir, model_type):
+    base_generator, base_model, nodes = _model_data(model_type, sparse=False)
+    corrupted_generator = CorruptedGenerator(base_generator)
+    infomax = DeepGraphInfomax(base_model, corrupted_generator)
+
+    test_utils.model_save_load(tmpdir, infomax)

--- a/tests/layer/test_gcn.py
+++ b/tests/layer/test_gcn.py
@@ -20,6 +20,7 @@ GCN tests
 
 """
 
+import stellargraph as sg
 from stellargraph.layer.gcn import *
 from stellargraph.mapper import FullBatchNodeGenerator, FullBatchLinkGenerator
 from stellargraph.core.graph import StellarGraph
@@ -32,6 +33,7 @@ from tensorflow import keras
 import tensorflow as tf
 import pytest
 from ..test_utils.graphs import create_graph_features
+from .. import test_utils
 
 
 def test_GraphConvolution_config():
@@ -309,3 +311,11 @@ def test_kernel_and_bias_defaults():
             assert layer.bias_regularizer is None
             assert layer.kernel_constraint is None
             assert layer.bias_constraint is None
+
+
+@pytest.mark.parametrize("sparse", [False, True])
+def test_gcn_save_load(tmpdir, sparse):
+    G, _ = create_graph_features()
+    generator = FullBatchNodeGenerator(G, sparse=sparse)
+    gcn = GCN([2, 3], generator)
+    test_utils.model_save_load(tmpdir, gcn)

--- a/tests/layer/test_gcn.py
+++ b/tests/layer/test_gcn.py
@@ -313,7 +313,9 @@ def test_kernel_and_bias_defaults():
             assert layer.bias_constraint is None
 
 
-@pytest.mark.parametrize("sparse", [False, True])
+@pytest.mark.parametrize(
+    "sparse", [False, pytest.param(True, marks=pytest.mark.xfail(reason="FIXME #1251"))]
+)
 def test_gcn_save_load(tmpdir, sparse):
     G, _ = create_graph_features()
     generator = FullBatchNodeGenerator(G, sparse=sparse)

--- a/tests/layer/test_gcn_lstm.py
+++ b/tests/layer/test_gcn_lstm.py
@@ -217,6 +217,7 @@ def test_gcn_lstm_generator(arange_graph):
     np.testing.assert_array_equal(predictions, predictions2)
 
 
+@pytest.mark.xfail(reason="FIXME #1681")
 def test_gcn_lstm_save_load(tmpdir, arange_graph):
     gen = SlidingFeaturesNodeGenerator(arange_graph, 2, batch_size=3)
     gcn_lstm = GCN_LSTM(None, None, [2], [4], generator=gen)

--- a/tests/layer/test_graph_attention.py
+++ b/tests/layer/test_graph_attention.py
@@ -609,6 +609,18 @@ class Test_GAT:
                 assert layer.bias_constraint is None
                 assert layer.attn_kernel_constraint is None
 
+    def test_save_load(self, tmpdir):
+        graph = example_graph(feature_size=self.F_in)
+        gen = FullBatchNodeGenerator(graph, sparse=self.sparse, method=self.method)
+        gat = GAT(
+            layer_sizes=self.layer_sizes,
+            activations=self.activations,
+            attn_heads=self.attn_heads,
+            generator=gen,
+        )
+
+        test_utils.model_save_load(tmpdir, gat)
+
 
 def TestGATsparse(Test_GAT):
     sparse = True

--- a/tests/layer/test_graph_classification.py
+++ b/tests/layer/test_graph_classification.py
@@ -21,6 +21,7 @@ from stellargraph.layer import SortPooling
 from stellargraph.mapper import PaddedGraphGenerator, FullBatchNodeGenerator
 import pytest
 from ..test_utils.graphs import example_graph_random
+from .. import test_utils
 
 
 graphs = [
@@ -217,3 +218,13 @@ def test_dgcnn_smoke():
 
     preds = model.predict(generator.flow([0, 1, 2]))
     assert preds.shape == (3, (2 + 3 + 4) * 5, 1)
+
+
+def test_save_load(tmpdir):
+    layer_sizes = [16, 8]
+    activations = ["relu", "relu"]
+
+    model = GCNSupervisedGraphClassification(
+        layer_sizes=layer_sizes, activations=activations, generator=generator
+    )
+    test_utils.model_save_load(tmpdir, model)

--- a/tests/layer/test_graphsage.py
+++ b/tests/layer/test_graphsage.py
@@ -698,3 +698,8 @@ def test_kernel_and_bias_defaults():
         assert layer.bias_regularizer is None
         assert layer.kernel_constraint is None
         assert layer.bias_constraint is None
+
+
+def test_graphsage_save_load(tmpdir):
+    gs = GraphSAGE(layer_sizes=[4, 4], n_samples=[2, 2], input_dim=2, multiplicity=1)
+    test_utils.model_save_load(tmpdir, gs)

--- a/tests/layer/test_hinsage.py
+++ b/tests/layer/test_hinsage.py
@@ -28,6 +28,7 @@ from stellargraph import StellarGraph
 from stellargraph.layer.hinsage import *
 from stellargraph.mapper import *
 from ..test_utils.graphs import example_hin_1
+from .. import test_utils
 
 
 def test_mean_hin_agg_constructor():
@@ -635,3 +636,18 @@ def test_kernel_and_bias_defaults():
             assert layer.bias_regularizer is None
             assert layer.kernel_constraint is None
             assert layer.bias_constraint is None
+
+
+def test_hinsage_save_load(tmpdir):
+    G = example_hin_1({"A": 8, "B": 4})
+
+    gen = HinSAGENodeGenerator(G, 1, [2, 2], "A")
+
+    hs = HinSAGE(
+        layer_sizes=[2, 2],
+        generator=gen,
+        normalize="none",
+        activations=["relu", "relu"],
+    )
+
+    test_utils.model_save_load(tmpdir, hs)

--- a/tests/layer/test_knowledge_graph.py
+++ b/tests/layer/test_knowledge_graph.py
@@ -49,6 +49,11 @@ pytestmark = [
 ]
 
 
+@pytest.fixture(params=[ComplEx, DistMult, RotatE, RotH, RotE])
+def model_maker(request):
+    return request.param
+
+
 def triple_df(*values):
     return pd.DataFrame(values, columns=["source", "label", "target"])
 
@@ -285,7 +290,6 @@ def test_rote_roth(knowledge_graph, model_class):
     np.testing.assert_array_equal(prediction, prediction2)
 
 
-@pytest.mark.parametrize("model_maker", [ComplEx, DistMult, RotatE, RotH, RotE])
 def test_model_rankings(model_maker):
     nodes = pd.DataFrame(index=["a", "b", "c", "d"])
     rels = ["W", "X", "Y", "Z"]
@@ -482,3 +486,9 @@ def test_embedding_validation(knowledge_graph):
 
     # all good:
     KGModel(gen, X(([e, e], [e, e, e])), 2, **kwargs)
+
+
+def test_save_load(tmpdir, knowledge_graph, model_maker):
+    gen = KGTripleGenerator(knowledge_graph, 3)
+    sg_model = model_maker(gen, embedding_dimension=6)
+    test_utils.model_save_load(tmpdir, sg_model)

--- a/tests/layer/test_node2vec.py
+++ b/tests/layer/test_node2vec.py
@@ -27,6 +27,7 @@ from tensorflow import keras
 import numpy as np
 import pytest
 from ..test_utils.graphs import example_graph
+from .. import test_utils
 
 
 def test_node2vec_constructor():
@@ -105,3 +106,8 @@ def test_node2vec_serialize():
 
     actual = model2.predict(x)
     assert expected == pytest.approx(actual)
+
+
+def test_node2vec_save_load(tmpdir):
+    node2vec = Node2Vec(emb_size=4, node_num=4, multiplicity=2)
+    test_utils.model_save_load(tmpdir, node2vec)

--- a/tests/layer/test_ppnp.py
+++ b/tests/layer/test_ppnp.py
@@ -83,4 +83,4 @@ def test_PPNP_save_load(tmpdir):
     G, _ = create_graph_features()
     generator = FullBatchNodeGenerator(G, sparse=False)
     ppnp = PPNP([2, 3], generator, ["relu", "relu"])
-    test_utils.model_save_load(tmpdir, appnp)
+    test_utils.model_save_load(tmpdir, ppnp)

--- a/tests/layer/test_ppnp.py
+++ b/tests/layer/test_ppnp.py
@@ -25,6 +25,7 @@ import numpy as np
 from tensorflow import keras
 import pytest
 from ..test_utils.graphs import create_graph_features
+from .. import test_utils
 
 
 def test_PPNP_edge_cases():
@@ -76,3 +77,10 @@ def test_PPNP_apply_dense():
     assert preds_2.shape == (1, 2, 2)
 
     assert preds_1 == pytest.approx(preds_2)
+
+
+def test_PPNP_save_load(tmpdir):
+    G, _ = create_graph_features()
+    generator = FullBatchNodeGenerator(G, sparse=False)
+    ppnp = PPNP([2, 3], generator, ["relu", "relu"])
+    test_utils.model_save_load(tmpdir, appnp)

--- a/tests/layer/test_rgcn.py
+++ b/tests/layer/test_rgcn.py
@@ -373,6 +373,7 @@ def test_kernel_and_bias_defaults():
             assert layer.bias_constraint is None
 
 
+@pytest.mark.xfail(reason="FIXME #1252")
 @pytest.mark.parametrize("num_bases", [0, 10])
 @pytest.mark.parametrize("sparse", [False, True])
 def test_RGCN_save_load(tmpdir, num_bases, sparse):

--- a/tests/layer/test_rgcn.py
+++ b/tests/layer/test_rgcn.py
@@ -30,6 +30,7 @@ import pandas as pd
 from ..test_utils.graphs import (
     relational_create_graph_features as create_graph_features,
 )
+from .. import test_utils
 
 
 def test_RelationalGraphConvolution_config():
@@ -370,3 +371,12 @@ def test_kernel_and_bias_defaults():
             assert layer.bias_regularizer is None
             assert layer.kernel_constraint is None
             assert layer.bias_constraint is None
+
+
+@pytest.mark.parametrize("num_bases", [0, 10])
+@pytest.mark.parametrize("sparse", [False, True])
+def test_RGCN_save_load(tmpdir, num_bases, sparse):
+    graph, _ = create_graph_features()
+    generator = RelationalFullBatchNodeGenerator(graph, sparse=sparse)
+    rgcn = RGCN([2, 2], generator, num_bases=num_bases)
+    test_utils.model_save_load(tmpdir, rgcn)

--- a/tests/layer/test_watch_your_step.py
+++ b/tests/layer/test_watch_your_step.py
@@ -21,6 +21,7 @@ from stellargraph.mapper import AdjacencyPowerGenerator
 from stellargraph.losses import graph_log_likelihood
 import pytest
 from tensorflow.keras import Model
+from .. import test_utils
 
 
 def test_AttentiveWalk_config():
@@ -102,3 +103,9 @@ def test_WatchYourStep_embeddings(barbell):
     embs = wys.embeddings()
 
     assert (embs == 1).all()
+
+
+def test_WatchYourStep_save_load(tmpdir, barbell):
+    generator = AdjacencyPowerGenerator(barbell, num_powers=5)
+    wys = WatchYourStep(generator)
+    test_utils.model_save_load(tmpdir, wys)

--- a/tests/test_utils/__init__.py
+++ b/tests/test_utils/__init__.py
@@ -16,7 +16,27 @@
 
 import pytest
 
+from tensorflow import keras
+import stellargraph as sg
+import numpy as np
 
 ignore_stellargraph_experimental_mark = pytest.mark.filterwarnings(
     r"ignore:StellarGraph\(nodes=..., edges=...\):stellargraph.core.experimental.ExperimentalWarning"
 )
+
+
+def model_save_load(tmpdir, sg_model):
+    model = keras.Model(*sg_model.in_out_tensors())
+
+    model.summary()
+    save_model_dir = tmpdir.join("save_model")
+    keras.models.save_model(model, str(save_model_dir))
+
+    save_dir = tmpdir.join("save")
+    model.save(str(save_dir))
+
+    for saved_dir in [save_model_dir, save_dir]:
+        loaded = keras.models.load_model(str(saved_dir), sg.custom_keras_layers)
+
+        for orig, new in zip(model.get_weights(), loaded.get_weights()):
+            np.testing.assert_array_equal(orig, new)

--- a/tests/test_utils/__init__.py
+++ b/tests/test_utils/__init__.py
@@ -51,6 +51,9 @@ def model_save_load(tmpdir, sg_model):
             for orig, new in zip(orig_weights, new_weights):
                 np.testing.assert_array_equal(orig, new)
 
+    # clear the tensorflow session to free memory
+    tf.keras.backend.clear_session()
+
 
 def flaky_xfail_mark(exception, issue_numbers):
     """

--- a/tests/test_utils/__init__.py
+++ b/tests/test_utils/__init__.py
@@ -28,7 +28,6 @@ ignore_stellargraph_experimental_mark = pytest.mark.filterwarnings(
 def model_save_load(tmpdir, sg_model):
     model = keras.Model(*sg_model.in_out_tensors())
 
-    model.summary()
     save_model_dir = tmpdir.join("save_model")
     keras.models.save_model(model, str(save_model_dir))
 


### PR DESCRIPTION
This PR test saving and loading of a `tf.keras.Model` instance for every model in StellarGraph.

It does so by adding a `test_utils.model_save_load` helper function that serialises and deserialisers a given model using various APIs provided by TensorFlow:

- saving:
  - [`tf.keras.Model.save`](https://www.tensorflow.org/api_docs/python/tf/keras/Model#save)
  - [`tf.keras.models.save_model`](https://www.tensorflow.org/api_docs/python/tf/keras/models/save_model)
  - [`tf.saved_model.save`](https://www.tensorflow.org/api_docs/python/tf/saved_model/save)
- loading: [`tf.keras.models.load_model`](https://www.tensorflow.org/api_docs/python/tf/keras/models/load_model) (not [`tf.saved_model.load`](https://www.tensorflow.org/api_docs/python/tf/saved_model/load), because it doesn't create a Keras `Model` object)

Several of these new tests fail (they're included but marked as xfail), due to:

- #1251 
- #1252 
- #1680 (found in this PR)
- #1681 (found in this PR)

As those issues are fixed, the xfailing can be removed.