### PR TITLE
Remove accidentally preserved windows-only xfails

### DIFF
--- a/tests/layer/test_appnp.py
+++ b/tests/layer/test_appnp.py
@@ -19,7 +19,6 @@ from stellargraph.mapper import FullBatchNodeGenerator, FullBatchLinkGenerator
 from stellargraph import StellarGraph
 from stellargraph.core.utils import GCN_Aadj_feats_op
 
-import sys
 import networkx as nx
 import pandas as pd
 import numpy as np
@@ -116,7 +115,6 @@ def test_APPNP_apply_dense():
     assert preds_1 == pytest.approx(preds_2)
 
 
-@pytest.mark.xfail(sys.platform == "win32", reason="FIXME #1699")
 def test_APPNP_apply_sparse():
 
     G, features = create_graph_features()
@@ -169,7 +167,6 @@ def test_APPNP_linkmodel_apply_dense():
     assert preds_1 == pytest.approx(preds_2)
 
 
-@pytest.mark.xfail(sys.platform == "win32", reason="FIXME #1699")
 def test_APPNP_linkmodel_apply_sparse():
 
     G, features = create_graph_features()
@@ -268,7 +265,6 @@ def test_APPNP_propagate_model_matches_manual(model_type):
     np.testing.assert_allclose(preds_1, manual_preds)
 
 
-@pytest.mark.xfail(sys.platform == "win32", reason="FIXME #1699")
 def test_APPNP_apply_propagate_model_sparse():
 
     G, features = create_graph_features()

--- a/tests/layer/test_deep_graph_infomax.py
+++ b/tests/layer/test_deep_graph_infomax.py
@@ -22,7 +22,6 @@ from .. import require_gpu, test_utils
 import tensorflow as tf
 import pytest
 import numpy as np
-import sys
 
 
 def _model_data(model_type, sparse):
@@ -78,9 +77,6 @@ def _model_data(model_type, sparse):
 )
 @pytest.mark.parametrize("sparse", [False, True])
 def test_dgi(model_type, sparse):
-    if sys.platform == "win32" and model_type is RGCN and sparse:
-        pytest.xfail("FIXME #1699")
-
     base_generator, base_model, nodes = _model_data(model_type, sparse)
     corrupted_generator = CorruptedGenerator(base_generator)
     gen = corrupted_generator.flow(nodes)

--- a/tests/layer/test_gcn.py
+++ b/tests/layer/test_gcn.py
@@ -26,7 +26,6 @@ from stellargraph.mapper import FullBatchNodeGenerator, FullBatchLinkGenerator
 from stellargraph.core.graph import StellarGraph
 from stellargraph.core.utils import GCN_Aadj_feats_op
 
-import sys
 import networkx as nx
 import pandas as pd
 import numpy as np
@@ -91,7 +90,6 @@ def test_GraphConvolution_dense():
         np.testing.assert_array_equal(preds[i, ...], preds[0, ...])
 
 
-@pytest.mark.xfail(sys.platform == "win32", reason="FIXME #1699")
 def test_GraphConvolution_sparse():
     G, features = create_graph_features()
     n_nodes = features.shape[0]
@@ -168,7 +166,6 @@ def test_GCN_apply_dense():
     assert preds_1 == pytest.approx(preds_2)
 
 
-@pytest.mark.xfail(sys.platform == "win32", reason="FIXME #1699")
 def test_GCN_apply_sparse():
 
     G, features = create_graph_features()
@@ -223,7 +220,6 @@ def test_GCN_linkmodel_apply_dense():
     assert preds_1 == pytest.approx(preds_2)
 
 
-@pytest.mark.xfail(sys.platform == "win32", reason="FIXME #1699")
 def test_GCN_linkmodel_apply_sparse():
 
     G, features = create_graph_features()

--- a/tests/layer/test_rgcn.py
+++ b/tests/layer/test_rgcn.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 import numpy as np
 from stellargraph.layer.rgcn import RelationalGraphConvolution, RGCN
 from stellargraph.mapper.full_batch_generators import RelationalFullBatchNodeGenerator
@@ -80,7 +79,6 @@ def test_RelationalGraphConvolution_init():
     assert rgcn_layer.get_config()["activation"] == "relu"
 
 
-@pytest.mark.xfail(sys.platform == "win32", reason="FIXME #1699")
 def test_RelationalGraphConvolution_sparse():
     G, features = create_graph_features()
     n_edge_types = len(G.edge_types)
@@ -179,7 +177,6 @@ def test_RGCN_init():
     assert rgcnModel.num_bases == 10
 
 
-@pytest.mark.xfail(sys.platform == "win32", reason="FIXME #1699")
 def test_RGCN_apply_sparse():
     G, features = create_graph_features(is_directed=True)
 
@@ -233,7 +230,6 @@ def test_RGCN_apply_dense():
     assert preds_1 == pytest.approx(preds_2)
 
 
-@pytest.mark.xfail(sys.platform == "win32", reason="FIXME #1699")
 def test_RGCN_apply_sparse_directed():
     G, features = create_graph_features(is_directed=True)
 


### PR DESCRIPTION
The merge of #1704 apparently didn't include the removal of the xfails that were added in #1696, possibly because:

- #1704 was opened, building of #1696's branch, before #1696 merged
- Once #1696, #1704 was automatically reset to point to `develop`
- No merge commit was added between `develop` and #1704 

Together, this means that the series of commits of #1704 didn't seem to include any modifications of the `def ...` lines of the test (because #1696 added them, and later commits in #1704 removed them), and thus the removal didn't happen.

NB. these tests do work on Windows, the problem here is just that they still xfailed, despite passing.

See: #1699