### PR TITLE
Allow GCN_LSTM to be saved and loaded

### DIFF
--- a/stellargraph/layer/gcn_lstm.py
+++ b/stellargraph/layer/gcn_lstm.py
@@ -137,16 +137,16 @@ class FixedAdjacencyGraphConvolution(Layer):
         """
         _batch_dim, n_nodes, features = input_shapes
 
-        if self.adj is None:
-            raise ValueError(
-                "A: expected adjacency matrix when initially defining layer, found None which is only supported when loading a saved model"
-            )
+        if self.adj is not None:
+            adj_init = initializers.constant(self.adj)
+        else:
+            adj_init = initializers.zeros()
 
         self.A = self.add_weight(
             name="A",
             shape=(n_nodes, n_nodes),
             trainable=False,
-            initializer=initializers.constant(self.adj),
+            initializer=adj_init,
         )
         self.kernel = self.add_weight(
             shape=(features, self.units),

--- a/stellargraph/layer/gcn_lstm.py
+++ b/stellargraph/layer/gcn_lstm.py
@@ -143,10 +143,7 @@ class FixedAdjacencyGraphConvolution(Layer):
             adj_init = initializers.zeros()
 
         self.A = self.add_weight(
-            name="A",
-            shape=(n_nodes, n_nodes),
-            trainable=False,
-            initializer=adj_init,
+            name="A", shape=(n_nodes, n_nodes), trainable=False, initializer=adj_init
         )
         self.kernel = self.add_weight(
             shape=(features, self.units),

--- a/tests/layer/test_gcn_lstm.py
+++ b/tests/layer/test_gcn_lstm.py
@@ -217,7 +217,6 @@ def test_gcn_lstm_generator(arange_graph):
     np.testing.assert_array_equal(predictions, predictions2)
 
 
-@pytest.mark.xfail(reason="FIXME #1681")
 def test_gcn_lstm_save_load(tmpdir, arange_graph):
     gen = SlidingFeaturesNodeGenerator(arange_graph, 2, batch_size=3)
     gcn_lstm = GCN_LSTM(None, None, [2], [4], generator=gen)


### PR DESCRIPTION
This allows the `A` parameter to the underlying `FixedAdjacencyGraphConvolution` layer to be `None`. If it's `None`, the adjacency matrix weight is created with zeros. In the case of saving/loading models, the weight is serialised during save and the `A` parameter is specified as None in the configuration, thus, when the model is loaded, the weight is created with zeros, but overwritten with the serialised weight.

NB. setting `A` to `None` shouldn't generally be used explicitly (only while saving/loading models), and so this isn't documented.

Fixes #1681