### PR TITLE
Fix saving and loading of (non-sparse) APPNP models

### DIFF
--- a/stellargraph/layer/appnp.py
+++ b/stellargraph/layer/appnp.py
@@ -80,7 +80,6 @@ class APPNPPropagationLayer(Layer):
 
         config = {
             "units": self.units,
-            "final_layer": self.final_layer,
             "teleport_probability": self.teleport_probability,
         }
 

--- a/tests/layer/test_appnp.py
+++ b/tests/layer/test_appnp.py
@@ -293,10 +293,7 @@ def test_APPNP_apply_propagate_model_sparse():
 
 @pytest.mark.parametrize(
     "sparse",
-    [
-        pytest.param(False, marks=pytest.mark.xfail(reason="FIXME #1680")),
-        pytest.param(True, marks=pytest.mark.xfail(reason="FIXME #1251")),
-    ],
+    [False, pytest.param(True, marks=pytest.mark.xfail(reason="FIXME #1251"))],
 )
 def test_APPNP_save_load(tmpdir, sparse):
     G, _ = create_graph_features()


### PR DESCRIPTION
The `final_layer` access was left over from #1204.

Sparse APPNP models still hit #1251.

See: #1680