### PR TITLE
Try running without a cache on Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,14 +28,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Restore cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-${{ matrix.python-version }}-pip-${{ hashFiles('setup.py') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.python-version }}-pip-
-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -158,14 +150,6 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Restore cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-${{ env.PYTHON_VERSION }}-pip-${{ hashFiles('setup.py') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ env.PYTHON_VERSION }}-pip-
-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -215,14 +199,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-
-      - name: Restore cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-${{ env.PYTHON_VERSION }}-pip-neo4j-${{ hashFiles('setup.py') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ env.PYTHON_VERSION }}-pip-neo4j-
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
It seems running without a cache on Github Actions is likely faster: for our dependencies, the vast majority of the time is spent installing dependencies, not downloading them. This is especially true on Windows, where (IIRC) file operations involving many small files (such as a large Python package with many files/resources) are much slower than on Linux.

For a comparison, #1726 gets caching working on both Linux and Windows. The following table reports the times (in seconds) for the installation-related steps for three runs (all three of which have cache hits, for #1726):

| configuration |  #1726 (cache+install) | this PR (install) |
|---|---|---|
| 3.6, ubuntu | 193, 187, 226 | 177, 169, 189 |
| 3.6, windows | 556, 509, 529 | 430, 517, 552 |
| 3.7, ubuntu | 181, 574*, 179 | 169, 178, 148 |
| 3.7, windows | 630, 478, 493 | 419, 473, 439 |
| 3.8, ubuntu | 159, 177, 176 | 161, 162, 161 |
| 3.8, windows | 458, 543, 494 | 408, 439, 486 |

The * build (https://github.com/stellargraph/stellargraph/runs/802956366) seemed to have a particularly high latency when downloading the cache, which is potentially https://github.com/actions/cache/issues/267.