### PR TITLE
Run tests on Windows on GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,12 @@ name: Continuous Integration
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8]
+        os: [ubuntu-latest, windows-latest]
+
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
+    env:
+      JUNIT_NAME: pytest-results-${{ matrix.python-version }}-${{ matrix.os }}
+
     steps:
       - uses: actions/checkout@v2
 
@@ -44,7 +47,7 @@ jobs:
           # just runs them once (as a test)
           py.test -ra tests/ --doctest-modules \
               --cov=stellargraph --cov-report=xml \
-              -p no:cacheprovider --junitxml="pytest-results-${{ matrix.python-version }}.xml" \
+              -p no:cacheprovider --junitxml="${{ env.JUNIT_NAME }}.xml" \
               --benchmark-disable
         # explicitly use bash on windows, for consistent command parsing
         shell: bash
@@ -52,8 +55,8 @@ jobs:
       - name: Upload pytest test results
         uses: actions/upload-artifact@v1
         with:
-          name: pytest-results-${{ matrix.python-version }}
-          path: pytest-results-${{ matrix.python-version }}.xml
+          name: ${{ env.JUNIT_NAME }}
+          path: ${{ env.JUNIT_NAME }}.xml
         if: ${{ always() }}
 
       - name: Upload coverage to Codecov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
               --cov=stellargraph --cov-report=xml \
               -p no:cacheprovider --junitxml="pytest-results-${{ matrix.python-version }}.xml" \
               --benchmark-disable
+        # explicitly use bash on windows, for consistent command parsing
+        shell: bash
 
       - name: Upload pytest test results
         uses: actions/upload-artifact@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8]
-        os: [windows-latest]
+        os: [ubuntu-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8]
-        os: [ubuntu-latest, windows-latest]
+        os: [windows-latest]
 
     runs-on: ${{ matrix.os }}
 

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ EXTRAS_REQUIRES = {
 
 # Long description
 try:
-    with open("README.md", "r") as fh:
+    with open("README.md", "r", encoding="utf8") as fh:
         LONG_DESCRIPTION = fh.read()
 except FileNotFoundError:
     # can't find the README (e.g. building the docker image), so skip it

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -175,7 +175,7 @@ def test_movielens_load() -> None:
 @pytest.mark.parametrize("is_directed", [False, True])
 @pytest.mark.parametrize("largest_cc_only", [False, True])
 @pytest.mark.parametrize("subject_as_feature", [False, True])
-@pytest.mark.xfail(sys.platform == 'win32', reason="FIXME #1698")
+@pytest.mark.xfail(sys.platform == "win32", reason="FIXME #1698")
 def test_cora_load(is_directed, largest_cc_only, subject_as_feature) -> None:
     g, subjects = Cora().load(is_directed, largest_cc_only, subject_as_feature)
 

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -175,6 +175,7 @@ def test_movielens_load() -> None:
 @pytest.mark.parametrize("is_directed", [False, True])
 @pytest.mark.parametrize("largest_cc_only", [False, True])
 @pytest.mark.parametrize("subject_as_feature", [False, True])
+@pytest.mark.xfail(sys.platform == 'win32', reason="FIXME #1698")
 def test_cora_load(is_directed, largest_cc_only, subject_as_feature) -> None:
     g, subjects = Cora().load(is_directed, largest_cc_only, subject_as_feature)
 

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -17,6 +17,7 @@
 import pytest
 import tempfile
 import os
+import sys
 import numpy as np
 from stellargraph.datasets import *
 from urllib.error import URLError

--- a/tests/layer/test_appnp.py
+++ b/tests/layer/test_appnp.py
@@ -19,6 +19,7 @@ from stellargraph.mapper import FullBatchNodeGenerator, FullBatchLinkGenerator
 from stellargraph import StellarGraph
 from stellargraph.core.utils import GCN_Aadj_feats_op
 
+import sys
 import networkx as nx
 import pandas as pd
 import numpy as np

--- a/tests/layer/test_appnp.py
+++ b/tests/layer/test_appnp.py
@@ -115,6 +115,7 @@ def test_APPNP_apply_dense():
     assert preds_1 == pytest.approx(preds_2)
 
 
+@pytest.mark.xfail(sys.platform == 'win32', reason="FIXME #1699")
 def test_APPNP_apply_sparse():
 
     G, features = create_graph_features()
@@ -165,6 +166,7 @@ def test_APPNP_linkmodel_apply_dense():
     assert preds_1 == pytest.approx(preds_2)
 
 
+@pytest.mark.xfail(sys.platform == 'win32', reason="FIXME #1699")
 def test_APPNP_linkmodel_apply_sparse():
 
     G, features = create_graph_features()
@@ -261,6 +263,7 @@ def test_APPNP_propagate_model_matches_manual(model_type):
     np.testing.assert_allclose(preds_1, manual_preds)
 
 
+@pytest.mark.xfail(sys.platform == 'win32', reason="FIXME #1699")
 def test_APPNP_apply_propagate_model_sparse():
 
     G, features = create_graph_features()

--- a/tests/layer/test_appnp.py
+++ b/tests/layer/test_appnp.py
@@ -115,7 +115,7 @@ def test_APPNP_apply_dense():
     assert preds_1 == pytest.approx(preds_2)
 
 
-@pytest.mark.xfail(sys.platform == 'win32', reason="FIXME #1699")
+@pytest.mark.xfail(sys.platform == "win32", reason="FIXME #1699")
 def test_APPNP_apply_sparse():
 
     G, features = create_graph_features()
@@ -166,7 +166,7 @@ def test_APPNP_linkmodel_apply_dense():
     assert preds_1 == pytest.approx(preds_2)
 
 
-@pytest.mark.xfail(sys.platform == 'win32', reason="FIXME #1699")
+@pytest.mark.xfail(sys.platform == "win32", reason="FIXME #1699")
 def test_APPNP_linkmodel_apply_sparse():
 
     G, features = create_graph_features()
@@ -263,7 +263,7 @@ def test_APPNP_propagate_model_matches_manual(model_type):
     np.testing.assert_allclose(preds_1, manual_preds)
 
 
-@pytest.mark.xfail(sys.platform == 'win32', reason="FIXME #1699")
+@pytest.mark.xfail(sys.platform == "win32", reason="FIXME #1699")
 def test_APPNP_apply_propagate_model_sparse():
 
     G, features = create_graph_features()

--- a/tests/layer/test_deep_graph_infomax.py
+++ b/tests/layer/test_deep_graph_infomax.py
@@ -22,6 +22,7 @@ from .. import require_gpu, test_utils
 import tensorflow as tf
 import pytest
 import numpy as np
+import sys
 
 
 def _model_data(model_type, sparse):

--- a/tests/layer/test_deep_graph_infomax.py
+++ b/tests/layer/test_deep_graph_infomax.py
@@ -77,6 +77,9 @@ def _model_data(model_type, sparse):
 )
 @pytest.mark.parametrize("sparse", [False, True])
 def test_dgi(model_type, sparse):
