### PR TITLE
Silence Numpy 1.19 tostring deprecation warning from TensorFlow

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,5 +3,8 @@ junit_family = xunit2
 
 # make sure that no new uses of the legacy constructor are added (see also: test in test_graph.py,
 # PYTHONWARNINGS in .buildkite/docker-compose.yml)
+# Also, work-around noisy logging from TensorFlow due to ndarray.tostring() being deprecated in
+# NumPy 1.19 (#1771)
 filterwarnings =
     error:Constructing a StellarGraph:DeprecationWarning
+    ignore:tostring\(\) is deprecated:DeprecationWarning:tensorflow.*tensor_util


### PR DESCRIPTION
TensorFlow calls `numpy.ndarray.tostring` internally. As of the recent [NumPy 1.19 release](https://github.com/numpy/numpy/releases/tag/v1.19.0), this method is deprecated and emits a DeprecationWarning. 

Unfortunately, this TF functionality happens to be used a lot, and so there's many calls to `tostring` and thus many warnings emitted. Pytest's default behaviour ([docs](https://docs.pytest.org/en/latest/warnings.html)) of listing warnings after a test run results in tens of thousands of lines of output, one for each of the invocations. This isn't useful, and there's not much we can do about it, other than restricting the NumPy version (which would be unfortunate). Thus, this configures pytest to ignore those particular warnings.

This output was only visible on Github Actions and locally, not Buildkite due to difference in the environment variables (#1716).

Pytest warning output for this PR: https://github.com/stellargraph/stellargraph/pull/1724/checks?check_run_id=801902235#step:7:89

See: #1711