### PR TITLE
Use np.testing.assert_array_equal, not assert np.array_equal or np.allclose

### DIFF
--- a/tests/core/test_element_data.py
+++ b/tests/core/test_element_data.py
@@ -36,7 +36,7 @@ def test_external_id_index_to_iloc(count, expected_missing):
     if count <= 256:
         # only do individual lookups when there's a few IDs, and assume that if those work, then large ones will too
         for i, x in enumerate(values):
-            assert np.array_equal(idx.to_iloc([x]), [i])
+            np.testing.assert_array_equal(idx.to_iloc([x]), [i])
 
     # missing value
     assert idx.to_iloc(["A"]) == expected_missing

--- a/tests/core/test_graph.py
+++ b/tests/core/test_graph.py
@@ -774,12 +774,12 @@ def test_feature_conversion_from_iterator():
 
     A = gs.to_adjacency_matrix()
     assert A.dtype == "float32"
-    assert np.allclose(A.toarray(), adj_expected)
+    np.testing.assert_allclose(A.toarray(), adj_expected)
 
     # Test adjacency matrix with node arguement
     A = gs.to_adjacency_matrix(nodes=[3, 2])
     assert A.dtype == "float32"
-    assert np.allclose(A.toarray(), adj_expected[[2, 1]][:, [2, 1]])
+    np.testing.assert_allclose(A.toarray(), adj_expected[[2, 1]][:, [2, 1]])
 
     g = example_hin_1_nx()
     nf = {
@@ -1883,10 +1883,10 @@ def test_to_adjacency_matrix_weighted_undirected():
     actual[0, 5] = actual[5, 0] = 1
     actual[6, 5] = actual[5, 6] = 10
     actual[5, 5] = 1 + 11 + 12
-    assert np.array_equal(matrix, actual)
+    np.testing.assert_array_equal(matrix, actual)
 
     # just to confirm, it should be symmetric
-    assert np.array_equal(matrix, matrix.T)
+    np.testing.assert_array_equal(matrix, matrix.T)
 
     # use a funny order to verify order
     subgraph = g.to_adjacency_matrix([1, 6, 5], weighted=True).todense()
@@ -1895,7 +1895,7 @@ def test_to_adjacency_matrix_weighted_undirected():
     actual = np.zeros((3, 3), dtype=subgraph.dtype)
     actual[one, five] = actual[five, one] = 1
     actual[five, five] = 1 + 11 + 12
-    assert np.array_equal(subgraph, actual)
+    np.testing.assert_array_equal(subgraph, actual)
 
 
 def test_to_adjacency_matrix_weighted_directed():
@@ -1911,7 +1911,7 @@ def test_to_adjacency_matrix_weighted_directed():
     actual[6, 5] = 10
     actual[5, 5] = 1 + 11 + 12
 
-    assert np.array_equal(matrix, actual)
+    np.testing.assert_array_equal(matrix, actual)
 
     # use a funny order to verify order
     subgraph = g.to_adjacency_matrix([1, 6, 5], weighted=True).todense()
@@ -1920,7 +1920,7 @@ def test_to_adjacency_matrix_weighted_directed():
     actual = np.zeros((3, 3), dtype=subgraph.dtype)
     actual[one, five] = 1
     actual[five, five] = 1 + 11 + 12
-    assert np.array_equal(subgraph, actual)
+    np.testing.assert_array_equal(subgraph, actual)
 
 
 def test_to_adjacency_matrix():
@@ -1935,7 +1935,7 @@ def test_to_adjacency_matrix():
     actual[0, 5] = actual[5, 0] = 1
     actual[6, 5] = actual[5, 6] = 1
     actual[5, 5] = 3
-    assert np.array_equal(matrix, actual)
+    np.testing.assert_array_equal(matrix, actual)
 
 
 def test_to_adjacency_matrix_edge_type():
@@ -2102,7 +2102,7 @@ def test_from_networkx_smoke():
 
     def both(f, numpy=False):
         if numpy:
-            assert np.array_equal(f(from_nx), f(raw))
+            np.testing.assert_array_equal(f(from_nx), f(raw))
         else:
             assert f(from_nx) == f(raw)
 

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -228,7 +228,7 @@ def test_GCN_Aadj_feats_op(example_graph):
     features = example_graph.node_features(node_list)
 
     features_, Aadj_ = GCN_Aadj_feats_op(features=features, A=Aadj, method="gcn")
-    assert np.array_equal(features, features_)
+    np.testing.assert_array_equal(features, features_)
     assert 6 == pytest.approx(Aadj_.todense().sum(), 0.1)
 
     # k must be positive integer
@@ -247,7 +247,7 @@ def test_GCN_Aadj_feats_op(example_graph):
     features_, Aadj_ = GCN_Aadj_feats_op(features=features, A=Aadj, method="sgc", k=2)
 
     assert len(features_) == 6
-    assert np.array_equal(features, features_)
+    np.testing.assert_array_equal(features, features_)
     assert Aadj.get_shape() == Aadj_.get_shape()
 
     # Check if the power of the normalised adjacency matrix is calculated correctly.

--- a/tests/data/test_biased_random_walker.py
+++ b/tests/data/test_biased_random_walker.py
@@ -106,7 +106,7 @@ class TestBiasedWeightedRandomWalk(object):
         run_2 = rw_no_params.run(
             nodes=nodes, n=n, p=p, q=q, length=length, seed=seed, weighted=True
         )
-        assert np.array_equal(run_1, run_2)
+        np.testing.assert_array_equal(run_1, run_2)
 
     def test_identity_unweighted_weighted_1_walks(self):
 
@@ -126,7 +126,7 @@ class TestBiasedWeightedRandomWalk(object):
         run_2 = biasedrw.run(
             nodes=nodes, n=n, p=p, q=q, length=length, seed=seed, weighted=True
         )
-        assert np.array_equal(run_1, run_2)
+        np.testing.assert_array_equal(run_1, run_2)
 
     def test_weighted_walks(self):
 

--- a/tests/data/test_metapath_walker.py
+++ b/tests/data/test_metapath_walker.py
@@ -314,7 +314,8 @@ class TestMetaPathWalk(object):
             nodes=nodes, n=n, length=length, metapaths=metapaths, seed=seed
         )
         assert len(run_1) == len(run_2)
-        assert all(np.array_equal(w1, w2) for w1, w2 in zip(run_1, run_2))
+        for w1, w2 in zip(run_1, run_2):
+            np.testing.assert_array_equal(w1, w2)
 
     def test_benchmark_uniformrandommetapathwalk(self, benchmark):
         g = example_graph_random(n_nodes=50, n_edges=500, node_types=2)

--- a/tests/data/test_temporal_random_walker.py
+++ b/tests/data/test_temporal_random_walker.py
@@ -68,7 +68,7 @@ def test_exp_biases(temporal_graph):
     t_0 = 1
     expected = np.exp(t_0 - times) / sum(np.exp(t_0 - times))
     biases = rw._exp_biases(times, t_0, decay=True)
-    assert np.allclose(biases, expected)
+    np.testing.assert_allclose(biases, expected)
 
 
 def test_exp_biases_extreme(temporal_graph):
@@ -122,4 +122,4 @@ def test_init_parameters(temporal_graph):
         num_cw=num_cw, cw_size=cw_size, max_walk_length=max_walk_length, seed=seed
     )
 
-    assert np.array_equal(run_1, run_2)
+    np.testing.assert_array_equal(run_1, run_2)

--- a/tests/data/test_uniform_random_walker.py
+++ b/tests/data/test_uniform_random_walker.py
@@ -236,7 +236,7 @@ class TestUniformRandomWalk(object):
 
         run_1 = urw.run(nodes=nodes)
         run_2 = urw_no_params.run(nodes=nodes, n=n, length=length, seed=seed)
