### PR TITLE
Replace README/doc references to Buildkite with Github Actions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ StellarGraph considers courtesy and respect for others an essential part of the 
 
 #### Continuous Integration (CI)
 
-A pull request can only be merged if it passes tests. StellarGraph uses Buildkite CI to let a computer do the testing, and results are reported directly in each pull request. The full Buildkite pipeline can be viewed at <https://buildkite.com/stellar/stellargraph-public/>.
+A pull request can only be merged if it passes tests. StellarGraph uses GitHub Actions to let a computer do the testing, and results are reported directly in each pull request. The CI configuration is in [the `ci.yml` workflow file](.github/workflows/ci.yml), and full set of workflow runs can be viewed at <https://github.com/stellargraph/stellargraph/actions>.
 
 ### Experimental code
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 </p>
 <p align="center">
   <a href="https://github.com/stellargraph/stellargraph/blob/develop/CONTRIBUTING.md" alt="contributions welcome"><img src="https://img.shields.io/badge/contributions-welcome-brightgreen.svg"/></a>
-  <a href="https://buildkite.com/stellar/stellargraph-public?branch=master/" alt="Build status: master"><img src="https://img.shields.io/buildkite/8aa4d147372ccc0153101b50137f5f3439c6038f29b21f78f8/master.svg?label=branch:+master"/></a>
-  <a href="https://buildkite.com/stellar/stellargraph-public?branch=develop/" alt="Build status: develop"><img src="https://img.shields.io/buildkite/8aa4d147372ccc0153101b50137f5f3439c6038f29b21f78f8/develop.svg?label=branch:+develop"/></a>
+  <a href="https://github.com/stellargraph/stellargraph/actions?query=branch%3Amaster" alt="Build status: master"><img src="https://github.com/stellargraph/stellargraph/workflows/CI/badge.svg?branch=master"/></a>
+  <a href="https://github.com/stellargraph/stellargraph/actions?query=branch%3Adevelop" alt="Build status: develop"><img src="https://github.com/stellargraph/stellargraph/workflows/CI/badge.svg?branch=develop"/></a>
   <a href="https://codecov.io/gh/stellargraph/stellargraph"><img src="https://codecov.io/gh/stellargraph/stellargraph/branch/develop/graph/badge.svg" /></a>
   <a href="https://pypi.org/project/stellargraph" alt="pypi downloads"><img alt="pypi downloads" src="https://pepy.tech/badge/stellargraph"></a>
 </p>

--- a/RELEASE_PROCEDURE.md
+++ b/RELEASE_PROCEDURE.md
@@ -88,7 +88,7 @@
      conda build .
      ```
 
-      NOTE: The Conda package is also built in CI, and uploaded to a Buildkite artifact in the "conda build" stage of the pipeline.  It's possible to download this artifact to be uploaded in the following step, rather than building the conda package locally.
+      NOTE: The Conda package is also built in CI, and uploaded to a GitHub Actions artifact in the "conda build" stage of the pipeline.  It's possible to download this artifact to be uploaded in the following step, rather than building the conda package locally.
 
    - Upload to Anaconda Cloud in the “stellargraph” organization
      ```shell


### PR DESCRIPTION
We've now disabled Buildkite, so our badges etc. should all be pointing to Github Actions.

Rendered:

- https://github.com/stellargraph/stellargraph/blob/483c5287f1b5ed0adcf54d563a0744cba4cc659a/README.md
- https://github.com/stellargraph/stellargraph/blob/483c5287f1b5ed0adcf54d563a0744cba4cc659a/CONTRIBUTING.md#continuous-integration-ci