### PR TITLE
Rename RotHEScoring to RotHEScore, for consistency

### DIFF
--- a/stellargraph/layer/knowledge_graph.py
+++ b/stellargraph/layer/knowledge_graph.py
@@ -693,7 +693,7 @@ class RotatE(KGModel):
         )
 
 
-class RotHEScoring(Layer, KGScore):
+class RotHEScore(Layer, KGScore):
     def __init__(self, hyperbolic):
         self._hyperbolic = hyperbolic
         if self._hyperbolic:
@@ -855,7 +855,7 @@ class RotH(KGModel):
     ):
         super().__init__(
             generator,
-            RotHEScoring(hyperbolic=True),
+            RotHEScore(hyperbolic=True),
             embedding_dimension=embedding_dimension,
             embeddings_initializer=embeddings_initializer,
             embeddings_regularizer=embeddings_regularizer,
@@ -899,7 +899,7 @@ class RotE(KGModel):
     ):
         super().__init__(
             generator,
-            RotHEScoring(hyperbolic=False),
+            RotHEScore(hyperbolic=False),
             embedding_dimension=embedding_dimension,
             embeddings_initializer=embeddings_initializer,
             embeddings_regularizer=embeddings_regularizer,


### PR DESCRIPTION
Other than `RotHEScoring`, all of the knowledge graph scoring layers are `...Score` (e.g. `ComplExScore`). This PR renames the RotH and RotE algorithms' scoring layer `RotHEScoring` to `RotHEScore` match that convention. These algorithms are experimental, so we can avoid the extra code required to do a deprecation.