### PR TITLE
Wrap sparse operation in Lambda in tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ URL = "https://github.com/stellargraph/stellargraph"
 # full tensorflow is too big for readthedocs's builder
 tensorflow = "tensorflow-cpu" if "READTHEDOCS" in os.environ else "tensorflow"
 REQUIRES = [
-    f"{tensorflow}==2.3.0-rc0",
+    f"{tensorflow}>=2.1.0",
     "numpy>=1.14",
     "scipy>=1.1.0",
     "networkx>=2.2",

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ URL = "https://github.com/stellargraph/stellargraph"
 # full tensorflow is too big for readthedocs's builder
 tensorflow = "tensorflow-cpu" if "READTHEDOCS" in os.environ else "tensorflow"
 REQUIRES = [
-    f"{tensorflow}>=2.1.0",
+    f"{tensorflow}==2.3.0-rc0",
     "numpy>=1.14",
     "scipy>=1.1.0",
     "networkx>=2.2",

--- a/tests/layer/test_gcn.py
+++ b/tests/layer/test_gcn.py
@@ -126,7 +126,7 @@ def test_GraphConvolution_sparse():
     ):
         GraphConvolution(2)([x_t_10, A_mat])
 
-    A_mat = tf.sparse.expand_dims(A_mat, axis=0)
+    A_mat = keras.layers.Lambda(lambda x: tf.sparse.expand_dims(x, axis=0))(A_mat)
     with pytest.raises(
         ValueError,
         match="adjacency: expected a single adjacency matrix .* found adjacency tensor of rank 3",


### PR DESCRIPTION
TensorFlow Keras generally requires that sparse operations happen within a layer, not just as operations directly on the raw tensors. This validation apparently previously missed the `tf.sparse.expand_dims` operation, but it is now caught in TF 2.3.0-rc0 (see #1742, in particular https://github.com/stellargraph/stellargraph/runs/817093240#step:6:90).

This PR pre-emptively fixes the test, so that we do not have to diagnose or debug it in future.

Test run of this PR using TF 2.3.0-rc0, which passes: https://github.com/stellargraph/stellargraph/pull/1750/checks?check_run_id=817247674

See: #1749