+    if sys.platform == "win32" and model_type is RGCN and sparse:
+        pytest.xfail("FIXME #1699")
+
     base_generator, base_model, nodes = _model_data(model_type, sparse)
     corrupted_generator = CorruptedGenerator(base_generator)
     gen = corrupted_generator.flow(nodes)

--- a/tests/layer/test_gcn.py
+++ b/tests/layer/test_gcn.py
@@ -90,6 +90,7 @@ def test_GraphConvolution_dense():
         np.testing.assert_array_equal(preds[i, ...], preds[0, ...])
 
 
+@pytest.mark.xfail(sys.platform == 'win32', reason="FIXME #1699")
 def test_GraphConvolution_sparse():
     G, features = create_graph_features()
     n_nodes = features.shape[0]
@@ -164,6 +165,7 @@ def test_GCN_apply_dense():
     assert preds_1 == pytest.approx(preds_2)
 
 
+@pytest.mark.xfail(sys.platform == 'win32', reason="FIXME #1699")
 def test_GCN_apply_sparse():
 
     G, features = create_graph_features()
@@ -216,6 +218,7 @@ def test_GCN_linkmodel_apply_dense():
     assert preds_1 == pytest.approx(preds_2)
 
 
+@pytest.mark.xfail(sys.platform == 'win32', reason="FIXME #1699")
 def test_GCN_linkmodel_apply_sparse():
 
     G, features = create_graph_features()

--- a/tests/layer/test_gcn.py
+++ b/tests/layer/test_gcn.py
@@ -90,7 +90,7 @@ def test_GraphConvolution_dense():
         np.testing.assert_array_equal(preds[i, ...], preds[0, ...])
 
 
-@pytest.mark.xfail(sys.platform == 'win32', reason="FIXME #1699")
+@pytest.mark.xfail(sys.platform == "win32", reason="FIXME #1699")
 def test_GraphConvolution_sparse():
     G, features = create_graph_features()
     n_nodes = features.shape[0]
@@ -165,7 +165,7 @@ def test_GCN_apply_dense():
     assert preds_1 == pytest.approx(preds_2)
 
 
-@pytest.mark.xfail(sys.platform == 'win32', reason="FIXME #1699")
+@pytest.mark.xfail(sys.platform == "win32", reason="FIXME #1699")
 def test_GCN_apply_sparse():
 
     G, features = create_graph_features()
