### PR TITLE
Improve efficiency of neighborhood sampling query

### DIFF
--- a/stellargraph/connector/neo4j/sampler.py
+++ b/stellargraph/connector/neo4j/sampler.py
@@ -58,7 +58,7 @@ def _bfs_neighbor_query(sampling_direction, id_property, node_label=None):
 
             // pick random nodes with replacement
             WITH apoc.coll.randomItems(in_neighbors_list, $num_samples, True) AS sampled
-            
+
             // pull the ids of the sampled nodes only
             unwind sampled as nn
             WITH CASE collect(nn.{id_property}) WHEN [] THEN sampled ELSE collect(nn.{id_property}) END AS in_samples_list
@@ -66,7 +66,7 @@ def _bfs_neighbor_query(sampling_direction, id_property, node_label=None):
             RETURN in_samples_list',
             {{ node_id: node_id, num_samples: $num_samples  }}) YIELD value
 
-        RETURN apoc.coll.flatten(collect(value.in_samples_list)) AS sampled
+        RETURN apoc.coll.flatten(collect(value.in_samples_list)) AS next_sample
         """
 
 

--- a/stellargraph/connector/neo4j/sampler.py
+++ b/stellargraph/connector/neo4j/sampler.py
@@ -66,7 +66,7 @@ def _bfs_neighbor_query(sampling_direction, id_property, node_label=None):
             RETURN in_samples_list',
             {{ node_id: node_id, num_samples: $num_samples  }}) YIELD value
 
-        RETURN apoc.coll.flatten(collect(value.in_samples_list)) AS next_sample
+        RETURN apoc.coll.flatten(collect(value.in_samples_list)) AS next_samples
         """
 
 

--- a/stellargraph/connector/neo4j/sampler.py
+++ b/stellargraph/connector/neo4j/sampler.py
@@ -60,7 +60,7 @@ def _bfs_neighbor_query(sampling_direction, id_property, node_label=None):
             WITH apoc.coll.randomItems(in_neighbors_list, $num_samples, True) AS sampled
 
             // pull the ids of the sampled nodes only
-            unwind sampled as nn
+            UNWIND sampled AS nn
             WITH CASE collect(nn.{id_property}) WHEN [] THEN sampled ELSE collect(nn.{id_property}) END AS in_samples_list
 
             RETURN in_samples_list',

--- a/stellargraph/connector/neo4j/sampler.py
+++ b/stellargraph/connector/neo4j/sampler.py
@@ -61,7 +61,9 @@ def _bfs_neighbor_query(sampling_direction, id_property, node_label=None):
 
             // pull the ids of the sampled nodes only
             UNWIND sampled AS nn
-            WITH CASE collect(nn.{id_property}) WHEN [] THEN sampled ELSE collect(nn.{id_property}) END AS in_samples_list
+            WITH collect(nn.{id_property}) AS in_samples_list
+            // collect ignores nulls, so re-handle the no-neighbours case to ensure we get [null, null, ...] output
+            WITH CASE in_samples_list WHEN [] THEN sampled ELSE in_samples_list END AS in_samples_list
 
             RETURN in_samples_list',
             {{ node_id: node_id, num_samples: $num_samples  }}) YIELD value

--- a/stellargraph/connector/neo4j/sampler.py
+++ b/stellargraph/connector/neo4j/sampler.py
@@ -61,9 +61,8 @@ def _bfs_neighbor_query(sampling_direction, id_property, node_label=None):
 
             // pull the ids of the sampled nodes only
             UNWIND sampled AS nn
-            WITH collect(nn.{id_property}) AS in_samples_list
             // collect ignores nulls, so re-handle the no-neighbours case to ensure we get [null, null, ...] output
-            WITH CASE in_samples_list WHEN [] THEN sampled ELSE in_samples_list END AS in_samples_list
+            WITH CASE collect(nn.{id_property}) WHEN [] THEN sampled ELSE collect(nn.{id_property}) END AS in_samples_list
 
             RETURN in_samples_list',
             {{ node_id: node_id, num_samples: $num_samples  }}) YIELD value


### PR DESCRIPTION
Improve efficiency of neighborhood sampling query when the central node has many neighbors. The orignal query made 2 * ( number of neighbors ) database hits, the new version makes ( number of neighbors ) + num_samples database hits  (less repeated ids in the sampled nodes).

In the particular case I tested on `node_label = "entity"` `id_property = "id"` and the graph is undirected ( `direction_arrow = "--"` ). Also, `num_samples` in these examples is set to 25.

The two version of the query are essentially:

old:
```
MATCH (cur_node:entity) WHERE cur_node.id = $some_node_id
MATCH (cur_node){direction_arrow}(neighbors)

// put all neighbours into a list and pull ids:
WITH CASE collect(neighbors.id) WHEN [] THEN [null] ELSE collect(neighbors.id) END AS in_neighbors_list

// pick random neighbours with replacement:
WITH apoc.coll.randomItems(in_neighbors_list, 25, True) AS in_samples_list

RETURN in_samples_list
```

new:
```
// Pull neighbours of given node:
MATCH (cur_node:entity) WHERE cur_node.id = $some_node_id
MATCH (cur_node)--(neighbors)

// put all neighbours into a list:
WITH CASE collect(neighbors) WHEN [] THEN [null] ELSE collect(neighbors) END AS in_neighbors_list

// pick random neighbours with replacement:
WITH apoc.coll.randomItems(in_neighbors_list, 25, True) AS sampled

// unpack sampled node list:
unwind sampled as nn

// collect ids of sampled nodes:
WITH CASE collect( nn.id ) WHEN [] THEN sampled ELSE collect( nn.id ) END AS in_samples_list

RETURN in_samples_list
```
In a case where the `some_node_id` has ~1,700,000 neighbours the profiler says:

old:
```
Cypher version: CYPHER 4.2, planner: COST, runtime: INTERPRETED. 3364764 total db hits in 2250 ms.
```

new:
```
Cypher version: CYPHER 4.2, planner: COST, runtime: INTERPRETED. 1682409 total db hits in 1480 ms.
```

An example where the node has no neighbours:

old:
```
Cypher version: CYPHER 4.2, planner: COST, runtime: INTERPRETED. 4 total db hits in 86 ms.
```

new:
```
Cypher version: CYPHER 4.2, planner: COST, runtime: INTERPRETED. 4 total db hits in 0 ms.
```
