### PR TITLE
Fix flaky test_normalize_adj in tests.core.test_utils

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,6 +339,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: s-weigand/setup-conda@v1
+        with:
+          python-version: 3.8
 
       - name: Install conda build tools
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,8 +339,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: s-weigand/setup-conda@v1
-        with:
-          python-version: 3.8
 
       - name: Install conda build tools
         run: |

--- a/stellargraph/data/epgm.py
+++ b/stellargraph/data/epgm.py
@@ -21,7 +21,6 @@ import os
 import json
 import uuid
 import numpy as np
-import chardet
 import scipy.sparse as sp
 
 import multiprocessing

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -184,14 +184,13 @@ def test_smart_array_concatenate_broadcast():
         _check_smart_concatenate([a0, c43])
 
 
-@flaky_xfail_mark(AssertionError, 1678)
 def test_normalize_adj(example_graph):
     node_list = list(example_graph.nodes())
     Aadj = example_graph.to_adjacency_matrix()
     csr = normalize_adj(Aadj, symmetric=True)
     dense = csr.todense()
     eigen_vals, _ = np.linalg.eig(dense)
-    assert eigen_vals.max() == pytest.approx(1, abs=1e-7)
+    assert eigen_vals.max() == pytest.approx(1, abs=1e-5)
     assert csr.get_shape() == Aadj.get_shape()
 
     # Sum of normalized adjacency matrix is equal to the number of positive degree nodes

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -194,9 +194,11 @@ def test_normalize_adj(example_graph):
     assert eigen_vals.max() == pytest.approx(1, abs=1e-7)
     assert csr.get_shape() == Aadj.get_shape()
 
+    # Sum of normalized adjacency matrix is equal to the number of positive degree nodes
     csr = normalize_adj(Aadj, symmetric=False)
     dense = csr.todense()
-    assert 5 == pytest.approx(dense.sum(), 0.1)
+    num_pos_degree_nodes = (Aadj.sum(axis=1) > 0).sum()
+    assert num_pos_degree_nodes == pytest.approx(dense.sum(), 0.1)
     assert csr.get_shape() == Aadj.get_shape()
 
 
@@ -212,7 +214,7 @@ def test_normalized_laplacian(example_graph):
     assert laplacian.shape == Aadj.get_shape()
 
     # Sum of laplacian is equal to the number of degree 0 nodes
-    laplacian = normalized_laplacian(Aadj, symmetric=False) 
+    laplacian = normalized_laplacian(Aadj, symmetric=False)
     num_degree_zero_nodes = (Aadj.sum(axis=1) == 0).sum()
     assert num_degree_zero_nodes == pytest.approx(laplacian.sum(), abs=1e-7)
     assert laplacian.get_shape() == Aadj.get_shape()


### PR DESCRIPTION
Closes #1678 

This PR fixes `test_normalize_adj` in `tests.core.test_utils` which was failing in a flaky way. 

The test was occasionally failing in two places:
- Comparing the top eigenvalue of symmetrically normalized adjacency matrix with 1. See, for example, https://buildkite.com/stellar/stellargraph-public/builds/3837
- Checking the sum of elements of non-symmetrically normalized adjacency matrix. See, for example, https://buildkite.com/stellar/stellargraph-public/builds/3967

The first point of failure seems to be the question of precision when calculating eigenvalues. The current error threshold equal to 1e-7 is too low. I ran 100000 iterations of the test and got 14963 occasions when the error is > 1e-8 and 33 occasions when the error is > 1e-7. By setting the threshold to 1e-5 we would make it virtually impossible for the test to fail. 

The second point of failure is similar to https://github.com/stellargraph/stellargraph/pull/1986. The sum of elements of the normalized adjacency matrix should be compared to the number of nodes of positive degree (each row contributes 1 except for those corresponding to degree 0 nodes). For graphs generated with `example_graph_random` this is equal to 5 most of the time, but not always -  that's why the test was failing

I also remove unused import in `stellargraph/data/epgm.py`, which is not in the dependencies and caused many CI jobs to fail - let me know if you would prefer to keep it and just add to the dependencies.

## Tests

The following code runs without errors:
```
from tests.core.test_utils import example_graph_random, test_normalize_adj
for i in range(100000):
    random_graph = example_graph_random()
    test_normalize_adj(random_graph)
```