### PR TITLE
Add basic GitHub Actions CI workflow, running pytest tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,14 +43,14 @@ jobs:
           # just runs them once (as a test)
           py.test -ra tests/ --doctest-modules \
               --cov=stellargraph --cov-report=xml \
-              -p no:cacheprovider --junitxml="junit-${{ matrix.python-version }}.xml" \
+              -p no:cacheprovider --junitxml="pytest-results-${{ matrix.python-version }}.xml" \
               --benchmark-disable
 
       - name: Upload pytest test results
         uses: actions/upload-artifact@v1
         with:
           name: pytest-results-${{ matrix.python-version }}
-          path: junit-${{ matrix.python-version }}.xml
+          path: pytest-results-${{ matrix.python-version }}.xml
         if: ${{ always() }}
 
       - name: Upload coverage to Codecov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+---
+
+name: Continuous Integration
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[test,demos]
+
+      - name: Run pytest tests
+        run: |
+          # benchmarks on shared infrastructure like the CI machines are usually unreliable (high variance), so there's no point spending too much time, hence --benchmark-disable which just runs them once (as a test)
+          py.test -ra --cov=stellargraph tests/ --doctest-modules --cov-report=xml -p no:cacheprovider --junitxml="junit-${{ matrix.python-version }}.xml" --benchmark-disable || exitCode=$?
+
+      - name: Upload pytest test results
+        uses: actions/upload-artifact@v1
+        with:
+          name: pytest-results-${{ matrix.python-version }}
+          path: junit-${{ matrix.python-version }}.xml
+        if: ${{ always() }}
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          env_vars: OS,PYTHON

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,14 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Restore cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-${{ matrix.python-version }}-pip-${{ hashFiles('setup.py') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.python-version }}-pip-
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,7 @@
 ---
-
 name: Continuous Integration
 
-on:
+"on":
   push:
     # only build each push to develop and master, other branches are built through pull requests
     branches: [develop, master]
@@ -39,8 +38,13 @@ jobs:
 
       - name: Run pytest tests
         run: |
-          # benchmarks on shared infrastructure like the CI machines are usually unreliable (high variance), so there's no point spending too much time, hence --benchmark-disable which just runs them once (as a test)
-          py.test -ra --cov=stellargraph tests/ --doctest-modules --cov-report=xml -p no:cacheprovider --junitxml="junit-${{ matrix.python-version }}.xml" --benchmark-disable || exitCode=$?
+          # benchmarks on shared infrastructure like the CI machines are usually unreliable (high
+          # variance), so there's no point spending too much time, hence --benchmark-disable which
+          # just runs them once (as a test)
+          py.test -ra tests/ --doctest-modules \
+              --cov=stellargraph --cov-report=xml \
+              -p no:cacheprovider --junitxml="junit-${{ matrix.python-version }}.xml" \
+              --benchmark-disable
 
       - name: Upload pytest test results
         uses: actions/upload-artifact@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,11 @@
 
 name: Continuous Integration
 
-on: [push, pull_request]
+on:
+  push:
+    # only build each push to develop and master, other branches are built through pull requests
+    branches: [develop, master]
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
This is an MVP of using GitHub Actions for CI instead of Buildkite. This change is designed to reduce our costs and our DevOps requirements.

It works successfully for that:

- The build is running, on Python 3.6, 3.7 and 3.8, in parallel: https://github.com/stellargraph/stellargraph/actions/runs/139107467
- The JUnit XML files are being uploaded: (see pytest-results-... in link above)
- Codecov results are being uploaded: https://codecov.io/gh/stellargraph/stellargraph/commit/6470d09d5cdb07620a352544b6e865724f4254f8/build

This is quite easy because there's native support (or actions) for:
- build matrices, with multiple options such as different Python versions
- dependency caching (so we don't have to do the prebuilding of docker images like we do on Buildkite... for now) (I haven't investigated the improvement from this, yet, though)
- attaching artefacts
- uploading codecov results

Things missing compared to Buildkite:

- clean annotation of test failures?
- everything other than pytest tests (notebooks, documentation, formatting, etc.)

These can be done as follow up work.

See: #1687