### PR TITLE
Upgrade doc dependencies, including sphinx-rtd-theme 0.5.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,12 +1,12 @@
 recommonmark==0.6.0
-sphinx-markdown-tables==0.0.12
-nbsphinx==0.6.1
+sphinx-markdown-tables==0.0.15
+nbsphinx==0.7.1
 nbsphinx-link==1.3.0
 # needed for Pygments highlighting in notebooks
 ipython==7.13.0
 
 sphinx-notfound-page==0.4
-sphinxcontrib-spelling==5.1.0
+sphinxcontrib-spelling==5.1.2
 
 # dependencies used by RtD, fixed here so that our CI and RtD use the same (newer) versions.
 # https://github.com/readthedocs/readthedocs.org/blob/35b5ca286dff9d3fbcfdf1351e570375cd0c2bd3/readthedocs/doc_builder/python_environments.py#L335-L365
@@ -17,6 +17,6 @@ mock==4.0.2
 pillow==7.1.2
 alabaster==0.7.12
 commonmark==0.9.1
-sphinx==3.0.3
+sphinx==3.1.1
 sphinx-rtd-theme==0.5.0
-readthedocs-sphinx-ext==1.0.3
+readthedocs-sphinx-ext==2.0.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -18,5 +18,5 @@ pillow==7.1.2
 alabaster==0.7.12
 commonmark==0.9.1
 sphinx==3.0.3
-sphinx-rtd-theme==0.4.3
+sphinx-rtd-theme==0.5.0
 readthedocs-sphinx-ext==1.0.3


### PR DESCRIPTION
Upgrades:
- sphinx-rtd-theme 0.5.0 gives us slightly nicer display, and helps with #1499 (there's built-in styles for deeper table-of-contents sidebars: #1512).
- nbsphinx 0.7.1 includes the fix for https://github.com/spatialaudio/nbsphinx/issues/452, which affected all of the plots in demos
- other upgrades are just nice-to-have without particular bug fixes in mind

Rendered: https://stellargraph--1722.org.readthedocs.build/en/1722/

Notable improvements:

- nicer display of function parameter docs (etc.):
  - before: https://stellargraph.readthedocs.io/en/v1.1.0/api.html#stellargraph.StellarGraph.edges
     <img width="531" alt="image" src="https://user-images.githubusercontent.com/1203825/85493464-4ae2bd80-b61a-11ea-9af5-5ee03de1b034.png">
  - after: https://stellargraph--1722.org.readthedocs.build/en/1722/api.html#stellargraph.StellarGraph.edges
    <img width="624" alt="image" src="https://user-images.githubusercontent.com/1203825/85493481-533af880-b61a-11ea-808e-255509ab48ca.png">

- glossary:
  - before: https://stellargraph.readthedocs.io/en/v1.1.0/glossary.html
    <img width="583" alt="image" src="https://user-images.githubusercontent.com/1203825/85493141-b1b3a700-b619-11ea-9110-eb92da32cb63.png">
  - after: https://stellargraph--1722.org.readthedocs.build/en/1722/glossary.html
     <img width="502" alt="image" src="https://user-images.githubusercontent.com/1203825/85493132-ad878980-b619-11ea-948f-993d18ba605f.png">
- scrolling of images in notebooks, in Safari:
  - before (hover over the history plot and scroll): https://stellargraph.readthedocs.io/en/v1.1.0/demos/embeddings/deep-graph-infomax-embeddings.html#Model-Creation-and-Training
  - after: https://stellargraph--1722.org.readthedocs.build/en/1722/demos/embeddings/deep-graph-infomax-embeddings.html#Model-Creation-and-Training