### PR TITLE
List dependency versions on GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install .[test,demos]
 
+      - name: List dependency versions
+        run: "pip freeze"
+
       - name: Run pytest tests
         run: |
           # benchmarks on shared infrastructure like the CI machines are usually unreliable (high
@@ -171,6 +174,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install .[test,demos]
 
+      - name: List dependency versions
+        run: "pip freeze"
+
       - name: Run notebook
         id: run_notebook
         run: scripts/ci/run_notebook.sh ${{ matrix.notebook }}
@@ -228,6 +234,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install .[test,neo4j]
+
+      - name: List dependency versions
+        run: "pip freeze"
 
       # Run each Neo4j notebook, and upload it as an artifact
 


### PR DESCRIPTION
This adds the functionality we had from Buildkite to GitHub Actions. It is helpful for debugging, particularly #1711 (see also #613).

See: #1711