### PR TITLE
Implement self-adversarial negative sampling knowledge graph loss

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -231,6 +231,12 @@ Neo4j Connector
   :members: Neo4jStellarGraph, Neo4jStellarDiGraph, Neo4jGraphSAGENodeGenerator, Neo4jDirectedGraphSAGENodeGenerator, Neo4jSampledBreadthFirstWalk, Neo4jDirectedBreadthFirstNeighbors
 
 
+Loss functions
+------------------------
+
+.. automodule:: stellargraph.losses
+  :members: graph_log_likelihood, SelfAdversarialNegativeSampling
+
 Utilities
 ------------------------
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -82,6 +82,7 @@ Muhan
 Nesreen
 NetworkX
 Neumann
+Nie
 Nitesh
 Oksana
 Peng
@@ -96,6 +97,7 @@ Rfou
 Riedel
 Rong
 Rossi
+RotatE
 RotE
 RotH
 SNE

--- a/stellargraph/losses.py
+++ b/stellargraph/losses.py
@@ -29,7 +29,7 @@ def graph_log_likelihood(batch_adj, wys_output):
     """
     Computes the graph log likelihood loss function as in https://arxiv.org/abs/1710.09599.
 
-    This is different to most keras loss functions in that it doesn't directly compare predicted values to expected
+    This is different to most Keras loss functions in that it doesn't directly compare predicted values to expected
     values. It uses `wys_output` which contains the dot products of embeddings and expected random walks,
     and part of the adjacency matrix `batch_adj` to calculate how well the node embeddings capture the graph
     structure in some sense.

--- a/stellargraph/losses.py
+++ b/stellargraph/losses.py
@@ -93,10 +93,13 @@ class SelfAdversarialNegativeSampling(tf.keras.losses.Loss):
 
         denoms = tf.gather(sums, tf.maximum(flipped_labels, 0))
 
+        # adversarial sampling shouldn't influence the gradient/update
+        negative_weights = tf.stop_gradient(exp_scores / denoms)
+
         loss_elems = tf.where(
             labels > 0,
             -tf.math.log_sigmoid(logit_scores),
-            -tf.math.log_sigmoid(-logit_scores) * exp_scores / denoms,
+            -tf.math.log_sigmoid(-logit_scores) * negative_weights,
         )
 
         return tf.reduce_mean(loss_elems, axis=-1)

--- a/stellargraph/mapper/knowledge_graph.py
+++ b/stellargraph/mapper/knowledge_graph.py
@@ -75,11 +75,13 @@ class KGTripleGenerator(Generator):
 
             sample_strategy (str, optional): the sampling strategy to use for negative sampling, if ``negative_samples`` is not None. Supported values:
 
-                ``uniform`` Uniform sampling, where a negative edge is created from a positive edge
-                  in ``edges`` by replacing the source or destination entity with a uniformly
-                  sampled random entity in the graph (without verifying if the edge exists in the
-                  graph: for sparse graphs, this is unlikely). Each element in a batch is labelled
-                  as 1 (positive) or 0 (negative). An appropriate loss function is
+                ``uniform``
+
+                  Uniform sampling, where a negative edge is created from a positive edge in
+                  ``edges`` by replacing the source or destination entity with a uniformly sampled
+                  random entity in the graph (without verifying if the edge exists in the graph: for
+                  sparse graphs, this is unlikely). Each element in a batch is labelled as 1
+                  (positive) or 0 (negative). An appropriate loss function is
                   :class:`tensorflow.keras.losses.BinaryCrossentropy` (probably with
                   ``from_logits=True``).
 

--- a/stellargraph/mapper/knowledge_graph.py
+++ b/stellargraph/mapper/knowledge_graph.py
@@ -24,6 +24,7 @@ from tensorflow.keras.utils import Sequence
 from ..globalvar import SOURCE, TARGET, TYPE_ATTR_NAME
 from ..random import random_state, SeededPerBatch
 from .base import Generator
+from ..core.validation import comma_sep, require_integer_in_range
 
 
 class KGTripleGenerator(Generator):
@@ -53,7 +54,7 @@ class KGTripleGenerator(Generator):
     def num_batch_dims(self):
         return 1
 
-    def flow(self, edges, negative_samples=None, shuffle=False, seed=None):
+    def flow(self, edges, negative_samples=None, sample_strategy="uniform", shuffle=False, seed=None):
         """
         Create a Keras Sequence yielding the edges/triples in ``edges``, potentially with some negative
         edges.
@@ -64,6 +65,25 @@ class KGTripleGenerator(Generator):
         Args:
             edges: the edges/triples to feed into a knowledge graph model.
             negative_samples (int, optional): the number of negative samples to generate for each positive edge.
