### PR TITLE
Use shorter name for GitHub Action CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,6 @@
 ---
-name: Continuous Integration
+# Continuous Integration is too long for the GitHub view
+name: CI
 
 "on":
   push:


### PR DESCRIPTION
The "Continuous Integration" name takes up a lot of space in the checks summary view at the bottom of a PR. We can make this view a little more useful, with more of the content visible, by shortening the name.

Comparison:

- Before:
  <img width="869" alt="image" src="https://user-images.githubusercontent.com/1203825/85244283-839e5d80-b487-11ea-961d-3be006f4fd09.png">

- This PR:
  <img width="858" alt="image" src="https://user-images.githubusercontent.com/1203825/85244311-96b12d80-b487-11ea-9319-22108b0cba35.png">
