### PR TITLE
Fix for graphsage weight concatenation issue (Whitespace issue fixed)

### DIFF
--- a/stellargraph/layer/graphsage.py
+++ b/stellargraph/layer/graphsage.py
@@ -147,15 +147,11 @@ class GraphSAGEAggregator(Layer):
                 "There must be at least one input with a non-zero neighbourhood dimension"
             )
 
-        # Calculate the dimensionality of each group, and put remainder into the first group
-        # with non-zero dimensions, which should be the head node group.
-        group_output_dim = self.output_dim // num_groups
-        remainder_dim = self.output_dim - num_groups * group_output_dim
+        # Store dimensions for the weights
         weight_dims = []
         for g in self.included_weight_groups:
             if g:
-                group_dim = group_output_dim + remainder_dim
-                remainder_dim = 0
+                group_dim = self.output_dim
             else:
                 group_dim = 0
             weight_dims.append(group_dim)
@@ -262,9 +258,8 @@ class GraphSAGEAggregator(Layer):
                 x_agg = self.group_aggregate(x, group_idx=ii)
                 sources.append(x_agg)
 
-        # Concatenate outputs from all groups
-        # TODO: Generalize to sum a subset of groups.
-        h_out = K.concatenate(sources, axis=2)
+        # Sum outputs from all groups
+        h_out = sum(sources)
 
         # Optionally add bias
         if self.has_bias:

--- a/stellargraph/layer/graphsage.py
+++ b/stellargraph/layer/graphsage.py
@@ -155,7 +155,6 @@ class GraphSAGEAggregator(Layer):
             else:
                 group_dim = 0
             weight_dims.append(group_dim)
-        
         self.weight_dims = weight_dims
 
     def build(self, input_shape):

--- a/stellargraph/layer/graphsage.py
+++ b/stellargraph/layer/graphsage.py
@@ -155,6 +155,7 @@ class GraphSAGEAggregator(Layer):
             else:
                 group_dim = 0
             weight_dims.append(group_dim)
+        
         self.weight_dims = weight_dims
 
     def build(self, input_shape):


### PR DESCRIPTION
Note: I previously submitted this change, but there was a whitespace issue I had missed.

I went into depth about the issue in #1789, so go there if you want to see more of the gory details, but I'll try to give a summary here.

Essentially, in the original graphsage paper, they first concatenate the previous layer's output with the aggregated feature vector and then applies a fully connected layer to the whole thing. However, in the current stellargraph implementation, weights are first applied to each vector and then the results are concatenated.

There are two main issues with this implementation. First, the network has about half as many parameters as it should, which leads to a lack of expressiveness. Secondly, and much more importantly, it means the first half of the output for each layer is ONLY based on the feature vector, and the second half is ONLY based on the aggregated vector, meaning that the network lacks the ability to gain any information about their interplay (at least within one layer).

I fixed this in a very simple way. First of all, I changed the output sizes of all the weights from outputdim/2 (plus some remainder terms) to just being outputdim. Next, I replaced the concatenation operation with a sum operation, which is the equivalent of saying that if A=[X,Y] and v = [x;y], then Av=[X,Y][x;y]=Xx+Yy, which is completely equivalent

I made no other changes, so it should still work with all other uses of the graphsage modelI went into depth about the issue in #1789, so go there if you want to see more of the gory details, but I'll try to give a summary here.

Essentially, in the original graphsage paper, they first concatenate the previous layer's output with the aggregated feature vector and then applies a fully connected layer to the whole thing. However, in the current stellargraph implementation, weights are first applied to each vector and then the results are concatenated.

There are two main issues with this implementation. First, the network has about half as many parameters as it should, which leads to a lack of expressiveness. Secondly, and much more importantly, it means the first half of the output for each layer is ONLY based on the feature vector, and the second half is ONLY based on the aggregated vector, meaning that the network lacks the ability to gain any information about their interplay (at least within one layer).

I fixed this in a very simple way. First of all, I changed the output sizes of all the weights from outputdim/2 (plus some remainder terms) to just being outputdim. Next, I replaced the concatenation operation with a sum operation, which is the equivalent of saying that if A=[X,Y] and v = [x;y], then Av=[X,Y][x;y]=Xx+Yy, which is completely equivalent

I made no other changes, so it should still work with all other uses of the graphsage model