+
+            sample_strategy (str, optional): the sampling strategy to use for negative sampling, if ``negative_samples`` is not None. Supported values:
+
+                ``uniform`` Uniform sampling, where a negative edge is created from a positive edge
+                  in ``edges`` by replacing the source or destination entity with a uniformly
+                  sampled random entity in the graph (without verifying if the edge exists in the
+                  graph: for sparse graphs, this is unlikely). Each element in a batch is labelled
+                  as 1 (positive) or 0 (negative). An appropriate loss function is
+                  :class:`tensorflow.keras.losses.BinaryCrossentropy` (probably with
+                  ``from_logits=True``).
+
+                ``self-adversarial``
+
+                  Self-adversarial sampling from [1], where each edge is sampled in the same manner
+                  as ``uniform`` sampling. Each element in a batch is labelled as 1 (positive) or an
+                  integer in ``[0, -batch_size)`` (negative). An appropriate loss function is
+                  :class:`stellargraph.losses.SelfAdversarialNegativeSampling`.
+
+                  [1] Z. Sun, Z.-H. Deng, J.-Y. Nie, and J. Tang, “RotatE: Knowledge Graph Embedding by Relational Rotation in Complex Space,” `arXiv:1902.10197 <http://arxiv.org/abs/1902.10197>`_, Feb. 2019.
 
         Returns:
             A Keras sequence that can be passed to the ``fit`` and ``predict`` method of knowledge-graph models.
@@ -78,14 +98,12 @@ class KGTripleGenerator(Generator):
             )
 
         if negative_samples is not None:
-            if not isinstance(negative_samples, int):
-                raise TypeError(
-                    f"negative_samples: expected int or None, found {type(negative_samples).__name__}"
-                )
-            if negative_samples < 0:
-                raise ValueError(
-                    f"negative_samples: expected non-negative integer, found {negative_samples}"
-                )
+            require_integer_in_range(negative_samples, "negative_samples", min_val=0)
+
+        supported_strategies = ["uniform", "self-adversarial"]
+        if sample_strategy not in supported_strategies:
+            raise ValueError(f"sample_strategy: expected one of {comma_sep(supported_strategies)}, found {sample_strategy!r}")
+
 
         source_ilocs = self.G.node_ids_to_ilocs(sources)
         rel_ilocs = self.G.edge_type_names_to_ilocs(rels)
@@ -99,6 +117,7 @@ class KGTripleGenerator(Generator):
             batch_size=self.batch_size,
             shuffle=shuffle,
             negative_samples=negative_samples,
+            sample_strategy=sample_strategy,
             seed=seed,
         )
 
@@ -114,6 +133,7 @@ class KGTripleSequence(Sequence):
         batch_size,
         shuffle,
         negative_samples,
+        sample_strategy,
         seed,
     ):
         self.max_node_iloc = max_node_iloc
@@ -126,6 +146,7 @@ class KGTripleSequence(Sequence):
         self.target_ilocs = np.asarray(target_ilocs)
 
         self.negative_samples = negative_samples
+        self.sample_strategy = sample_strategy
 
         self.batch_size = batch_size
         self.seed = seed
@@ -171,9 +192,19 @@ class KGTripleSequence(Sequence):
             s_iloc[positive_count:][change_source] = new_nodes[:source_changes]
             o_iloc[positive_count:][~change_source] = new_nodes[source_changes:]
 
-            targets = np.repeat(
-                np.array([1, 0], dtype=np.float32), [positive_count, negative_count]
-            )
+            if self.sample_strategy == "uniform":
+                targets = np.repeat(
+                    np.array([1, 0], dtype=np.float32), [positive_count, negative_count]
+                )
+            elif self.sample_strategy == "self-adversarial":
+                # the negative samples are labelled with an arbitrary within-batch integer <= 0, based on
+                # which positive edge they came from.
+                targets = np.tile(np.arange(0, -positive_count, -1), 1 + self.negative_samples)
+                # the positive examples are labelled with 1
+                targets[:positive_count] = 1
+            else:
+                raise ValueError(f"unknown sample_strategy: {sample_strategy!r}")
+
             assert len(targets) == len(s_iloc)
 
         assert len(s_iloc) == len(r_iloc) == len(o_iloc)

--- a/stellargraph/mapper/knowledge_graph.py
+++ b/stellargraph/mapper/knowledge_graph.py
@@ -54,7 +54,14 @@ class KGTripleGenerator(Generator):
     def num_batch_dims(self):
         return 1
 
