### PR TITLE
Implement UGraphEmb pooling

### DIFF
--- a/stellargraph/__init__.py
+++ b/stellargraph/__init__.py
@@ -93,6 +93,7 @@ custom_keras_layers = {
         layer.gcn_lstm.FixedAdjacencyGraphConvolution,
         _LinkEmbedding,
         _LeakyClippedLinear,
+        layer.ugraphemb_attention_pooling.UGraphEmbAttentionPooling,
     ]
 }
 """

--- a/stellargraph/layer/__init__.py
+++ b/stellargraph/layer/__init__.py
@@ -41,3 +41,4 @@ from .graph_classification import *
 from .deep_graph_infomax import *
 from .sort_pooling import *
 from .gcn_lstm import *
+from .ugraphemb_attention_pooling import UGraphEmbAttentionPooling

--- a/stellargraph/layer/ugraphemb_attention_pooling.py
+++ b/stellargraph/layer/ugraphemb_attention_pooling.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2020 Data61, CSIRO
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__all__ = ["UGraphEmbAttentionPooling"]
+
+import tensorflow as tf
+from tensorflow.keras.layers import Layer
+from tensorflow.keras import activations, initializers, constraints, regularizers, backend as K
+from ..core.experimental import experimental
+from ..core.validation import require_integer_in_range
+
+class UGraphEmbAttentionPooling(Layer):
+    def __init__(
+        self,
+        attention_activation="relu",
+        attention_initializer="glorot_uniform",
+        attention_regularizer=None,
+        attention_constraint=None,
+        **kwargs,
+    ):
+        self.attention_activation = activations.get(attention_activation)
+        self.attention_initializer = initializers.get(attention_initializer)
+        self.attention_regularizer = regularizers.get(attention_regularizer)
+        self.attention_constraint = constraints.get(attention_constraint)
+
+        super().__init__(**kwargs)
+
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            attention_activation=activations.serialize(self.attention_activation),
+            attention_initializer=initializers.serialize(self.attention_initializer),
+            attention_regularizer=regularizers.serialize(self.attention_regularizer),
+            attention_constraint=constraints.serialize(self.attention_constraint),
+        )
+        return config
+
+    def build(self, input_shape):
+        batch_size, num_nodes, dimension = input_shape
+
+        self.attention_kernel = self.add_weight(
+            shape=(dimension, dimension),
+            name="attention_kernel",
+            initializer=self.attention_initializer,
+            regularizer=self.attention_regularizer,
+            constraint=self.attention_constraint,
+        )
+
+        super().build(input_shape)
+
+    def call(self, embeddings, mask):
+        # embeddings.shape == (B, N, D), mask.shape == (B, N)
+
+        # shape == (B, N, 1)
+        element_mask = tf.cast(mask, embeddings.dtype)[..., None]
+
+        # shape == (B, D)
+        graph_means = tf.reduce_sum(embeddings * element_mask, axis=1) / tf.reduce_sum(element_mask, axis=1)
+
+        # shape == (B, D)
+        query = self.attention_activation(K.dot(graph_means, self.attention_kernel))
+
+        # shape == (B, N)
+        weights = K.sigmoid(K.batch_dot(embeddings, query))
+
+        # shape == (B, N, D)
+        weighted = weights[..., None] * embeddings * element_mask
+
+        # shape == (B, D)
+        return tf.reduce_sum(weighted, axis=1)

--- a/tests/layer/test_ugraphemb_attention_pooling.py
+++ b/tests/layer/test_ugraphemb_attention_pooling.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2020 Data61, CSIRO
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import numpy as np
+from stellargraph.layer.ugraphemb_attention_pooling import UGraphEmbAttentionPooling
+
+
+def test_config():
+    pool = UGraphEmbAttentionPooling(
+        attention_activation="tanh",
+        attention_initializer="zeros",
+        attention_regularizer="l2",
+        attention_constraint="unit_norm",
+    )
+
+    conf = pool.get_config()
+    assert conf["attention_activation"] == "tanh"
+    assert conf["attention_initializer"]["class_name"] == "Zeros"
+    assert conf["attention_regularizer"]["class_name"] == "L1L2"
+    assert conf["attention_constraint"]["class_name"] == "UnitNorm"
+
+
+def test_call():
+    pool = UGraphEmbAttentionPooling()
+    shape = (3, 4, 5)
+    sizes = [1, 4, 2]
+
+    nodes = np.random.rand(*shape).astype(np.float32)
+    mask = np.full(shape[:2], False)
+    for i, size in enumerate(sizes):
+        mask[i][:size] = True
+
+    embeddings = pool(nodes, mask=mask)
+    assert embeddings.shape == (3, 5)
+
+    kernel = pool.attention_kernel.numpy()
+
+    def sigmoid(x):
+        # numerically stable
+        return np.exp(-np.logaddexp(0, -x))
+
+    def relu(x):
+        return np.maximum(0, x)
+
+    # check each of the graphs
+    for emb, nod, msk, size in zip(embeddings, nodes, mask, sizes):
+        node_embs = nod[msk]
+        # internal consistency of this test:
+        assert node_embs.shape[0] == size
+
+        # naive reproduction of the paper's algorithm
+        query = relu(np.mean(node_embs, axis=0) @ kernel)
+        expected = sum(sigmoid(node @ query) * node for node in node_embs)
+
+        np.testing.assert_allclose(emb, expected, rtol=1e-4)


### PR DESCRIPTION
This implements the pooling layer from UGraphEmb. This doesn't quite fully implement the algorithm:

- the output of each GCN/GIN layer needs to be pooled separately
- the loss function seems to become `nan` when training with this in the existing unsupervised graph classification algorithm, so this clearly isn't fully useable yet

See: #1627