### PR TITLE
run tests on mac os

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,17 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8]
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         exclude:
+          # skip Mac OS Python 3.7 and 3.8 to save time
+          - python-version: 3.7
+            os: macos-latest
+          - python-version: 3.8
+            os: macos-latest
+
           # FIXME #1736: tests on Windows with Python3.8 are very slow, so excluded
-          - os: windows-latest
-            python-version: 3.8
+          - python-version: 3.8
+            os: windows-latest
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Add a single testing stage to CI for Mac OS (behaviour is likely to be similar to Ubuntu; we can just test on 3.6)

'exclude' syntax in ci.yml is used so that this stage can start earlier than if 'include' syntax was used.