### PR TITLE
Add two missing layers to custom_keras_layers

### DIFF
--- a/stellargraph/__init__.py
+++ b/stellargraph/__init__.py
@@ -87,7 +87,7 @@ custom_keras_layers = {
         layer.knowledge_graph.ComplExScore,
         layer.knowledge_graph.DistMultScore,
         layer.knowledge_graph.RotatEScore,
-        layer.knowledge_graph.RotHEScoring,
+        layer.knowledge_graph.RotHEScore,
         layer.preprocessing_layer.GraphPreProcessingLayer,
         layer.preprocessing_layer.SymmetricGraphPreProcessingLayer,
         layer.watch_your_step.AttentiveWalk,

--- a/stellargraph/__init__.py
+++ b/stellargraph/__init__.py
@@ -86,6 +86,8 @@ custom_keras_layers = {
         layer.graphsage.GraphSAGEAggregator,
         layer.knowledge_graph.ComplExScore,
         layer.knowledge_graph.DistMultScore,
+        layer.knowledge_graph.RotatEScore,
+        layer.knowledge_graph.RotHEScoring,
         layer.preprocessing_layer.GraphPreProcessingLayer,
         layer.preprocessing_layer.SymmetricGraphPreProcessingLayer,
         layer.watch_your_step.AttentiveWalk,


### PR DESCRIPTION
The `custom_keras_layers` dictionary wasn't updated to include the layers from the RotatE (#1522) and RotH/RotE algorithms (#1539). 

NB. the `custom_keras_layers` dictionary unfortunately has to be manually maintained because testing it automatically is really awkward (https://github.com/stellargraph/stellargraph/pull/1280 initially tried to add automated tests, but they were failing in non-reproducible ways on CI).