-        assert np.array_equal(run_1, run_2)
+        np.testing.assert_array_equal(run_1, run_2)
 
     def test_benchmark_uniformrandomwalk(self, benchmark):
         g = example_graph_random(n_nodes=100, n_edges=500)

--- a/tests/layer/test_deep_graph_infomax.py
+++ b/tests/layer/test_deep_graph_infomax.py
@@ -123,7 +123,7 @@ def test_dgi_stateful():
         generator.flow(G.nodes())
     )
 
-    assert np.array_equal(embeddings_1, embeddings_2)
+    np.testing.assert_array_equal(embeddings_1, embeddings_2)
 
     model_1.compile(loss=tf.nn.sigmoid_cross_entropy_with_logits, optimizer="Adam")
     model_1.fit(gen)
@@ -136,7 +136,7 @@ def test_dgi_stateful():
         generator.flow(G.nodes())
     )
 
-    assert np.array_equal(embeddings_1, embeddings_2)
+    np.testing.assert_array_equal(embeddings_1, embeddings_2)
 
     model_2.compile(loss=tf.nn.sigmoid_cross_entropy_with_logits, optimizer="Adam")
     model_2.fit(gen)
@@ -149,7 +149,7 @@ def test_dgi_stateful():
         generator.flow(G.nodes())
     )
 
-    assert np.array_equal(embeddings_1, embeddings_2)
+    np.testing.assert_array_equal(embeddings_1, embeddings_2)
 
 
 def test_dgi_deprecated_no_generator():

--- a/tests/layer/test_graph_attention.py
+++ b/tests/layer/test_graph_attention.py
@@ -118,7 +118,7 @@ class Test_GraphAttention:
         expected = np.ones((self.N, self.F_out * self.attn_heads)) * self.F_in
         actual = model.predict([X] + As)
 
