### PR TITLE
Run CI workflow at 00:00 UTC every day

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ name: CI
     # only build each push to develop and master, other branches are built through pull requests
     branches: [develop, master]
   pull_request:
+  schedule:
+    - cron: "0 0 * * *"
 
 jobs:
   build:


### PR DESCRIPTION
We aren't running CI as often these days (since there's less development/contributions), which means if a dependency version change breaks something, we may not realise this for a while. This means that (a) the code may be broken for longer, and (b) may make it hard to work out what went wrong, since there will likely be some unrelated changes to dependency versions. Running CI regularly ensures that we at least only have to determine the dependency versions that change over the course of a single day (easier with #1712).

Reference docs: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onschedule