### PR TITLE
Update LINQS dataset URLs for directory change

### DIFF
--- a/stellargraph/datasets/datasets.py
+++ b/stellargraph/datasets/datasets.py
@@ -200,7 +200,7 @@ class CiteSeer(
 class PubMedDiabetes(
     DatasetLoader,
     name="PubMed Diabetes",
-    directory_name="Pubmed-Diabetes",
+    directory_name="pubmed-diabetes",
     url="https://linqs-data.soe.ucsc.edu/public/pubmed-diabetes/pubmed-diabetes.tar.gz",
     url_archive_format="gztar",
     expected_files=[

--- a/stellargraph/datasets/datasets.py
+++ b/stellargraph/datasets/datasets.py
@@ -101,7 +101,7 @@ class Cora(
     DatasetLoader,
     name="Cora",
     directory_name="cora",
-    url="https://linqs-data.soe.ucsc.edu/public/lbc/cora.tgz",
+    url="https://linqs-data.soe.ucsc.edu/public/cora/cora.tar.gz",
     url_archive_format="gztar",
     expected_files=["cora.cites", "cora.content"],
     description="The Cora dataset consists of 2708 scientific publications classified into one of seven classes. "
@@ -160,8 +160,8 @@ class Cora(
 class CiteSeer(
     DatasetLoader,
     name="CiteSeer",
-    directory_name="citeseer",
-    url="https://linqs-data.soe.ucsc.edu/public/lbc/citeseer.tgz",
+    directory_name="citeseer-doc-classification",
+    url="https://linqs-data.soe.ucsc.edu/public/citeseer-doc-classification/citeseer-doc-classification.tar.gz",
     url_archive_format="gztar",
     expected_files=["citeseer.cites", "citeseer.content"],
     description="The CiteSeer dataset consists of 3312 scientific publications classified into one of six classes. "
@@ -201,7 +201,7 @@ class PubMedDiabetes(
     DatasetLoader,
     name="PubMed Diabetes",
     directory_name="Pubmed-Diabetes",
-    url="https://linqs-data.soe.ucsc.edu/public/Pubmed-Diabetes.tgz",
+    url="https://linqs-data.soe.ucsc.edu/public/pubmed-diabetes/pubmed-diabetes.tar.gz",
     url_archive_format="gztar",
     expected_files=[
         "data/Pubmed-Diabetes.DIRECTED.cites.tab",


### PR DESCRIPTION
Some URLs associated with datasets from https://linqs.soe.ucsc.edu/data have changed. In particular, the contents of https://linqs-data.soe.ucsc.edu/public/ has been rearranged. For instance, Cora was previously at https://linqs-data.soe.ucsc.edu/public/lbc/cora.tgz and is now at https://linqs-data.soe.ucsc.edu/public/cora/cora.tar.gz (`/lbc/` -> `/cora/`).

Affected datasets:

- Cora
- PubMed-Diabetes (the internal directory was also renamed to be lowercase)
- CiteSeer (this also had its internal directory renamed)

Based on our CI runs, it looks like this happened somewhere in the ~18 hours between the following two builds:

- 2020-06-20T14:25+1000: https://buildkite.com/stellar/stellargraph-public/builds/5123
- 2020-06-21T08:30+1000: https://buildkite.com/stellar/stellargraph-public/builds/5124

See: #1735