### PR TITLE
Fix a few doc cross-reference typos

### DIFF
--- a/stellargraph/layer/appnp.py
+++ b/stellargraph/layer/appnp.py
@@ -165,9 +165,9 @@ class APPNP:
     To use this class as a Keras model, the features and preprocessed adjacency matrix
     should be supplied using:
 
-    - the :class:`FullBatchNodeGenerator` class for node inference
-    - the :class:`ClusterNodeGenerator` class for scalable/inductive node inference using the Cluster-GCN training procedure (https://arxiv.org/abs/1905.07953)
-    - the :class:`FullBatchLinkGenerator` class for link inference
+    - the :class:`.FullBatchNodeGenerator` class for node inference
+    - the :class:`.ClusterNodeGenerator` class for scalable/inductive node inference using the Cluster-GCN training procedure (https://arxiv.org/abs/1905.07953)
+    - the :class:`.FullBatchLinkGenerator` class for link inference
 
     To have the appropriate preprocessing the generator object should be instantiated
     with the `method='gcn'` argument.
@@ -192,7 +192,7 @@ class APPNP:
         Keras methods. When using the :class:`.FullBatchNodeGenerator` specify the
         ``method='gcn'`` argument to do this preprocessing.
 
-      - The nodes provided to the :class:`.FullBatchNodeGenerator.flow` method are
+      - The nodes provided to the :meth:`.FullBatchNodeGenerator.flow` method are
         used by the final layer to select the predictions for those nodes in order.
         However, the intermediate layers before the final layer order the nodes
         in the same way as the adjacency matrix.

--- a/stellargraph/layer/gcn.py
+++ b/stellargraph/layer/gcn.py
@@ -263,7 +263,7 @@ class GCN:
         Keras methods. When using the :class:`.FullBatchNodeGenerator` specify the
         ``method='gcn'`` argument to do this preprocessing.
 
-      - The nodes provided to the :class:`.FullBatchNodeGenerator.flow` method are
+      - The nodes provided to the :meth:`.FullBatchNodeGenerator.flow` method are
         used by the final layer to select the predictions for those nodes in order.
         However, the intermediate layers before the final layer order the nodes
         in the same way as the adjacency matrix.

--- a/stellargraph/layer/graph_attention.py
+++ b/stellargraph/layer/graph_attention.py
@@ -561,7 +561,7 @@ class GAT:
         the adjacency matrix to add self-loops, using the ``method='gat'`` argument
         of the :class:`.FullBatchNodeGenerator`.
 
-      - The nodes provided to the :class:`.FullBatchNodeGenerator.flow` method are
+      - The nodes provided to the :meth:`.FullBatchNodeGenerator.flow` method are
         used by the final layer to select the predictions for those nodes in order.
         However, the intermediate layers before the final layer order the nodes
         in the same way as the adjacency matrix.

--- a/stellargraph/layer/rgcn.py
+++ b/stellargraph/layer/rgcn.py
@@ -342,7 +342,7 @@ class RGCN:
       - The inputs are tensors with a batch dimension of 1. These are provided by the \
         :class:`.RelationalFullBatchNodeGenerator` object.
 
-      - The nodes provided to the :class:`.RelationalFullBatchNodeGenerator.flow` method are
+      - The nodes provided to the :meth:`.RelationalFullBatchNodeGenerator.flow` method are
         used by the final layer to select the predictions for those nodes in order.
         However, the intermediate layers before the final layer order the nodes
         in the same way as the adjacency matrix.

--- a/stellargraph/mapper/base.py
+++ b/stellargraph/mapper/base.py
@@ -43,7 +43,7 @@ class Generator(abc.ABC):
     def default_corrupt_input_index_groups(self):
         """
         Optionally returns the indices of input tensors that can be shuffled for
-        :class:`.CorruptGenerator` to use in :class:`.DeepGraphInfomax`.
+        :class:`.CorruptedGenerator` to use in :class:`.DeepGraphInfomax`.
 
         If this isn't overridden, this method returns None, indicating that the generator doesn't
         have a default or "canonical" set of indices that can be corrupted for Deep Graph Infomax.


### PR DESCRIPTION
There's a few instances where documentation was referring to something in a way that Sphinx couldn't understand. This fixes the simple examples of that (e.g. typos, adding `.`s similar to #1718, or changing `:class:` to `:meth:`) so that they become links in the final documentation. These were found by scanning the output of Sphinx's 'nitpick' mode: `make html SPHINXOPTS=-n`.

(There's a _lot_ of warnings from that mode, so we can't easily enable this on CI right now: https://gist.github.com/huonw/af43004f0ff33cc3705dc11bc5bce4de )