### PR TITLE
Compute notebook name for artifact upload before running

### DIFF
--- a/demos/node-classification/gcn-node-classification.ipynb
+++ b/demos/node-classification/gcn-node-classification.ipynb
@@ -166,7 +166,7 @@
    "source": [
     "dataset = sg.datasets.Cora()\n",
     "display(HTML(dataset.description))\n",
-    "G, node_subjects = dataset.load()"
+    "G, a, node_subjects = dataset.load()"
    ]
   },
   {

--- a/demos/node-classification/gcn-node-classification.ipynb
+++ b/demos/node-classification/gcn-node-classification.ipynb
@@ -166,7 +166,7 @@
    "source": [
     "dataset = sg.datasets.Cora()\n",
     "display(HTML(dataset.description))\n",
-    "G, a, node_subjects = dataset.load()"
+    "G, node_subjects = dataset.load()"
    ]
   },
   {

--- a/scripts/ci/run_notebook.sh
+++ b/scripts/ci/run_notebook.sh
@@ -3,10 +3,13 @@
 set -euo pipefail
 
 notebook="$1"
+
+# work out the name of the notebook for the artifact uploading, before running the notebook itself,
+# in case that fails
+notebook_name="$(basename "$notebook")"
+echo "::set-output name=notebook_name::$notebook_name"
+
 # papermill will replace parameters on some notebooks to make them run faster in CI
 papermill --execution-timeout=600 \
   --parameters_file "./.buildkite/notebook-parameters.yml" --log-output \
   "$notebook" "$notebook"
-
-notebook_name="$(basename "$notebook")"
-echo "::set-output name=notebook_name::$notebook_name"


### PR DESCRIPTION
We need to compute the output (name of the notebook) required for the artifact upload step before running the notebook with Papermill. We use `set -e`, meaning the script will stop at `papermill ...` if that invocation fails.

Example: https://github.com/stellargraph/stellargraph/pull/1747/commits/bd2d7ce4db27adb3c7d08ab16f0408f650e09969 broke the GCN node classification notebook. `papermill` failed as expected, but the notebook upload worked: https://github.com/stellargraph/stellargraph/pull/1747/checks?check_run_id=817222719#step:7:11

See: #1746