### PR TITLE
Depend on tensorflow-macos on M1, to support separate install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,11 +20,24 @@ import os
 DESCRIPTION = "Python library for machine learning on graphs"
 URL = "https://github.com/stellargraph/stellargraph"
 
+uname = os.uname()
+on_m1 = uname.sysname == "Darwin" and uname.machine == "arm64"
+
 # Required packages
-# full tensorflow is too big for readthedocs's builder
-tensorflow = "tensorflow-cpu" if "READTHEDOCS" in os.environ else "tensorflow"
+if "READTHEDOCS" in os.environ:
+    # full tensorflow is too big for readthedocs's builder
+    tensorflow = "tensorflow-cpu>=2.1"
+elif on_m1:
+    # tensorflow doesn't run directly on Apple M1 chips, and instead
+    # the https://github.com/apple/tensorflow_macos preview needs to
+    # be (manually) installed. It provides an (unversioned) package
+    # called 'tensorflow-macos'.
+    tensorflow = "tensorflow-macos"
+else:
+    tensorflow = "tensorflow>=2.1"
+
 REQUIRES = [
-    f"{tensorflow}>=2.1.0",
+    tensorflow,
     "numpy>=1.14",
     "scipy>=1.1.0",
     "networkx>=2.2",


### PR DESCRIPTION
Tensorflow doesn't run directly on an Apple M1 machine, either natively (arm64) or under Rosetta (x86-64). Apple has provided preview builds at https://github.com/apple/tensorflow_macos which can be manually installed, to provide the `tensorflow-macos` package, which is still imported as `import tensorflow`. If these are manually installed then, theoretically, StellarGraph should be able to run. This patch makes this more feasible, by changing the phrasing of the Tensorflow dependency to `tensorflow-macos` when running on (what looks like) an M1 mac. This allows installation to proceed somewhat further, as it's no longer looking for a compatible `tensorflow` package on PyPI.

This is a draft PR, because I haven't yet got this to work fully: `OPENBLAS="$(brew --prefix openblas)" pip install -e .` fails in `grpcio` (looks like https://github.com/grpc/grpc/issues/24677):


```
Building wheels for collected packages: grpcio
  Building wheel for grpcio (setup.py) ... error
...
    clang -Wno-unused-result -Wsign-compare -Wunreachable-code -DNDEBUG -g -fwrapv -O3 -Wall -I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include -I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include -D_WIN32_WINNT=1536 -DOPENSSL_NO_ASM=1 -DGPR_BACKWARDS_COMPATIBILITY_MODE=1 -DHAVE_CONFIG_H=1 -DGRPC_ENABLE_FORK_SUPPORT=1 -DPyMODINIT_FUNC=extern "C" __attribute__((visibility ("default"))) PyObject* -DGRPC_POSIX_FORK_ALLOW_PTHREAD_ATFORK=1 -Isrc/python/grpcio -Iinclude -I. -Ithird_party/abseil-cpp -Ithird_party/address_sorting/include -Ithird_party/cares -Ithird_party/cares/cares -Ithird_party/cares/config_darwin -Ithird_party/re2 -Ithird_party/boringssl-with-bazel/src/include -Ithird_party/upb -Isrc/core/ext/upb-generated -Isrc/core/ext/upbdefs-generated -Ithird_party/zlib -I/Users/huon/.pyenv/versions/sg/include -I/Users/huon/.pyenv/versions/3.8.7/include/python3.8 -c third_party/zlib/gzlib.c -o python_build/temp.macosx-11.1-arm64-3.8/third_party/zlib/gzlib.o -stdlib=libc++ -fvisibility=hidden -fno-wrapv -fno-exceptions -pthread
    third_party/zlib/gzlib.c:252:9: error: implicit declaration of function 'lseek' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
            LSEEK(state->fd, 0, SEEK_END);  /* so gzoffset() is correct */
            ^
    third_party/zlib/gzlib.c:14:17: note: expanded from macro 'LSEEK'
    #  define LSEEK lseek
                    ^
    third_party/zlib/gzlib.c:252:9: note: did you mean 'fseek'?
    third_party/zlib/gzlib.c:14:17: note: expanded from macro 'LSEEK'
    #  define LSEEK lseek
                    ^
    /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/stdio.h:162:6: note: 'fseek' declared here
    int      fseek(FILE *, long, int);
             ^
    third_party/zlib/gzlib.c:258:24: error: implicit declaration of function 'lseek' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
            state->start = LSEEK(state->fd, 0, SEEK_CUR);
                           ^
    third_party/zlib/gzlib.c:14:17: note: expanded from macro 'LSEEK'
    #  define LSEEK lseek
                    ^
    third_party/zlib/gzlib.c:359:9: error: implicit declaration of function 'lseek' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
        if (LSEEK(state->fd, state->start, SEEK_SET) == -1)
            ^
    third_party/zlib/gzlib.c:14:17: note: expanded from macro 'LSEEK'
    #  define LSEEK lseek
                    ^
    third_party/zlib/gzlib.c:400:15: error: implicit declaration of function 'lseek' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
            ret = LSEEK(state->fd, offset - state->x.have, SEEK_CUR);
                  ^
    third_party/zlib/gzlib.c:14:17: note: expanded from macro 'LSEEK'
    #  define LSEEK lseek
                    ^
    third_party/zlib/gzlib.c:496:14: error: implicit declaration of function 'lseek' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
        offset = LSEEK(state->fd, 0, SEEK_CUR);
                 ^
    third_party/zlib/gzlib.c:14:17: note: expanded from macro 'LSEEK'
    #  define LSEEK lseek
                    ^
  5 errors generated.
...
  ----------------------------------------
  ERROR: Failed building wheel for grpcio

```

Fixes #1856 