-    def flow(self, edges, negative_samples=None, sample_strategy="uniform", shuffle=False, seed=None):
+    def flow(
+        self,
+        edges,
+        negative_samples=None,
+        sample_strategy="uniform",
+        shuffle=False,
+        seed=None,
+    ):
         """
         Create a Keras Sequence yielding the edges/triples in ``edges``, potentially with some negative
         edges.
@@ -102,8 +109,9 @@ class KGTripleGenerator(Generator):
 
         supported_strategies = ["uniform", "self-adversarial"]
         if sample_strategy not in supported_strategies:
-            raise ValueError(f"sample_strategy: expected one of {comma_sep(supported_strategies)}, found {sample_strategy!r}")
-
+            raise ValueError(
+                f"sample_strategy: expected one of {comma_sep(supported_strategies)}, found {sample_strategy!r}"
+            )
 
         source_ilocs = self.G.node_ids_to_ilocs(sources)
         rel_ilocs = self.G.edge_type_names_to_ilocs(rels)
@@ -199,7 +207,9 @@ class KGTripleSequence(Sequence):
             elif self.sample_strategy == "self-adversarial":
                 # the negative samples are labelled with an arbitrary within-batch integer <= 0, based on
                 # which positive edge they came from.
-                targets = np.tile(np.arange(0, -positive_count, -1), 1 + self.negative_samples)
+                targets = np.tile(
+                    np.arange(0, -positive_count, -1), 1 + self.negative_samples
+                )
                 # the positive examples are labelled with 1
                 targets[:positive_count] = 1
             else:

--- a/tests/layer/test_knowledge_graph.py
+++ b/tests/layer/test_knowledge_graph.py
@@ -82,7 +82,9 @@ def test_complex(knowledge_graph, sample_strategy):
     # check the model can be trained on a few (uneven) batches
     model.fit(
         gen.flow(df.iloc[:7], negative_samples=2, sample_strategy=sample_strategy),
-        validation_data=gen.flow(df.iloc[7:14], negative_samples=3, sample_strategy=sample_strategy),
+        validation_data=gen.flow(
+            df.iloc[7:14], negative_samples=3, sample_strategy=sample_strategy
+        ),
     )
 
     # compute the exact values based on the model by extracting the embeddings for each element and

--- a/tests/mapper/test_knowledge_graph.py
+++ b/tests/mapper/test_knowledge_graph.py
@@ -132,6 +132,7 @@ def test_kg_triple_sequence_batches(negative_samples):
         batch_size=3,
         shuffle=False,
         negative_samples=negative_samples,
+        sample_strategy="uniform",
         seed=None,
     )
     assert len(seq) == 2
@@ -153,6 +154,7 @@ def test_kg_triple_sequence_shuffle(shuffle):
         batch_size=5,
         shuffle=shuffle,
         negative_samples=None,
+        sample_strategy="uniform",
         seed=None,
     )
     assert len(seq) == 1
@@ -212,6 +214,7 @@ def test_kg_triple_sequence_seed_shuffle_negative_samples():
             batch_size=1,
             shuffle=True,
             negative_samples=5,
+            sample_strategy="uniform",
             seed=seed,
         )
 

--- a/tests/mapper/test_knowledge_graph.py
+++ b/tests/mapper/test_knowledge_graph.py
@@ -35,6 +35,7 @@ def check_sequence_output(
     source_ilocs=None,
     rel_ilocs=None,
     target_ilocs=None,
+    sample_strategy="uniform",
 ):
     s, r, o = output[0]
     l = output[1] if len(output) == 2 else None
@@ -53,7 +54,14 @@ def check_sequence_output(
     else:
         assert len(l) == expected_length
         assert set(l[:batch_size]) == {1}
-        assert set(l[batch_size:]) == {0}
+
+        negative_labels = l[batch_size:]
+        if sample_strategy == "uniform":
+            assert set(negative_labels) == {0}
+        if sample_strategy == "self-adversarial":
+            for i in range(batch_size):
+                # every batch_size'th element corresponds to the i'th positive example
+                assert set(negative_labels[i::batch_size]) == {-i}
 
         if max_node_iloc is not None:
             assert np.all((0 <= s) & (s <= max_node_iloc))
@@ -97,6 +105,18 @@ def test_kg_triple_generator_errors(knowledge_graph):
 
     with pytest.raises(ValueError, match="negative_samples: expected.*found -1"):
         gen.flow(triple_df(), negative_samples=-1)
+
+    with pytest.raises(
+        ValueError,
+        match="sample_strategy: expected one of 'uniform', 'self-adversarial', found None",
+    ):
+        gen.flow(triple_df(), sample_strategy=None)
+
+    with pytest.raises(
+        ValueError, match="sample_strategy: expected .* found 'UNIFORM'"
+    ):
+        # case-sensitive
+        gen.flow(triple_df(), sample_strategy="UNIFORM")
 
 
 @pytest.mark.parametrize("negative_samples", [None, 1, 10])
@@ -150,7 +170,8 @@ def test_kg_triple_sequence_shuffle(shuffle):
     assert all(epoch_sample_equal(first, r) for r in rest) == should_be_equal
 
 
-def test_kg_triple_sequence_negative_samples():
+@pytest.mark.parametrize("sample_strategy", ["uniform", "self-adversarial"])
+def test_kg_triple_sequence_negative_samples(sample_strategy):
     max_node_iloc = 1234567
     negative_sampless = 100
     s = [0, 1]
@@ -164,11 +185,21 @@ def test_kg_triple_sequence_negative_samples():
         batch_size=2,
         shuffle=False,
         negative_samples=negative_sampless,
+        sample_strategy=sample_strategy,
         seed=None,
     )
 
     sample = seq[0]
-    check_sequence_output(sample, 2, negative_sampless, max_node_iloc, s, r, t)
+    check_sequence_output(
+        sample,
+        2,
+        negative_sampless,
+        max_node_iloc,
+        s,
+        r,
+        t,
+        sample_strategy=sample_strategy,
+    )
 
 
 def test_kg_triple_sequence_seed_shuffle_negative_samples():

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -14,8 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from stellargraph.losses import graph_log_likelihood
+from stellargraph.losses import *
 import numpy as np
+import pytest
+import tensorflow as tf
+from scipy.special import softmax, expit  # sigmoid
 
 
 def test_graph_log_likelihood():
@@ -40,3 +43,35 @@ def test_graph_log_likelihood():
     expected_loss = expected_loss.sum()
 
     np.testing.assert_allclose(actual_loss, expected_loss, rtol=0.01)
+
+
+@pytest.mark.parametrize("from_logits", [False, True])
+@pytest.mark.parametrize("temperature", [0.0, 0.5, 1.0, 2.0])
+def test_self_adversarial_negative_sampling(temperature, from_logits):
+    labels = np.array([1, 0, -2, 0, 1], dtype=np.int32)
+    logit_scores = np.array([1.2, -2.3, 0.0, 4.5, -0.67], dtype=np.float32)
+    scores = expit(logit_scores)
+
+    loss_func = SelfAdversarialNegativeSampling(temperature, from_logits)
+
+    input_scores = tf.constant(logit_scores if from_logits else scores)
+    actual_loss = loss_func(tf.constant(labels), input_scores)
+
+    def loss_part(score, label):
+        # equations (5) and (6) in http://arxiv.org/abs/1902.10197
+        if label == 1:
+            # positive edge
+            return -np.log(score)
+
+        # Negative sample. The
+        relevant = scores[np.where(labels == label)]
+        numer = np.exp(temperature * score)
+        denom = np.sum(np.exp(temperature * relevant))
+
+        # sigmoid(-x) == 1 - sigmoid(x)
+        return -np.log(1 - score) * numer / denom
+
+    expected_loss = np.mean(
+        [loss_part(score, label) for score, label in zip(scores, labels)]
+    )
+    assert actual_loss.numpy() == pytest.approx(expected_loss, rel=1e-6)


### PR DESCRIPTION
This implements a slightly different loss function for knowledge graph algorithms. It's so called "self-adversarial", because it uses the knowledge graph's algorithm computed scores to give different weights to the negative sampled edges. The intuition is that some edges end up being "obviously" negative as the model trains, and so it's better to focus more attention on the highly-scored negative edges and ignore the very low scoring ones.

Recall that knowledge graph algorithms typically work by taking in a set of true edges, and, for each one, computing a series of corruptions or negative edges by changing the source or target nodes (leaving the other node and the edge type unchanged). This self-adversarial scoring works by grouping the negative edges by their original "parent" edge, and computing a softmax over the scores within that group. That is, for each true edge `(s, r, o)`, the scores of the negative samples `(s', r, o)` and `(s, r, o')` are compared against each other to compute the weights for that set of negative samples. Weights for negative edges created from other true edges (even in the same batch) are computed independently.

This approach gives a small, but, apparently, noticeable improvement in the performance of knowledge graph algorithms.

This is equations (5) and (6) from [1], and that paper includes an comparison of different scoring techniques in Table 7 (screenshots below, for ease of reference).

[1] Z. Sun, Z.-H. Deng, J.-Y. Nie, and J. Tang, “RotatE: Knowledge Graph Embedding by Relational Rotation in Complex Space,” [arXiv:1902.10197](http://arxiv.org/abs/1902.10197), Feb. 2019.

See: #1708

<img width="746" alt="image" src="https://user-images.githubusercontent.com/1203825/84860075-b6c0a580-b0b1-11ea-954c-a061796737cf.png">

<img width="721" alt="image" src="https://user-images.githubusercontent.com/1203825/84860091-be804a00-b0b1-11ea-86f4-7ab473dc87b7.png">
