### PR TITLE
Fix flaky test_normalized_laplacian in tests.core.test_utils

### DIFF
--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -200,7 +200,6 @@ def test_normalize_adj(example_graph):
     assert csr.get_shape() == Aadj.get_shape()
 
 
-@flaky_xfail_mark(AssertionError, 1160)
 def test_normalized_laplacian(example_graph):
     Aadj = example_graph.to_adjacency_matrix()
     laplacian = normalized_laplacian(Aadj).todense()
@@ -212,8 +211,10 @@ def test_normalized_laplacian(example_graph):
     assert eigenvalues.max() <= (2 + 1e-7)
     assert laplacian.shape == Aadj.get_shape()
 
-    laplacian = normalized_laplacian(Aadj, symmetric=False)
-    assert 1 == pytest.approx(laplacian.sum(), abs=1e-7)
+    # Sum of laplacian is equal to the number of degree 0 nodes
+    laplacian = normalized_laplacian(Aadj, symmetric=False) 
+    num_degree_zero_nodes = (Aadj.sum(axis=1) == 0).sum()
+    assert num_isolated_nodes == pytest.approx(laplacian.sum(), abs=1e-7)
     assert laplacian.get_shape() == Aadj.get_shape()
 
 

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -214,7 +214,7 @@ def test_normalized_laplacian(example_graph):
     # Sum of laplacian is equal to the number of degree 0 nodes
     laplacian = normalized_laplacian(Aadj, symmetric=False) 
     num_degree_zero_nodes = (Aadj.sum(axis=1) == 0).sum()
-    assert num_isolated_nodes == pytest.approx(laplacian.sum(), abs=1e-7)
+    assert num_degree_zero_nodes == pytest.approx(laplacian.sum(), abs=1e-7)
     assert laplacian.get_shape() == Aadj.get_shape()
 
 


### PR DESCRIPTION
Closes #1160 

Test `test_normalized_laplacian` in `tests.core.test_utils` is flaky, this PR fixes it.

## Reason for flakiness
The test was failing because it assumed the sum of elements of normalized asymmetric Laplacian should be 1. In fact this sum is equal to _the number of degree 0 nodes_. Most of the time the graphs generated by `example_graph_random` had one such node and the current test passed. However, sometimes there are 2 or more of them, and then the test failed

## Why the new test works
The new test checks that sum of elements of normalized asymmetric Laplacian is equal to the number of degree 0 nodes. 
Let's show that this always holds. Indeed, Laplacian is computed as `L = I - D * A`, where `A` is the adjacency matrix and `D` is diagonal matrix whose elements are 1 over row sums of `A` https://github.com/stellargraph/stellargraph/blob/e46af15c2dbcaa9ae6328dd1ec62c6f9ef7f5467/stellargraph/core/utils.py#L152

If the graph doesn't have degree 0 nodes, all rows in `A` have non-zero sums, so sums of each row in `D * A` is equal to 1, and the sum of elements in `L` is equal to zero.
If, however, a certain node is degree 0, the corresponding row contains only zeros. Then the corresponding element of `D` is `inf`, but multiplied by `A` is computed to 0 in https://github.com/stellargraph/stellargraph/blob/e46af15c2dbcaa9ae6328dd1ec62c6f9ef7f5467/stellargraph/core/utils.py#L135
So the corresponding row of `D * A` sums to 0 instead of 1. 

Thus each degree 0 node adds 1 to the sum of elements of `L`

## Tests
The following code runs without errors on the PR branch (and fails on `develop`)
```
from tests.core.test_utils import example_graph_random, test_normalized_laplacian
for i in range(10000):
    random_graph = example_graph_random()
    test_normalized_laplacian(random_graph)
```