### PR TITLE
Use higher relative tolerance in SqueezedSparseConversion tests

### DIFF
--- a/tests/layer/test_misc.py
+++ b/tests/layer/test_misc.py
@@ -56,7 +56,7 @@ def test_squeezedsparseconversion():
 
     z = model.predict([x, np.expand_dims(A_indices, 0), np.expand_dims(A_values, 0)])
 
-    np.testing.assert_allclose(z.squeeze(), A.dot(x.squeeze()), atol=1e-7)
+    np.testing.assert_allclose(z.squeeze(), A.dot(x.squeeze()), atol=1e-7, rtol=1e-5)
 
 
 def test_squeezedsparseconversion_dtype():
@@ -79,7 +79,7 @@ def test_squeezedsparseconversion_dtype():
     z = model.predict([x, np.expand_dims(A_indices, 0), np.expand_dims(A_values, 0)])
 
     assert A_mat.dtype == tf.dtypes.float64
-    np.testing.assert_allclose(z.squeeze(), A.dot(x.squeeze()), atol=1e-7)
+    np.testing.assert_allclose(z.squeeze(), A.dot(x.squeeze()), atol=1e-7, rtol=1e-5)
 
 
 def test_squeezedsparseconversion_axis():
@@ -104,7 +104,7 @@ def test_squeezedsparseconversion_axis():
     model = keras.Model(inputs=[A_ind, A_val], outputs=x_out)
     z = model.predict([A_indices, A_values])
 
-    np.testing.assert_allclose(z, A.sum(axis=1), atol=1e-7)
+    np.testing.assert_allclose(z, A.sum(axis=1), atol=1e-7, rtol=1e-5)
 
 
 def test_gather_indices():


### PR DESCRIPTION
These tests seem to be failing occasionally (e.g. 3 failures across a few hundred runs locally), probably due to the changing thresholds in #1679. These tests are slightly numerically unstable, and so `assert_allclose`'s default relative threshold of 1e-7 is too small (in fact, this is less than the precision of a float32, meaning if `abs(a - b) > atol` (where `atol = 1e-7`), then the test will fail unless `a == b` exactly).

This patch changes the relative tolerance for these tests back to `rtol = 1e-5` to match the `np.allclose` function:

| function | `rtol` | `atol` |
|---|---|---|
| [`allclose`](https://numpy.org/doc/stable/reference/generated/numpy.allclose.html) | 1e-5 | 1e-8 |
| [`assert_allclose`](https://numpy.org/doc/stable/reference/generated/numpy.testing.assert_allclose.html)  | 1e-7 | 0 |

I "verified" this by running each of the three tests 1000 times locally.

See: #1709