### PR TITLE
Un-xfail full-batch saving tests fixed by TensorFlow 2.3

### DIFF
--- a/tests/layer/test_appnp.py
+++ b/tests/layer/test_appnp.py
@@ -298,8 +298,7 @@ def test_APPNP_apply_propagate_model_sparse():
 
 
 @pytest.mark.parametrize(
-    "sparse",
-    [False, pytest.param(True, marks=pytest.mark.xfail(reason="FIXME #1251"))],
+    "sparse", [False, True],
 )
 def test_APPNP_save_load(tmpdir, sparse):
     G, _ = create_graph_features()

--- a/tests/layer/test_gcn.py
+++ b/tests/layer/test_gcn.py
@@ -319,9 +319,7 @@ def test_kernel_and_bias_defaults():
             assert layer.bias_constraint is None
 
 
-@pytest.mark.parametrize(
-    "sparse", [False, pytest.param(True, marks=pytest.mark.xfail(reason="FIXME #1251"))]
-)
+@pytest.mark.parametrize("sparse", [False, True])
 def test_gcn_save_load(tmpdir, sparse):
     G, _ = create_graph_features()
     generator = FullBatchNodeGenerator(G, sparse=sparse)

--- a/tests/layer/test_rgcn.py
+++ b/tests/layer/test_rgcn.py
@@ -377,9 +377,7 @@ def test_kernel_and_bias_defaults():
 
 
 @pytest.mark.parametrize("num_bases", [0, 10])
-@pytest.mark.parametrize(
-    "sparse", [False, pytest.param(True, marks=pytest.mark.xfail(reason="FIXME #1251"))]
-)
+@pytest.mark.parametrize("sparse", [False, True])
 def test_RGCN_save_load(tmpdir, num_bases, sparse):
     graph, _ = create_graph_features()
     generator = RelationalFullBatchNodeGenerator(graph, sparse=sparse)


### PR DESCRIPTION
[TensorFlow 2.3.0](https://github.com/tensorflow/tensorflow/releases/tag/v2.3.0) was released over the last day. This release includes the fix for https://github.com/tensorflow/tensorflow/issues/38465 (which we filed a duplicate of at https://github.com/tensorflow/tensorflow/issues/40373) which is the underlying issue behind #1251.

As such, we can remove the xfail markings from tests involving the saving of full-batch models like APPNP, GCN and RGCN.

Fixes: #1251