### PR TITLE
Fix minor bugs in docs

### DIFF
--- a/demos/link-prediction/gcn-link-prediction.ipynb
+++ b/demos/link-prediction/gcn-link-prediction.ipynb
@@ -330,7 +330,7 @@
    ],
    "source": [
     "test_gen = FullBatchLinkGenerator(G_test, method=\"gcn\")\n",
-    "test_flow = train_gen.flow(edge_ids_test, edge_labels_test)"
+    "test_flow = test_gen.flow(edge_ids_test, edge_labels_test)"
    ]
   },
   {

--- a/stellargraph/mapper/sampled_link_generators.py
+++ b/stellargraph/mapper/sampled_link_generators.py
@@ -213,7 +213,7 @@ class GraphSAGELinkGenerator(BatchedLinkGenerator):
 
     Example::
 
-        G_generator = GraphSageLinkGenerator(G, 50, [10,10])
+        G_generator = GraphSAGELinkGenerator(G, 50, [10,10])
         train_data_gen = G_generator.flow(edge_ids)
 
     .. seealso::


### PR DESCRIPTION
Fixes GCN link prediction demo to use test_gen for test_flow generation. If I understand everything correctly, this change doesn't actually impact runtime, but prevents any confusion since `test_gen` is otherwise an unused variable in the demo right now.

Fixes typo in `GraphSAGELinkGenerator` in docstring which propagates to ReadDocs.