### PR TITLE
Add names to RGCN weights

### DIFF
--- a/stellargraph/layer/rgcn.py
+++ b/stellargraph/layer/rgcn.py
@@ -237,6 +237,7 @@ class RelationalGraphConvolution(Layer):
             self.relational_kernels = [
                 self.add_weight(
                     shape=(input_dim, self.units),
+                    name="relational_kernels",
                     initializer=self.kernel_initializer,
                     regularizer=self.kernel_regularizer,
                     constraint=self.kernel_constraint,
@@ -246,6 +247,7 @@ class RelationalGraphConvolution(Layer):
 
         self.self_kernel = self.add_weight(
             shape=(input_dim, self.units),
+            name="self_kernel",
             initializer=self.kernel_initializer,
             regularizer=self.kernel_regularizer,
             constraint=self.kernel_constraint,

--- a/tests/layer/test_rgcn.py
+++ b/tests/layer/test_rgcn.py
@@ -373,9 +373,10 @@ def test_kernel_and_bias_defaults():
             assert layer.bias_constraint is None
 
 
-@pytest.mark.xfail(reason="FIXME #1252")
 @pytest.mark.parametrize("num_bases", [0, 10])
-@pytest.mark.parametrize("sparse", [False, True])
+@pytest.mark.parametrize(
+    "sparse", [False, pytest.param(True, marks=pytest.mark.xfail(reason="FIXME #1251"))]
+)
 def test_RGCN_save_load(tmpdir, num_bases, sparse):
     graph, _ = create_graph_features()
     generator = RelationalFullBatchNodeGenerator(graph, sparse=sparse)


### PR DESCRIPTION
A Keras Layer with weights without names cannot be saved (https://github.com/tensorflow/tensorflow/issues/36962), because an exception is thrown:

```
AttributeError: 'NoneType' object has no attribute 'replace'
```

This PR adds names to the `add_weight` calls within `RelationalGraphConvolution`, which were the only ones within all of StellarGraph missing the `name=...` parameter.

This allows non-sparse RGCN models to be saved, but sparse ones still hit #1251.

See: #1252