### PR TITLE
Test against pre-release versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install .[test,demos]
+          python -m pip install --pre --upgrade pip
+          pip install --pre .[test,demos]
 
       - name: List dependency versions
         run: "pip freeze"
@@ -165,8 +165,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install .[test,demos]
+          python -m pip install --pre --upgrade pip
+          pip install --pre .[test,demos]
 
       - name: List dependency versions
         run: "pip freeze"
@@ -218,8 +218,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install .[test,neo4j]
+          python -m pip install --pre --upgrade pip
+          pip install --pre .[test,neo4j]
 
       - name: List dependency versions
         run: "pip freeze"
@@ -290,8 +290,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install black
         run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install black==19.10b0
+          python3 -m pip install --pre --upgrade pip
+          python3 -m pip install --pre black==19.10b0
           echo ::add-path::$HOME/.local/bin
       - name: Check formatting
         run: |
@@ -372,8 +372,8 @@ jobs:
 
       - name: Install requirements
         run: |
-          pip install --upgrade pip
-          pip install nbconvert nbformat black==19.10b0
+          pip install --pre --upgrade pip
+          pip install --pre nbconvert nbformat black==19.10b0
 
       - name: Run check
         run: python scripts/format_notebooks.py --default --ci demos/
@@ -389,8 +389,8 @@ jobs:
 
       - name: Install requirements
         run: |
-          pip install --upgrade pip
-          pip install nbformat commonmark
+          pip install --pre --upgrade pip
+          pip install --pre nbformat commonmark
 
       - name: Run check
         run: python scripts/notebook_text_checker.py demos/
@@ -453,8 +453,8 @@ jobs:
 
       - name: Install requirements
         run: |
-          pip install --upgrade pip
-          pip install nbformat
+          pip install --pre --upgrade pip
+          pip install --pre nbformat
 
       - name: Check demo indexing
         run: python scripts/demo_indexing.py --action=compare
@@ -476,9 +476,9 @@ jobs:
 
       - name: Install python requirements
         run: |
-          pip install --upgrade pip
-          pip install .
-          pip install -r docs/requirements.txt
+          pip install --pre --upgrade pip
+          pip install --pre .
+          pip install --pre -r docs/requirements.txt
 
       - name: Listing dependency versions
         run: pip freeze

--- a/tests/layer/test_appnp.py
+++ b/tests/layer/test_appnp.py
@@ -302,8 +302,7 @@ def test_APPNP_apply_propagate_model_sparse():
 
 
 @pytest.mark.parametrize(
-    "sparse",
-    [False, pytest.param(True, marks=pytest.mark.xfail(reason="FIXME #1251"))],
+    "sparse", [False, True],
 )
 def test_APPNP_save_load(tmpdir, sparse):
     G, _ = create_graph_features()

--- a/tests/layer/test_gcn.py
+++ b/tests/layer/test_gcn.py
@@ -126,7 +126,7 @@ def test_GraphConvolution_sparse():
     ):
         GraphConvolution(2)([x_t_10, A_mat])
 
-    A_mat = tf.sparse.expand_dims(A_mat, axis=0)
+    A_mat = keras.layers.Lambda(lambda x: tf.sparse.expand_dims(x, axis=0))(A_mat)
     with pytest.raises(
         ValueError,
         match="adjacency: expected a single adjacency matrix .* found adjacency tensor of rank 3",

--- a/tests/layer/test_gcn.py
+++ b/tests/layer/test_gcn.py
@@ -323,9 +323,7 @@ def test_kernel_and_bias_defaults():
             assert layer.bias_constraint is None
 
 
-@pytest.mark.parametrize(
-    "sparse", [False, pytest.param(True, marks=pytest.mark.xfail(reason="FIXME #1251"))]
-)
+@pytest.mark.parametrize("sparse", [False, True])
 def test_gcn_save_load(tmpdir, sparse):
     G, _ = create_graph_features()
     generator = FullBatchNodeGenerator(G, sparse=sparse)

--- a/tests/layer/test_rgcn.py
+++ b/tests/layer/test_rgcn.py
@@ -381,9 +381,7 @@ def test_kernel_and_bias_defaults():
 
 
 @pytest.mark.parametrize("num_bases", [0, 10])
-@pytest.mark.parametrize(
-    "sparse", [False, pytest.param(True, marks=pytest.mark.xfail(reason="FIXME #1251"))]
-)
+@pytest.mark.parametrize("sparse", [False, True])
 def test_RGCN_save_load(tmpdir, num_bases, sparse):
     graph, _ = create_graph_features()
     generator = RelationalFullBatchNodeGenerator(graph, sparse=sparse)


### PR DESCRIPTION
Of particular note is [TensorFlow 2.3.0-rc0](https://github.com/tensorflow/tensorflow/releases/tag/v2.3.0-rc0), which includes the fix for #1251.