### PR TITLE
Test saving sparse full batch methods against tf-nightly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ URL = "https://github.com/stellargraph/stellargraph"
 # full tensorflow is too big for readthedocs's builder
 tensorflow = "tensorflow-cpu" if "READTHEDOCS" in os.environ else "tensorflow"
 REQUIRES = [
-    f"{tensorflow}>=2.1.0",
+    "tf-nightly==2.3.0.dev20200617",
     "numpy>=1.14",
     "scipy>=1.1.0",
     "networkx>=2.2",

--- a/tests/layer/test_appnp.py
+++ b/tests/layer/test_appnp.py
@@ -291,10 +291,7 @@ def test_APPNP_apply_propagate_model_sparse():
     assert preds_1 == pytest.approx(preds_2)
 
 
-@pytest.mark.parametrize(
-    "sparse",
-    [False, pytest.param(True, marks=pytest.mark.xfail(reason="FIXME #1251"))],
-)
+@pytest.mark.parametrize("sparse", [False, True])
 def test_APPNP_save_load(tmpdir, sparse):
     G, _ = create_graph_features()
     generator = FullBatchNodeGenerator(G, sparse=sparse)

--- a/tests/layer/test_gcn.py
+++ b/tests/layer/test_gcn.py
@@ -313,9 +313,7 @@ def test_kernel_and_bias_defaults():
             assert layer.bias_constraint is None
 
 
-@pytest.mark.parametrize(
-    "sparse", [False, pytest.param(True, marks=pytest.mark.xfail(reason="FIXME #1251"))]
-)
+@pytest.mark.parametrize("sparse", [False, True])
 def test_gcn_save_load(tmpdir, sparse):
     G, _ = create_graph_features()
     generator = FullBatchNodeGenerator(G, sparse=sparse)

--- a/tests/layer/test_rgcn.py
+++ b/tests/layer/test_rgcn.py
@@ -374,9 +374,7 @@ def test_kernel_and_bias_defaults():
 
 
 @pytest.mark.parametrize("num_bases", [0, 10])
-@pytest.mark.parametrize(
-    "sparse", [False, pytest.param(True, marks=pytest.mark.xfail(reason="FIXME #1251"))]
-)
+@pytest.mark.parametrize("sparse", [False, True])
 def test_RGCN_save_load(tmpdir, num_bases, sparse):
     graph, _ = create_graph_features()
     generator = RelationalFullBatchNodeGenerator(graph, sparse=sparse)


### PR DESCRIPTION
The upstream tensorflow issue(s) (https://github.com/tensorflow/tensorflow/issues/38465, https://github.com/tensorflow/tensorflow/issues/40373) that stopped us being able to save our sparse full batch models seems to be fixed in `tf-nightly`, based on the minimal reproducer we provided there. This PR is working out whether it works for the full code.

See: #1251