### PR TITLE
Reduce CI time by excluding Python 3.8 tests on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,9 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8]
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        exclude:
+          # tests on Windows with Python3.8 are very slow, see #1736
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8]
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest]
         exclude:
           # FIXME #1736: tests on Windows with Python3.8 are very slow, so excluded
           - os: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,9 @@ jobs:
         python-version: [3.6, 3.7, 3.8]
         os: [ubuntu-latest, windows-latest, macos-latest]
         exclude:
-          # tests on Windows with Python3.8 are very slow, see #1736
+          # FIXME #1736: tests on Windows with Python3.8 are very slow, so excluded
+          - os: windows-latest
+            python-version: 3.8
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
See #1736: Exclude the CI stage for Python 3.8 on Windows, as it's very slow.