-        assert np.allclose(actual.squeeze(), expected)
+        np.testing.assert_allclose(actual.squeeze(), expected)
 
     def test_apply_average(self):
         gat = self.layer(
@@ -147,7 +147,7 @@ class Test_GraphAttention:
         expected = (X * self.F_in)[..., : self.F_out]
         actual = model.predict([X] + As)
 
-        assert np.allclose(actual.squeeze(), expected)
+        np.testing.assert_allclose(actual.squeeze(), expected)
 
     def test_apply_average_with_neighbours(self):
         gat_saliency = self.layer(
@@ -193,8 +193,8 @@ class Test_GraphAttention:
         expected[:, :2] = self.F_in / 2
         actual_origin = model_origin.predict([X] + As)
         actual_saliency = model_saliency.predict([X] + As)
-        assert np.allclose(expected, actual_origin)
-        assert np.allclose(expected, actual_saliency)
+        np.testing.assert_allclose(expected, actual_origin)
+        np.testing.assert_allclose(expected, actual_saliency)
 
     def test_layer_config(self):
         layer = self.layer(
@@ -500,7 +500,7 @@ class Test_GAT:
             1.0 / G.number_of_nodes()
         )
 
-        assert np.allclose(expected, actual[0])
+        np.testing.assert_allclose(expected, actual[0])
 
     def test_gat_build_no_norm(self):
         G = example_graph(feature_size=self.F_in)
@@ -529,7 +529,7 @@ class Test_GAT:
             * self.attn_heads
             * np.max(G.node_features(G.nodes()))
         )
-        assert np.allclose(expected, actual[0])
+        np.testing.assert_allclose(expected, actual[0])
 
     def test_gat_build_wrong_norm(self):
         G = example_graph(feature_size=self.F_in)
@@ -582,7 +582,7 @@ class Test_GAT:
         expected = np.ones((G.number_of_nodes(), self.layer_sizes[-1])) * (
             1.0 / G.number_of_nodes()
         )
-        assert np.allclose(expected, actual[0])
+        np.testing.assert_allclose(expected, actual[0])
 
     def test_kernel_and_bias_defaults(self):
         graph = example_graph(feature_size=self.F_in)

--- a/tests/layer/test_graph_attention.py
+++ b/tests/layer/test_graph_attention.py
@@ -147,7 +147,7 @@ class Test_GraphAttention:
         expected = (X * self.F_in)[..., : self.F_out]
         actual = model.predict([X] + As)
 
-        np.testing.assert_allclose(actual.squeeze(), expected)
+        np.testing.assert_allclose(actual.squeeze(), expected.squeeze())
 
     def test_apply_average_with_neighbours(self):
         gat_saliency = self.layer(

--- a/tests/layer/test_graph_classification.py
+++ b/tests/layer/test_graph_classification.py
@@ -113,7 +113,7 @@ def test_stateful():
     embeddings_1 = model_1.predict(train_gen)
     embeddings_2 = model_2.predict(train_gen)
 
-    assert np.array_equal(embeddings_1, embeddings_2)
+    np.testing.assert_array_equal(embeddings_1, embeddings_2)
 
     model_1.compile(loss=tf.nn.softmax_cross_entropy_with_logits, optimizer="Adam")
     model_1.fit(train_gen)
@@ -122,7 +122,7 @@ def test_stateful():
     embeddings_1 = model_1.predict(train_gen)
     embeddings_2 = model_2.predict(train_gen)
 
-    assert np.array_equal(embeddings_1, embeddings_2)
+    np.testing.assert_array_equal(embeddings_1, embeddings_2)
 
     model_2.compile(loss=tf.nn.softmax_cross_entropy_with_logits, optimizer="Adam")
     model_2.fit(train_gen)
@@ -131,7 +131,7 @@ def test_stateful():
     embeddings_1 = model_1.predict(train_gen)
     embeddings_2 = model_2.predict(train_gen)
 
-    assert np.array_equal(embeddings_1, embeddings_2)
+    np.testing.assert_array_equal(embeddings_1, embeddings_2)
 
 
 @pytest.mark.parametrize("pooling", ["default", "custom"])

--- a/tests/layer/test_knowledge_graph.py
+++ b/tests/layer/test_knowledge_graph.py
@@ -96,13 +96,13 @@ def test_complex(knowledge_graph):
     prediction = model.predict(gen.flow(df))
 
     # (use an absolute tolerance to allow for catastrophic cancellation around very small values)
-    assert np.allclose(prediction[:, 0], actual, rtol=1e-3, atol=1e-6)
+    np.testing.assert_allclose(prediction[:, 0], actual, rtol=1e-3, atol=1e-6)
 
     # the model is stateful (i.e. it holds the weights permanently) so the predictions with a second
     # 'build' should be the same as the original one
     model2 = Model(*complex_model.in_out_tensors())
     prediction2 = model2.predict(gen.flow(df))
-    assert np.array_equal(prediction, prediction2)
+    np.testing.assert_array_equal(prediction, prediction2)
 
 
 def test_distmult(knowledge_graph):
@@ -149,13 +149,13 @@ def test_distmult(knowledge_graph):
     prediction = model.predict(gen.flow(df))
 
     # (use an absolute tolerance to allow for catastrophic cancellation around very small values)
-    assert np.allclose(prediction[:, 0], actual, rtol=1e-3, atol=1e-14)
+    np.testing.assert_allclose(prediction[:, 0], actual, rtol=1e-3, atol=1e-14)
 
     # the model is stateful (i.e. it holds the weights permanently) so the predictions with a second
     # 'build' should be the same as the original one
     model2 = Model(*distmult_model.in_out_tensors())
     prediction2 = model2.predict(gen.flow(df))
-    assert np.array_equal(prediction, prediction2)
+    np.testing.assert_array_equal(prediction, prediction2)
 
 
 def test_rotate(knowledge_graph):
@@ -217,7 +217,7 @@ def test_rotate(knowledge_graph):
     # 'build' should be the same as the original one
     model2 = Model(*rotate_model.in_out_tensors())
     prediction2 = model2.predict(gen.flow(df))
-    assert np.array_equal(prediction, prediction2)
+    np.testing.assert_array_equal(prediction, prediction2)
 
 
 @pytest.mark.parametrize("model_class", [RotE, RotH])

--- a/tests/layer/test_misc.py
+++ b/tests/layer/test_misc.py
@@ -56,7 +56,7 @@ def test_squeezedsparseconversion():
 
     z = model.predict([x, np.expand_dims(A_indices, 0), np.expand_dims(A_values, 0)])
 
-    assert np.allclose(z.squeeze(), A.dot(x.squeeze()), atol=1e-7)
+    np.testing.assert_allclose(z.squeeze(), A.dot(x.squeeze()), atol=1e-7)
 
 
 def test_squeezedsparseconversion_dtype():
@@ -79,7 +79,7 @@ def test_squeezedsparseconversion_dtype():
     z = model.predict([x, np.expand_dims(A_indices, 0), np.expand_dims(A_values, 0)])
 
     assert A_mat.dtype == tf.dtypes.float64
-    assert np.allclose(z.squeeze(), A.dot(x.squeeze()), atol=1e-7)
+    np.testing.assert_allclose(z.squeeze(), A.dot(x.squeeze()), atol=1e-7)
 
 
 def test_squeezedsparseconversion_axis():
@@ -104,7 +104,7 @@ def test_squeezedsparseconversion_axis():
     model = keras.Model(inputs=[A_ind, A_val], outputs=x_out)
     z = model.predict([A_indices, A_values])
 
-    assert np.allclose(z, A.sum(axis=1), atol=1e-7)
+    np.testing.assert_allclose(z, A.sum(axis=1), atol=1e-7)
 
 
 def test_gather_indices():

--- a/tests/layer/test_sort_pooling.py
+++ b/tests/layer/test_sort_pooling.py
@@ -30,7 +30,7 @@ def test_sorting_padding():
 
     data_out = layer(data, mask=mask)
 
-    assert np.array_equal(data_out, data_sorted)
+    np.testing.assert_array_equal(data_out, data_sorted)
 
     # for mini-batch of size > 1
     data = np.array([[3, 1], [1, 2], [5, 0], [0, -4]], dtype=int).reshape((2, 2, 2))
@@ -43,7 +43,7 @@ def test_sorting_padding():
 
     data_out = layer(data, mask=mask)
 
-    assert np.array_equal(data_out, data_sorted)
+    np.testing.assert_array_equal(data_out, data_sorted)
 
 
 def test_sorting_truncation():
@@ -56,7 +56,7 @@ def test_sorting_truncation():
 
     data_out = layer(data, mask=mask)
 
-    assert np.array_equal(data_out, data_sorted)
+    np.testing.assert_array_equal(data_out, data_sorted)
 
     # for mini-batch of size > 1
     data = np.array([[3, 1], [1, 2], [5, 0], [0, -4]], dtype=int).reshape((2, 2, 2))
@@ -68,7 +68,7 @@ def test_sorting_truncation():
 
     data_out = layer(data, mask=mask)
 
-    assert np.array_equal(data_out, data_sorted)
+    np.testing.assert_array_equal(data_out, data_sorted)
 
 
 def test_sorting_negative_values():
@@ -84,7 +84,7 @@ def test_sorting_negative_values():
 
     data_out = layer(data, mask=mask)
 
-    assert np.array_equal(data_out, data_sorted)
+    np.testing.assert_array_equal(data_out, data_sorted)
 
 
 def test_mask():
@@ -97,7 +97,7 @@ def test_mask():
 
     data_out = layer(data, mask=mask)
 
-    assert np.array_equal(data_out, data_sorted)
+    np.testing.assert_array_equal(data_out, data_sorted)
 
     mask = np.array([[True, True, False]])
     data_sorted = np.array(
@@ -108,7 +108,7 @@ def test_mask():
 
     data_out = layer(data, mask=mask)
 
-    assert np.array_equal(data_out, data_sorted)
+    np.testing.assert_array_equal(data_out, data_sorted)
 
 
 def test_flatten_output():
@@ -121,7 +121,7 @@ def test_flatten_output():
 
     data_out = layer(data, mask=mask)
 
-    assert np.array_equal(data_out, data_sorted)
+    np.testing.assert_array_equal(data_out, data_sorted)
 
 
 def test_invalid_k():

--- a/tests/layer/test_watch_your_step.py
+++ b/tests/layer/test_watch_your_step.py
@@ -40,7 +40,7 @@ def test_AttentiveWalk():
 
     output = att_wlk(random_partial_powers).numpy()
 
-    np.testing.assert_allclose(output, random_partial_powers.mean(axis=1))
+    np.testing.assert_allclose(output, random_partial_powers.mean(axis=1), rtol=1e-5, atol=1e-8)
 
 
 def test_WatchYourStep_init(barbell):

--- a/tests/layer/test_watch_your_step.py
+++ b/tests/layer/test_watch_your_step.py
@@ -40,7 +40,7 @@ def test_AttentiveWalk():
 
     output = att_wlk(random_partial_powers).numpy()
 
-    assert np.allclose(output, random_partial_powers.mean(axis=1))
+    np.testing.assert_allclose(output, random_partial_powers.mean(axis=1))
 
 
 def test_WatchYourStep_init(barbell):
@@ -89,7 +89,7 @@ def test_WatchYourStep(barbell):
     # same predictions
     preds1 = model.predict(gen, steps=8)
     preds2 = Model(*wys.in_out_tensors()).predict(gen, steps=8)
-    assert np.array_equal(preds1, preds2)
+    np.testing.assert_array_equal(preds1, preds2)
 
 
 def test_WatchYourStep_embeddings(barbell):

--- a/tests/layer/test_watch_your_step.py
+++ b/tests/layer/test_watch_your_step.py
@@ -40,7 +40,9 @@ def test_AttentiveWalk():
 
     output = att_wlk(random_partial_powers).numpy()
 
-    np.testing.assert_allclose(output, random_partial_powers.mean(axis=1), rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(
+        output, random_partial_powers.mean(axis=1), rtol=1e-5, atol=1e-8
+    )
 
 
 def test_WatchYourStep_init(barbell):

--- a/tests/mapper/test_adjacency_generators.py
+++ b/tests/mapper/test_adjacency_generators.py
@@ -109,4 +109,4 @@ def test_partial_powers(barbell, num_powers):
         partial_powers = x[1].numpy()
         for j in range(num_powers):
             print(i, j)
-            assert np.allclose(partial_powers[0, j, :], actual_powers[j][i, :])
+            np.testing.assert_allclose(partial_powers[0, j, :], actual_powers[j][i, :])

--- a/tests/mapper/test_adjacency_generators.py
+++ b/tests/mapper/test_adjacency_generators.py
@@ -109,4 +109,4 @@ def test_partial_powers(barbell, num_powers):
         partial_powers = x[1].numpy()
         for j in range(num_powers):
             print(i, j)
-            np.testing.assert_allclose(partial_powers[0, j, :], actual_powers[j][i, :])
+            np.testing.assert_allclose(partial_powers[:, j, :], actual_powers[j][i, :], rtol=1e-5, atol=1e-8)

--- a/tests/mapper/test_adjacency_generators.py
+++ b/tests/mapper/test_adjacency_generators.py
@@ -109,4 +109,6 @@ def test_partial_powers(barbell, num_powers):
         partial_powers = x[1].numpy()
         for j in range(num_powers):
             print(i, j)
-            np.testing.assert_allclose(partial_powers[:, j, :], actual_powers[j][i, :], rtol=1e-5, atol=1e-8)
+            np.testing.assert_allclose(
+                partial_powers[:, j, :], actual_powers[j][i, :], rtol=1e-5, atol=1e-8
+            )

--- a/tests/mapper/test_full_batch_generators.py
+++ b/tests/mapper/test_full_batch_generators.py
@@ -113,15 +113,15 @@ class Test_FullBatchNodeGenerator:
             [X, tind, A], y = gen[0]
             A_dense = A[0]
 
-        assert np.allclose(X, gen.features)  # X should be equal to gen.features
+        np.testing.assert_allclose(X, gen.features)  # X should be equal to gen.features
         assert tind.shape[1] == len(node_ids)
 
         if node_targets is not None:
-            assert np.allclose(y, node_targets)
+            np.testing.assert_allclose(y, node_targets)
 
         # Check that the diagonals are one
         if method == "self_loops":
-            assert np.allclose(A_dense.diagonal(), 1)
+            np.testing.assert_allclose(A_dense.diagonal(), 1)
 
         return A_dense, tind, y
 
@@ -130,31 +130,31 @@ class Test_FullBatchNodeGenerator:
         _, tind, y = self.generator_flow(
             self.G, node_ids, None, sparse=False, method="none"
         )
-        assert np.allclose(tind, range(3))
+        np.testing.assert_allclose(tind, range(3))
         _, tind, y = self.generator_flow(
             self.G, node_ids, None, sparse=True, method="none"
         )
-        assert np.allclose(tind, range(3))
+        np.testing.assert_allclose(tind, range(3))
 
         node_ids = list(self.G.nodes())
         _, tind, y = self.generator_flow(
             self.G, node_ids, None, sparse=False, method="none"
         )
-        assert np.allclose(tind, range(len(node_ids)))
+        np.testing.assert_allclose(tind, range(len(node_ids)))
         _, tind, y = self.generator_flow(
             self.G, node_ids, None, sparse=True, method="none"
         )
-        assert np.allclose(tind, range(len(node_ids)))
+        np.testing.assert_allclose(tind, range(len(node_ids)))
 
     def test_generator_flow_withtargets(self):
         node_ids = list(self.G.nodes())[:3]
         node_targets = np.ones((len(node_ids), self.target_dim)) * np.arange(3)[:, None]
         _, tind, y = self.generator_flow(self.G, node_ids, node_targets, sparse=True)
-        assert np.allclose(tind, range(3))
-        assert np.allclose(y, node_targets[:3])
+        np.testing.assert_allclose(tind, range(3))
+        np.testing.assert_allclose(y, node_targets[:3])
         _, tind, y = self.generator_flow(self.G, node_ids, node_targets, sparse=False)
-        assert np.allclose(tind, range(3))
-        assert np.allclose(y, node_targets[:3])
+        np.testing.assert_allclose(tind, range(3))
+        np.testing.assert_allclose(y, node_targets[:3])
 
         node_ids = list(self.G.nodes())[::-1]
         node_targets = (
@@ -162,8 +162,8 @@ class Test_FullBatchNodeGenerator:
             * np.arange(len(node_ids))[:, None]
         )
         _, tind, y = self.generator_flow(self.G, node_ids, node_targets)
-        assert np.allclose(tind, range(len(node_ids))[::-1])
-        assert np.allclose(y, node_targets)
+        np.testing.assert_allclose(tind, range(len(node_ids))[::-1])
+        np.testing.assert_allclose(y, node_targets)
 
     def test_generator_flow_targets_as_list(self):
         generator = FullBatchNodeGenerator(self.G)
@@ -186,7 +186,7 @@ class Test_FullBatchNodeGenerator:
         G, feats = create_graph_features()
 
         generator = FullBatchNodeGenerator(G, method=None)
-        assert np.array_equal(feats, generator.features)
+        np.testing.assert_array_equal(feats, generator.features)
 
     def test_fullbatch_generator_init_3(self):
         G, feats = create_graph_features()
@@ -206,7 +206,7 @@ class Test_FullBatchNodeGenerator:
         assert generator.name == "test"
 
         A = G.to_adjacency_matrix().toarray()
-        assert np.array_equal(A.dot(A), generator.Aadj.toarray())
+        np.testing.assert_array_equal(A.dot(A), generator.Aadj.toarray())
 
     def test_generator_methods(self):
         node_ids = list(self.G.nodes())
@@ -219,48 +219,48 @@ class Test_FullBatchNodeGenerator:
         A_dense, _, _ = self.generator_flow(
             self.G, node_ids, None, sparse=True, method="none"
         )
-        assert np.allclose(A_dense, Aadj)
+        np.testing.assert_allclose(A_dense, Aadj)
         A_dense, _, _ = self.generator_flow(
             self.G, node_ids, None, sparse=False, method="none"
         )
-        assert np.allclose(A_dense, Aadj)
+        np.testing.assert_allclose(A_dense, Aadj)
 
         A_dense, _, _ = self.generator_flow(
             self.G, node_ids, None, sparse=True, method="self_loops"
         )
-        assert np.allclose(A_dense, Aadj_selfloops)
+        np.testing.assert_allclose(A_dense, Aadj_selfloops)
         A_dense, _, _ = self.generator_flow(
             self.G, node_ids, None, sparse=False, method="self_loops"
         )
-        assert np.allclose(A_dense, Aadj_selfloops)
+        np.testing.assert_allclose(A_dense, Aadj_selfloops)
 
         A_dense, _, _ = self.generator_flow(
             self.G, node_ids, None, sparse=True, method="gat"
         )
-        assert np.allclose(A_dense, Aadj_selfloops)
+        np.testing.assert_allclose(A_dense, Aadj_selfloops)
         A_dense, _, _ = self.generator_flow(
             self.G, node_ids, None, sparse=False, method="gat"
         )
-        assert np.allclose(A_dense, Aadj_selfloops)
+        np.testing.assert_allclose(A_dense, Aadj_selfloops)
 
         A_dense, _, _ = self.generator_flow(
             self.G, node_ids, None, sparse=True, method="gcn"
         )
-        assert np.allclose(A_dense, Agcn)
+        np.testing.assert_allclose(A_dense, Agcn)
         A_dense, _, _ = self.generator_flow(
             self.G, node_ids, None, sparse=False, method="gcn"
         )
-        assert np.allclose(A_dense, Agcn)
+        np.testing.assert_allclose(A_dense, Agcn)
 
         # Check other preprocessing options
         A_dense, _, _ = self.generator_flow(
             self.G, node_ids, None, sparse=True, method="sgc", k=2
         )
-        assert np.allclose(A_dense, Agcn.dot(Agcn))
+        np.testing.assert_allclose(A_dense, Agcn.dot(Agcn))
         A_dense, _, _ = self.generator_flow(
             self.G, node_ids, None, sparse=False, method="sgc", k=2
         )
-        assert np.allclose(A_dense, Agcn.dot(Agcn))
+        np.testing.assert_allclose(A_dense, Agcn.dot(Agcn))
 
         A_dense, _, _ = self.generator_flow(
             self.G,
@@ -270,7 +270,7 @@ class Test_FullBatchNodeGenerator:
             method="ppnp",
             teleport_probability=0.1,
         )
-        assert np.allclose(A_dense, Appnp)
+        np.testing.assert_allclose(A_dense, Appnp)
 
         ppnp_sparse_failed = False
         try:
@@ -356,18 +356,18 @@ class Test_FullBatchLinkGenerator:
             [X, tind, A], y = gen[0]
             A_dense = A[0]
 
-        assert np.allclose(X, gen.features)  # X should be equal to gen.features
+        np.testing.assert_allclose(X, gen.features)  # X should be equal to gen.features
         assert isinstance(tind, np.ndarray)
         assert tind.ndim == 3
         assert tind.shape[1] == len(link_ids)
         assert tind.shape[2] == 2
 
         if link_targets is not None:
-            assert np.allclose(y, link_targets)
+            np.testing.assert_allclose(y, link_targets)
 
         # Check that the diagonals are one
         if method == "self_loops":
-            assert np.allclose(A_dense.diagonal(), 1)
+            np.testing.assert_allclose(A_dense.diagonal(), 1)
 
         return A_dense, tind, y
 
@@ -377,22 +377,22 @@ class Test_FullBatchLinkGenerator:
         _, tind, y = self.generator_flow(
             self.G, link_ids, None, sparse=False, method="none"
         )
-        assert np.allclose(tind.reshape((3, 2)), link_ids)
+        np.testing.assert_allclose(tind.reshape((3, 2)), link_ids)
         _, tind, y = self.generator_flow(
             self.G, link_ids, None, sparse=True, method="none"
         )
-        assert np.allclose(tind.reshape((3, 2)), link_ids)
+        np.testing.assert_allclose(tind.reshape((3, 2)), link_ids)
 
     def test_generator_flow_withtargets(self):
         link_ids = list(self.G.edges())[:3]
         link_targets = np.ones((len(link_ids), self.target_dim)) * np.arange(3)[:, None]
         _, tind, y = self.generator_flow(self.G, link_ids, link_targets, sparse=True)
-        assert np.allclose(tind.reshape((3, 2)), link_ids)
-        assert np.allclose(y, link_targets[:3])
+        np.testing.assert_allclose(tind.reshape((3, 2)), link_ids)
+        np.testing.assert_allclose(y, link_targets[:3])
 
         _, tind, y = self.generator_flow(self.G, link_ids, link_targets, sparse=False)
-        assert np.allclose(tind.reshape((3, 2)), link_ids)
-        assert np.allclose(y, link_targets[:3])
+        np.testing.assert_allclose(tind.reshape((3, 2)), link_ids)
+        np.testing.assert_allclose(y, link_targets[:3])
 
     def test_generator_flow_targets_as_list(self):
         generator = FullBatchLinkGenerator(self.G)
@@ -419,7 +419,7 @@ class Test_FullBatchLinkGenerator:
         assert generator.name == "test"
 
         A = self.G.to_adjacency_matrix().toarray()
-        assert np.array_equal(A.dot(A), generator.Aadj.toarray())
+        np.testing.assert_array_equal(A.dot(A), generator.Aadj.toarray())
 
     def test_generator_methods(self):
         link_ids = list(self.G.edges())[:10]
@@ -432,48 +432,48 @@ class Test_FullBatchLinkGenerator:
         A_dense, _, _ = self.generator_flow(
             self.G, link_ids, None, sparse=True, method="none"
         )
-        assert np.allclose(A_dense, Aadj)
+        np.testing.assert_allclose(A_dense, Aadj)
         A_dense, _, _ = self.generator_flow(
             self.G, link_ids, None, sparse=False, method="none"
         )
-        assert np.allclose(A_dense, Aadj)
+        np.testing.assert_allclose(A_dense, Aadj)
 
         A_dense, _, _ = self.generator_flow(
             self.G, link_ids, None, sparse=True, method="self_loops"
         )
-        assert np.allclose(A_dense, Aadj_selfloops)
+        np.testing.assert_allclose(A_dense, Aadj_selfloops)
         A_dense, _, _ = self.generator_flow(
             self.G, link_ids, None, sparse=False, method="self_loops"
         )
-        assert np.allclose(A_dense, Aadj_selfloops)
+        np.testing.assert_allclose(A_dense, Aadj_selfloops)
 
         A_dense, _, _ = self.generator_flow(
             self.G, link_ids, None, sparse=True, method="gat"
         )
-        assert np.allclose(A_dense, Aadj_selfloops)
+        np.testing.assert_allclose(A_dense, Aadj_selfloops)
         A_dense, _, _ = self.generator_flow(
             self.G, link_ids, None, sparse=False, method="gat"
         )
-        assert np.allclose(A_dense, Aadj_selfloops)
+        np.testing.assert_allclose(A_dense, Aadj_selfloops)
 
         A_dense, _, _ = self.generator_flow(
             self.G, link_ids, None, sparse=True, method="gcn"
         )
-        assert np.allclose(A_dense, Agcn)
+        np.testing.assert_allclose(A_dense, Agcn)
         A_dense, _, _ = self.generator_flow(
             self.G, link_ids, None, sparse=False, method="gcn"
         )
-        assert np.allclose(A_dense, Agcn)
+        np.testing.assert_allclose(A_dense, Agcn)
 
         # Check other preprocessing options
         A_dense, _, _ = self.generator_flow(
             self.G, link_ids, None, sparse=True, method="sgc", k=2
         )
-        assert np.allclose(A_dense, Agcn.dot(Agcn))
+        np.testing.assert_allclose(A_dense, Agcn.dot(Agcn))
         A_dense, _, _ = self.generator_flow(
             self.G, link_ids, None, sparse=False, method="sgc", k=2
         )
-        assert np.allclose(A_dense, Agcn.dot(Agcn))
+        np.testing.assert_allclose(A_dense, Agcn.dot(Agcn))
 
         A_dense, _, _ = self.generator_flow(
             self.G,
@@ -483,7 +483,7 @@ class Test_FullBatchLinkGenerator:
             method="ppnp",
             teleport_probability=0.1,
         )
-        assert np.allclose(A_dense, Appnp)
+        np.testing.assert_allclose(A_dense, Appnp)
 
         ppnp_sparse_failed = False
         try:

--- a/tests/mapper/test_full_batch_generators.py
+++ b/tests/mapper/test_full_batch_generators.py
@@ -117,7 +117,7 @@ class Test_FullBatchNodeGenerator:
         assert tind.shape[1] == len(node_ids)
 
         if node_targets is not None:
-            np.testing.assert_allclose(y, node_targets)
+            np.testing.assert_allclose(y.squeeze(), node_targets)
 
         # Check that the diagonals are one
         if method == "self_loops":
@@ -130,31 +130,31 @@ class Test_FullBatchNodeGenerator:
         _, tind, y = self.generator_flow(
             self.G, node_ids, None, sparse=False, method="none"
         )
-        np.testing.assert_allclose(tind, range(3))
+        np.testing.assert_allclose(tind.squeeze(), range(3))
         _, tind, y = self.generator_flow(
             self.G, node_ids, None, sparse=True, method="none"
         )
-        np.testing.assert_allclose(tind, range(3))
+        np.testing.assert_allclose(tind.squeeze(), range(3))
 
         node_ids = list(self.G.nodes())
         _, tind, y = self.generator_flow(
             self.G, node_ids, None, sparse=False, method="none"
         )
-        np.testing.assert_allclose(tind, range(len(node_ids)))
+        np.testing.assert_allclose(tind.squeeze(), range(len(node_ids)))
         _, tind, y = self.generator_flow(
             self.G, node_ids, None, sparse=True, method="none"
         )
-        np.testing.assert_allclose(tind, range(len(node_ids)))
+        np.testing.assert_allclose(tind.squeeze(), range(len(node_ids)))
 
     def test_generator_flow_withtargets(self):
         node_ids = list(self.G.nodes())[:3]
         node_targets = np.ones((len(node_ids), self.target_dim)) * np.arange(3)[:, None]
         _, tind, y = self.generator_flow(self.G, node_ids, node_targets, sparse=True)
-        np.testing.assert_allclose(tind, range(3))
-        np.testing.assert_allclose(y, node_targets[:3])
+        np.testing.assert_allclose(tind.squeeze(), range(3))
+        np.testing.assert_allclose(y.squeeze(), node_targets[:3])
         _, tind, y = self.generator_flow(self.G, node_ids, node_targets, sparse=False)
-        np.testing.assert_allclose(tind, range(3))
-        np.testing.assert_allclose(y, node_targets[:3])
+        np.testing.assert_allclose(tind.squeeze(), range(3))
+        np.testing.assert_allclose(y.squeeze(), node_targets[:3])
 
         node_ids = list(self.G.nodes())[::-1]
         node_targets = (
@@ -162,8 +162,8 @@ class Test_FullBatchNodeGenerator:
             * np.arange(len(node_ids))[:, None]
         )
         _, tind, y = self.generator_flow(self.G, node_ids, node_targets)
-        np.testing.assert_allclose(tind, range(len(node_ids))[::-1])
-        np.testing.assert_allclose(y, node_targets)
+        np.testing.assert_allclose(tind.squeeze(), range(len(node_ids))[::-1])
+        np.testing.assert_allclose(y.squeeze(), node_targets)
 
     def test_generator_flow_targets_as_list(self):
         generator = FullBatchNodeGenerator(self.G)
@@ -363,7 +363,7 @@ class Test_FullBatchLinkGenerator:
         assert tind.shape[2] == 2
 
         if link_targets is not None:
-            np.testing.assert_allclose(y, link_targets)
+            np.testing.assert_allclose(y.squeeze(), link_targets)
 
         # Check that the diagonals are one
         if method == "self_loops":
@@ -388,11 +388,11 @@ class Test_FullBatchLinkGenerator:
         link_targets = np.ones((len(link_ids), self.target_dim)) * np.arange(3)[:, None]
         _, tind, y = self.generator_flow(self.G, link_ids, link_targets, sparse=True)
         np.testing.assert_allclose(tind.reshape((3, 2)), link_ids)
-        np.testing.assert_allclose(y, link_targets[:3])
+        np.testing.assert_allclose(y.squeeze(), link_targets[:3])
 
         _, tind, y = self.generator_flow(self.G, link_ids, link_targets, sparse=False)
         np.testing.assert_allclose(tind.reshape((3, 2)), link_ids)
-        np.testing.assert_allclose(y, link_targets[:3])
+        np.testing.assert_allclose(y.squeeze(), link_targets[:3])
 
     def test_generator_flow_targets_as_list(self):
         generator = FullBatchLinkGenerator(self.G)

--- a/tests/mapper/test_graphwave_generator.py
+++ b/tests/mapper/test_graphwave_generator.py
@@ -34,7 +34,9 @@ def _epoch_as_matrix(dataset):
 def test_init(barbell):
     generator = GraphWaveGenerator(barbell, scales=(0.1, 2, 3, 4), degree=10)
 
-    assert np.array_equal(generator.scales, np.array((0.1, 2, 3, 4)).astype(np.float32))
+    np.testing.assert_array_equal(
+        generator.scales, np.array((0.1, 2, 3, 4)).astype(np.float32)
+    )
     assert generator.coeffs.shape == (4, 10 + 1)
     assert generator.laplacian.shape == (
         barbell.number_of_nodes(),
@@ -100,7 +102,8 @@ def test_flow_shuffle(barbell, shuffle):
     if shuffle:
         assert not any(np.array_equal(first, r) for r in rest)
     else:
-        assert all(np.array_equal(first, r) for r in rest)
+        for r in rest:
+            np.testing.assert_array_equal(first, r)
 
 
 def test_determinism(barbell):
@@ -130,7 +133,7 @@ def test_determinism(barbell):
 
     second_epcoh = _epoch_as_matrix(embeddings_dataset)
 
-    assert np.array_equal(first_epoch, second_epcoh)
+    np.testing.assert_array_equal(first_epoch, second_epcoh)
 
 
 @pytest.mark.parametrize("repeat", [False, True])
@@ -266,4 +269,4 @@ def test_chebyshev(barbell):
     actual_embeddings = _epoch_as_matrix(actual_dataset)
 
     # compare exactly calculated wavelets to chebyshev
-    assert np.allclose(actual_embeddings, expected_embeddings, rtol=1e-2)
+    np.testing.assert_allclose(actual_embeddings, expected_embeddings, rtol=1e-2)

--- a/tests/mapper/test_node_mappers.py
+++ b/tests/mapper/test_node_mappers.py
@@ -870,15 +870,15 @@ class Test_FullBatchNodeGenerator:
             [X, tind, A], y = gen[0]
             A_dense = A[0]
 
-        assert np.allclose(X, gen.features)  # X should be equal to gen.features
+        np.testing.assert_allclose(X, gen.features)  # X should be equal to gen.features
         assert tind.shape[1] == len(node_ids)
 
         if node_targets is not None:
-            assert np.allclose(y, node_targets)
+            np.testing.assert_allclose(y, node_targets)
 
         # Check that the diagonals are one
         if method == "self_loops":
-            assert np.allclose(A_dense.diagonal(), 1)
+            np.testing.assert_allclose(A_dense.diagonal(), 1)
 
         return A_dense, tind, y
 
@@ -887,31 +887,31 @@ class Test_FullBatchNodeGenerator:
         _, tind, y = self.generator_flow(
             self.G, node_ids, None, sparse=False, method="none"
         )
-        assert np.allclose(tind, range(3))
+        np.testing.assert_allclose(tind, range(3))
         _, tind, y = self.generator_flow(
             self.G, node_ids, None, sparse=True, method="none"
         )
-        assert np.allclose(tind, range(3))
+        np.testing.assert_allclose(tind, range(3))
 
         node_ids = list(self.G.nodes())
         _, tind, y = self.generator_flow(
             self.G, node_ids, None, sparse=False, method="none"
         )
-        assert np.allclose(tind, range(len(node_ids)))
+        np.testing.assert_allclose(tind, range(len(node_ids)))
         _, tind, y = self.generator_flow(
             self.G, node_ids, None, sparse=True, method="none"
         )
-        assert np.allclose(tind, range(len(node_ids)))
+        np.testing.assert_allclose(tind, range(len(node_ids)))
 
     def test_generator_flow_withtargets(self):
         node_ids = list(self.G.nodes())[:3]
         node_targets = np.ones((len(node_ids), self.target_dim)) * np.arange(3)[:, None]
         _, tind, y = self.generator_flow(self.G, node_ids, node_targets, sparse=True)
-        assert np.allclose(tind, range(3))
-        assert np.allclose(y, node_targets[:3])
+        np.testing.assert_allclose(tind, range(3))
+        np.testing.assert_allclose(y, node_targets[:3])
         _, tind, y = self.generator_flow(self.G, node_ids, node_targets, sparse=False)
-        assert np.allclose(tind, range(3))
-        assert np.allclose(y, node_targets[:3])
+        np.testing.assert_allclose(tind, range(3))
+        np.testing.assert_allclose(y, node_targets[:3])
 
         node_ids = list(self.G.nodes())[::-1]
         node_targets = (
@@ -919,8 +919,8 @@ class Test_FullBatchNodeGenerator:
             * np.arange(len(node_ids))[:, None]
         )
         _, tind, y = self.generator_flow(self.G, node_ids, node_targets)
-        assert np.allclose(tind, range(len(node_ids))[::-1])
-        assert np.allclose(y, node_targets)
+        np.testing.assert_allclose(tind, range(len(node_ids))[::-1])
+        np.testing.assert_allclose(y, node_targets)
 
     def test_generator_flow_targets_as_list(self):
         generator = FullBatchNodeGenerator(self.G)
@@ -942,7 +942,7 @@ class Test_FullBatchNodeGenerator:
     def test_fullbatch_generator_init_1(self):
         G, feats = create_graph_features()
         generator = FullBatchNodeGenerator(G, method=None)
-        assert np.array_equal(feats, generator.features)
+        np.testing.assert_array_equal(feats, generator.features)
 
     def test_fullbatch_generator_init_3(self):
         G, _ = create_graph_features()
@@ -961,7 +961,7 @@ class Test_FullBatchNodeGenerator:
         assert generator.name == "test"
 
         A = G.to_adjacency_matrix().toarray()
-        assert np.array_equal(A.dot(A), generator.Aadj.toarray())
+        np.testing.assert_array_equal(A.dot(A), generator.Aadj.toarray())
 
     def test_generator_methods(self):
         node_ids = list(self.G.nodes())
@@ -974,48 +974,48 @@ class Test_FullBatchNodeGenerator:
         A_dense, _, _ = self.generator_flow(
             self.G, node_ids, None, sparse=True, method="none"
         )
-        assert np.allclose(A_dense, Aadj)
+        np.testing.assert_allclose(A_dense, Aadj)
         A_dense, _, _ = self.generator_flow(
             self.G, node_ids, None, sparse=False, method="none"
         )
-        assert np.allclose(A_dense, Aadj)
+        np.testing.assert_allclose(A_dense, Aadj)
 
         A_dense, _, _ = self.generator_flow(
             self.G, node_ids, None, sparse=True, method="self_loops"
         )
-        assert np.allclose(A_dense, Aadj_selfloops)
+        np.testing.assert_allclose(A_dense, Aadj_selfloops)
         A_dense, _, _ = self.generator_flow(
             self.G, node_ids, None, sparse=False, method="self_loops"
         )
-        assert np.allclose(A_dense, Aadj_selfloops)
+        np.testing.assert_allclose(A_dense, Aadj_selfloops)
 
         A_dense, _, _ = self.generator_flow(
             self.G, node_ids, None, sparse=True, method="gat"
         )
-        assert np.allclose(A_dense, Aadj_selfloops)
+        np.testing.assert_allclose(A_dense, Aadj_selfloops)
         A_dense, _, _ = self.generator_flow(
             self.G, node_ids, None, sparse=False, method="gat"
         )
-        assert np.allclose(A_dense, Aadj_selfloops)
+        np.testing.assert_allclose(A_dense, Aadj_selfloops)
 
         A_dense, _, _ = self.generator_flow(
             self.G, node_ids, None, sparse=True, method="gcn"
         )
-        assert np.allclose(A_dense, Agcn)
+        np.testing.assert_allclose(A_dense, Agcn)
         A_dense, _, _ = self.generator_flow(
             self.G, node_ids, None, sparse=False, method="gcn"
         )
-        assert np.allclose(A_dense, Agcn)
+        np.testing.assert_allclose(A_dense, Agcn)
 
         # Check other preprocessing options
         A_dense, _, _ = self.generator_flow(
             self.G, node_ids, None, sparse=True, method="sgc", k=2
         )
-        assert np.allclose(A_dense, Agcn.dot(Agcn))
+        np.testing.assert_allclose(A_dense, Agcn.dot(Agcn))
         A_dense, _, _ = self.generator_flow(
             self.G, node_ids, None, sparse=False, method="sgc", k=2
         )
-        assert np.allclose(A_dense, Agcn.dot(Agcn))
+        np.testing.assert_allclose(A_dense, Agcn.dot(Agcn))
 
         A_dense, _, _ = self.generator_flow(
             self.G,
@@ -1025,7 +1025,7 @@ class Test_FullBatchNodeGenerator:
             method="ppnp",
             teleport_probability=0.1,
         )
-        assert np.allclose(A_dense, Appnp)
+        np.testing.assert_allclose(A_dense, Appnp)
 
         ppnp_sparse_failed = False
         try:

--- a/tests/mapper/test_node_mappers.py
+++ b/tests/mapper/test_node_mappers.py
@@ -874,7 +874,7 @@ class Test_FullBatchNodeGenerator:
         assert tind.shape[1] == len(node_ids)
 
         if node_targets is not None:
-            np.testing.assert_allclose(y, node_targets)
+            np.testing.assert_allclose(y.squeeze(), node_targets)
 
         # Check that the diagonals are one
         if method == "self_loops":
@@ -887,31 +887,31 @@ class Test_FullBatchNodeGenerator:
         _, tind, y = self.generator_flow(
             self.G, node_ids, None, sparse=False, method="none"
         )
-        np.testing.assert_allclose(tind, range(3))
+        np.testing.assert_allclose(tind.squeeze(), range(3))
         _, tind, y = self.generator_flow(
             self.G, node_ids, None, sparse=True, method="none"
         )
-        np.testing.assert_allclose(tind, range(3))
+        np.testing.assert_allclose(tind.squeeze(), range(3))
 
         node_ids = list(self.G.nodes())
         _, tind, y = self.generator_flow(
             self.G, node_ids, None, sparse=False, method="none"
         )
-        np.testing.assert_allclose(tind, range(len(node_ids)))
+        np.testing.assert_allclose(tind.squeeze(), range(len(node_ids)))
         _, tind, y = self.generator_flow(
             self.G, node_ids, None, sparse=True, method="none"
         )
-        np.testing.assert_allclose(tind, range(len(node_ids)))
+        np.testing.assert_allclose(tind.squeeze(), range(len(node_ids)))
 
     def test_generator_flow_withtargets(self):
         node_ids = list(self.G.nodes())[:3]
         node_targets = np.ones((len(node_ids), self.target_dim)) * np.arange(3)[:, None]
         _, tind, y = self.generator_flow(self.G, node_ids, node_targets, sparse=True)
-        np.testing.assert_allclose(tind, range(3))
-        np.testing.assert_allclose(y, node_targets[:3])
+        np.testing.assert_allclose(tind.squeeze(), range(3))
+        np.testing.assert_allclose(y.squeeze(), node_targets[:3])
         _, tind, y = self.generator_flow(self.G, node_ids, node_targets, sparse=False)
-        np.testing.assert_allclose(tind, range(3))
-        np.testing.assert_allclose(y, node_targets[:3])
+        np.testing.assert_allclose(tind.squeeze(), range(3))
+        np.testing.assert_allclose(y.squeeze(), node_targets[:3])
 
         node_ids = list(self.G.nodes())[::-1]
         node_targets = (
@@ -919,8 +919,8 @@ class Test_FullBatchNodeGenerator:
             * np.arange(len(node_ids))[:, None]
         )
         _, tind, y = self.generator_flow(self.G, node_ids, node_targets)
-        np.testing.assert_allclose(tind, range(len(node_ids))[::-1])
-        np.testing.assert_allclose(y, node_targets)
+        np.testing.assert_allclose(tind.squeeze(), range(len(node_ids))[::-1])
+        np.testing.assert_allclose(y.squeeze(), node_targets)
 
     def test_generator_flow_targets_as_list(self):
         generator = FullBatchNodeGenerator(self.G)

--- a/tests/mapper/test_relational_node_mappers.py
+++ b/tests/mapper/test_relational_node_mappers.py
@@ -80,34 +80,34 @@ class Test_RelationalFullBatchNodeGenerator:
         assert tind.shape[1] == len(node_ids)
 
         if node_targets is not None:
-            np.testing.assert_allclose(y, node_targets)
+            np.testing.assert_allclose(y.squeeze(), node_targets)
 
         return As_dense, tind, y
 
     def test_generator_flow_notargets(self):
         node_ids = list(self.G.nodes())[:3]
         _, tind, y = self.generator_flow(self.G, node_ids, None, sparse=False)
-        np.testing.assert_allclose(tind, range(3))
+        np.testing.assert_allclose(tind.squeeze(), range(3))
 
         _, tind, y = self.generator_flow(self.G, node_ids, None, sparse=True)
-        np.testing.assert_allclose(tind, range(3))
+        np.testing.assert_allclose(tind.squeeze(), range(3))
 
         node_ids = list(self.G.nodes())
         _, tind, y = self.generator_flow(self.G, node_ids, None, sparse=False)
-        np.testing.assert_allclose(tind, range(len(node_ids)))
+        np.testing.assert_allclose(tind.squeeze(), range(len(node_ids)))
 
         _, tind, y = self.generator_flow(self.G, node_ids, None, sparse=True)
-        np.testing.assert_allclose(tind, range(len(node_ids)))
+        np.testing.assert_allclose(tind.squeeze(), range(len(node_ids)))
 
     def test_generator_flow_withtargets(self):
         node_ids = list(self.G.nodes())[:3]
         node_targets = np.ones((len(node_ids), self.target_dim)) * np.arange(3)[:, None]
         _, tind, y = self.generator_flow(self.G, node_ids, node_targets, sparse=True)
-        np.testing.assert_allclose(tind, range(3))
-        np.testing.assert_allclose(y, node_targets[:3])
+        np.testing.assert_allclose(tind.squeeze(), range(3))
+        np.testing.assert_allclose(y.squeeze(), node_targets[:3])
         _, tind, y = self.generator_flow(self.G, node_ids, node_targets, sparse=False)
-        np.testing.assert_allclose(tind, range(3))
-        np.testing.assert_allclose(y, node_targets[:3])
+        np.testing.assert_allclose(tind.squeeze(), range(3))
+        np.testing.assert_allclose(y.squeeze(), node_targets[:3])
 
         node_ids = list(self.G.nodes())[::-1]
         node_targets = (
@@ -115,8 +115,8 @@ class Test_RelationalFullBatchNodeGenerator:
             * np.arange(len(node_ids))[:, None]
         )
         _, tind, y = self.generator_flow(self.G, node_ids, node_targets)
-        np.testing.assert_allclose(tind, range(len(node_ids))[::-1])
-        np.testing.assert_allclose(y, node_targets)
+        np.testing.assert_allclose(tind.squeeze(), range(len(node_ids))[::-1])
+        np.testing.assert_allclose(y.squeeze(), node_targets)
 
     def test_generator_flow_targets_as_list(self):
         generator = RelationalFullBatchNodeGenerator(self.G)

--- a/tests/mapper/test_relational_node_mappers.py
+++ b/tests/mapper/test_relational_node_mappers.py
@@ -76,38 +76,38 @@ class Test_RelationalFullBatchNodeGenerator:
             [X, tind, *As], y = gen[0]
             As_dense = As
 
-        assert np.allclose(X, gen.features)  # X should be equal to gen.features
+        np.testing.assert_allclose(X, gen.features)  # X should be equal to gen.features
         assert tind.shape[1] == len(node_ids)
 
         if node_targets is not None:
-            assert np.allclose(y, node_targets)
+            np.testing.assert_allclose(y, node_targets)
 
         return As_dense, tind, y
 
     def test_generator_flow_notargets(self):
         node_ids = list(self.G.nodes())[:3]
         _, tind, y = self.generator_flow(self.G, node_ids, None, sparse=False)
-        assert np.allclose(tind, range(3))
+        np.testing.assert_allclose(tind, range(3))
 
         _, tind, y = self.generator_flow(self.G, node_ids, None, sparse=True)
-        assert np.allclose(tind, range(3))
+        np.testing.assert_allclose(tind, range(3))
 
         node_ids = list(self.G.nodes())
         _, tind, y = self.generator_flow(self.G, node_ids, None, sparse=False)
-        assert np.allclose(tind, range(len(node_ids)))
+        np.testing.assert_allclose(tind, range(len(node_ids)))
 
         _, tind, y = self.generator_flow(self.G, node_ids, None, sparse=True)
-        assert np.allclose(tind, range(len(node_ids)))
+        np.testing.assert_allclose(tind, range(len(node_ids)))
 
     def test_generator_flow_withtargets(self):
         node_ids = list(self.G.nodes())[:3]
         node_targets = np.ones((len(node_ids), self.target_dim)) * np.arange(3)[:, None]
         _, tind, y = self.generator_flow(self.G, node_ids, node_targets, sparse=True)
-        assert np.allclose(tind, range(3))
-        assert np.allclose(y, node_targets[:3])
+        np.testing.assert_allclose(tind, range(3))
+        np.testing.assert_allclose(y, node_targets[:3])
         _, tind, y = self.generator_flow(self.G, node_ids, node_targets, sparse=False)
-        assert np.allclose(tind, range(3))
-        assert np.allclose(y, node_targets[:3])
+        np.testing.assert_allclose(tind, range(3))
+        np.testing.assert_allclose(y, node_targets[:3])
 
         node_ids = list(self.G.nodes())[::-1]
         node_targets = (
@@ -115,8 +115,8 @@ class Test_RelationalFullBatchNodeGenerator:
             * np.arange(len(node_ids))[:, None]
         )
         _, tind, y = self.generator_flow(self.G, node_ids, node_targets)
-        assert np.allclose(tind, range(len(node_ids))[::-1])
-        assert np.allclose(y, node_targets)
+        np.testing.assert_allclose(tind, range(len(node_ids))[::-1])
+        np.testing.assert_allclose(y, node_targets)
 
     def test_generator_flow_targets_as_list(self):
         generator = RelationalFullBatchNodeGenerator(self.G)
@@ -140,7 +140,7 @@ class Test_RelationalFullBatchNodeGenerator:
 
         generator = RelationalFullBatchNodeGenerator(G, name="test")
         assert generator.name == "test"
-        assert np.array_equal(feats, generator.features)
+        np.testing.assert_array_equal(feats, generator.features)
 
     def test_fullbatch_generator_init_3(self):
         G, _ = create_graph_features()
@@ -189,10 +189,8 @@ class Test_RelationalFullBatchNodeGenerator:
 
             As.append(A)
 
-        assert all(
-            np.array_equal(A_1.dot(A_1).todense(), A_2.todense())
-            for A_1, A_2 in zip(As, generator.As)
-        )
+        for A_1, A_2 in zip(As, generator.As):
+            np.testing.assert_array_equal(A_1.dot(A_1).todense(), A_2.todense())
 
     def test_weighted(self):
         G, _ = create_graph_features(edge_weights=True)

--- a/tests/reproducibility/fixtures.py
+++ b/tests/reproducibility/fixtures.py
@@ -21,7 +21,9 @@ import tensorflow as tf
 def models_equals(model1, model2):
     w1 = model1.get_weights()
     w2 = model2.get_weights()
-    return all(np.array_equal(w, w_new) for w, w_new in zip(w1, w2))
+    assert len(w1) == len(w2)
+    for w, w_new in zip(w1, w2):
+        np.testing.assert_array_equal(w, w_new)
 
 
 def assert_reproducible(func, num_iter=10):
@@ -36,10 +38,7 @@ def assert_reproducible(func, num_iter=10):
     model = func()
     for i in range(num_iter):
         model_new = func()
-        assert models_equals(model, model_new), (
-            model.get_weights(),
-            model_new.get_weights(),
-        )
+        models_equals(model, model_new)
 
     # clear the tensorflow session to free memory
     tf.keras.backend.clear_session()

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -39,4 +39,4 @@ def test_graph_log_likelihood():
 
     expected_loss = expected_loss.sum()
 
-    assert np.allclose(actual_loss, expected_loss, rtol=0.01)
+    np.testing.assert_allclose(actual_loss, expected_loss, rtol=0.01)


### PR DESCRIPTION
The output of np.testing.assert_array_equal is much more informative than the output of `assert np.array_equal`, because it includes things like the number of different elements and their absolute and relative differences, e.g.:

```python
>>> assert np.array_equal([1, 2], [3, 2])
Traceback (most recent call last):
...
AssertionError
>>> np.testing.assert_array_equal([1, 2], [3, 2])
Traceback (most recent call last):
...
AssertionError: 
Arrays are not equal

Mismatch: 50%
Max absolute difference: 2
Max relative difference: 0.66666667
 x: array([1, 2])
 y: array([3, 2])
```

The same is true of `np.testing.assert_allclose` vs. `np.allclose`. This makes our test failure output both:

- more informative, because there's a hint about how wrong a failure is
- smaller, for the reproducibility tests (which previously included all of the models' weight NumPy arrays, in their entirety)