@@ -218,7 +218,7 @@ def test_GCN_linkmodel_apply_dense():
     assert preds_1 == pytest.approx(preds_2)
 
 
-@pytest.mark.xfail(sys.platform == 'win32', reason="FIXME #1699")
+@pytest.mark.xfail(sys.platform == "win32", reason="FIXME #1699")
 def test_GCN_linkmodel_apply_sparse():
 
     G, features = create_graph_features()

--- a/tests/layer/test_gcn.py
+++ b/tests/layer/test_gcn.py
@@ -26,6 +26,7 @@ from stellargraph.mapper import FullBatchNodeGenerator, FullBatchLinkGenerator
 from stellargraph.core.graph import StellarGraph
 from stellargraph.core.utils import GCN_Aadj_feats_op
 
+import sys
 import networkx as nx
 import pandas as pd
 import numpy as np

--- a/tests/layer/test_rgcn.py
+++ b/tests/layer/test_rgcn.py
@@ -79,7 +79,7 @@ def test_RelationalGraphConvolution_init():
     assert rgcn_layer.get_config()["activation"] == "relu"
 
 
-@pytest.mark.xfail(sys.platform == 'win32', reason="FIXME #1699")
+@pytest.mark.xfail(sys.platform == "win32", reason="FIXME #1699")
 def test_RelationalGraphConvolution_sparse():
     G, features = create_graph_features()
     n_edge_types = len(G.edge_types)
@@ -177,7 +177,7 @@ def test_RGCN_init():
     assert rgcnModel.num_bases == 10
 
 
-@pytest.mark.xfail(sys.platform == 'win32', reason="FIXME #1699")
+@pytest.mark.xfail(sys.platform == "win32", reason="FIXME #1699")
 def test_RGCN_apply_sparse():
     G, features = create_graph_features(is_directed=True)
 
@@ -230,7 +230,7 @@ def test_RGCN_apply_dense():
     assert preds_1 == pytest.approx(preds_2)
 
 
-@pytest.mark.xfail(sys.platform == 'win32', reason="FIXME #1699")
+@pytest.mark.xfail(sys.platform == "win32", reason="FIXME #1699")
 def test_RGCN_apply_sparse_directed():
     G, features = create_graph_features(is_directed=True)
 

--- a/tests/layer/test_rgcn.py
+++ b/tests/layer/test_rgcn.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 import numpy as np
 from stellargraph.layer.rgcn import RelationalGraphConvolution, RGCN
 from stellargraph.mapper.full_batch_generators import RelationalFullBatchNodeGenerator

--- a/tests/layer/test_rgcn.py
+++ b/tests/layer/test_rgcn.py
@@ -79,6 +79,7 @@ def test_RelationalGraphConvolution_init():
     assert rgcn_layer.get_config()["activation"] == "relu"
 
 
+@pytest.mark.xfail(sys.platform == 'win32', reason="FIXME #1699")
 def test_RelationalGraphConvolution_sparse():
     G, features = create_graph_features()
     n_edge_types = len(G.edge_types)
@@ -176,6 +177,7 @@ def test_RGCN_init():
     assert rgcnModel.num_bases == 10
 
 
+@pytest.mark.xfail(sys.platform == 'win32', reason="FIXME #1699")
 def test_RGCN_apply_sparse():
     G, features = create_graph_features(is_directed=True)
 
@@ -228,6 +230,7 @@ def test_RGCN_apply_dense():
     assert preds_1 == pytest.approx(preds_2)
 
 
+@pytest.mark.xfail(sys.platform == 'win32', reason="FIXME #1699")
 def test_RGCN_apply_sparse_directed():
     G, features = create_graph_features(is_directed=True)
 

--- a/tests/utils/test_hyperbolic.py
+++ b/tests/utils/test_hyperbolic.py
@@ -22,7 +22,7 @@ from stellargraph.utils.hyperbolic import *
 
 @pytest.fixture
 def seeded():
-    seed = np.random.randint(2 ** 32)
+    seed = np.random.randint(2 ** 32, dtype=np.uint32)
     # log for reproducibility
     print("seed:", seed)
     np.random.seed(seed)


### PR DESCRIPTION
We can augment our Python-version testing matrix to also run our unit tests on both Linux and Windows. This will make it more likely that StellarGraph works without issue on Windows.

We _could_ consider running our notebooks on Windows too, but that will result in a large explosion of tests being run, and thus will be investigated separately (#1706).

This found 3 additional Windows-related issues:

- xfailed on windows: #1698, #1699 
- fixed here: #1700

See: #1702, #1700