### PR TITLE
Use scipy 1.4.1 exactly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,6 +339,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: s-weigand/setup-conda@v1
+        with:
+          python-version: 3.7
 
       - name: Install conda build tools
         run: |

--- a/meta.yaml
+++ b/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - pandas >=0.24
     - python >=3.6
     - scikit-learn >=0.20
-    - scipy >=1.1.0
+    - scipy==1.4.1
     - tensorflow >=2.1.0
     - ipython
     - ipykernel

--- a/setup.py
+++ b/setup.py
@@ -24,9 +24,9 @@ URL = "https://github.com/stellargraph/stellargraph"
 # full tensorflow is too big for readthedocs's builder
 tensorflow = "tensorflow-cpu" if "READTHEDOCS" in os.environ else "tensorflow"
 REQUIRES = [
+    "scipy==1.4.1",
     f"{tensorflow}>=2.1.0",
     "numpy>=1.14",
-    "scipy>=1.1.0",
     "networkx>=2.2",
     "scikit_learn>=0.20",
     "matplotlib>=2.2",


### PR DESCRIPTION
This is a test for #1784, which sees some issues that may be connected to scipy==1.4.1.