### PR TITLE
Include docs for inherited methods in knowledge graph models

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -144,27 +144,32 @@ Knowledge Graph models
 
 .. autoclass:: ComplEx
   :members:
+  :inherited-members:
 
 .. autoclass:: ComplExScore
   :members:
 
 .. autoclass:: DistMult
   :members:
+  :inherited-members:
 
 .. autoclass:: DistMultScore
   :members:
 
 .. autoclass:: RotatE
   :members:
+  :inherited-members:
 
 .. autoclass:: RotatEScore
   :members:
 
 .. autoclass:: RotE
   :members:
+  :inherited-members:
 
 .. autoclass:: RotH
   :members:
+  :inherited-members:
 
 GCN Supervised Graph Classification
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
With #1573, the knowledge graph models have very few methods themselves, just the `__init__` and some other helpers. The functionality is all provided by the `KGModel` superclass, which is appropriately configured via `__init__`. The `KGModel` class is currently a (soft/semi-)private API, and so doesn't appear in the docs. Sphinx doesn't include methods from superclasses by default. Thus the useful methods on the knowledge graph models (like `embeddings`, `in_out_tensors` and `rank_edges_against_all_nodes`) aren't mentioned in the docs.

This PR ensures that they're displayed, using the `:inherited-members:` option to the `autoclass` directive ([relevant docs](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html)).

Rendered: https://stellargraph--1729.org.readthedocs.build/en/1729/api.html#stellargraph.layer.ComplEx

![image](https://user-images.githubusercontent.com/1203825/85649744-40422a00-b6e7-11ea-9f69-d346e5ffa66a.png)


See: #1727