### PR TITLE
Disable fail-fast for notebook GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,10 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      # Each notebook is mostly independent, unlike testing on (for instance) different Python
+      # versions
+      fail-fast: false
+
       matrix:
         # MARKER: list of all notebooks
         notebook:

--- a/demos/node-classification/gcn-node-classification.ipynb
+++ b/demos/node-classification/gcn-node-classification.ipynb
@@ -483,7 +483,7 @@
     }
    ],
    "source": [
-    "generator = FullBatchNodeGenerator(some_error, method=\"gcn\")"
+    "generator = FullBatchNodeGenerator(G, method=\"gcn\")"
    ]
   },
   {

--- a/demos/node-classification/gcn-node-classification.ipynb
+++ b/demos/node-classification/gcn-node-classification.ipynb
@@ -483,7 +483,7 @@
     }
    ],
    "source": [
-    "generator = FullBatchNodeGenerator(G, method=\"gcn\")"
+    "generator = FullBatchNodeGenerator(some_error, method=\"gcn\")"
    ]
   },
   {


### PR DESCRIPTION
This step ensures that all notebooks are tested for each GitHub Actions build.

Fail-fast in a matrix is great for reducing CPU time used when there's correlated failures. For instance, if tests fail on Python 3.6, they're likely to fail with 3.7 and 3.8, so there's no point continuing to run those steps.

The notebooks arguably have less correlated failures, because each element of the matrix is running different code (although there is the shared code of the library itself). It's thus helpful to run each to completion to be informed of all the notebooks with problems in each build.

This also has the benefit of having less noise in the overall "annotation" report, where each cancelled build gets an annotation card. (For instance, https://github.com/stellargraph/stellargraph/actions/runs/144404772 has 92 independent annotations containing "The job was canceled because ...".) 

Verification: in https://github.com/stellargraph/stellargraph/pull/1714/checks?check_run_id=798015954, I manually broke the GCN node classification notebook. The failure was registered but the other notebooks continued running to completion:

<img width="245" alt="image" src="https://user-images.githubusercontent.com/1203825/85363740-0517ed80-b565-11ea-94c5-7158d9081f57.png">

See: #1687