### PR TITLE
Node classification with Node2Vec NB: gensim==4.1.2, train_test_split typo, n_jobs

### DIFF
--- a/demos/node-classification/node2vec-node-classification.ipynb
+++ b/demos/node-classification/node2vec-node-classification.ipynb
@@ -58,7 +58,8 @@
     "# install StellarGraph if running on Google Colab\n",
     "import sys\n",
     "if 'google.colab' in sys.modules:\n",
-    "  %pip install -q stellargraph[demos]==1.3.0b"
+    "  %pip install -q stellargraph[demos]==1.3.0b\n",
+    "!pip install gensim==4.1.2"
    ]
   },
   {
@@ -416,7 +417,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "X_train, X_test, y_train, y_test = train_test_split(X, y, train_size=0.1, test_size=None)"
+    "X_train, X_test, y_train, y_test = train_test_split(X, y, train_size=0.75, test_size=None)"
    ]
   },
   {
@@ -430,10 +431,10 @@
      "output_type": "stream",
      "text": [
       "Array shapes:\n",
-      " X_train = (248, 128)\n",
-      " y_train = (248,)\n",
-      " X_test = (2237, 128)\n",
-      " y_test = (2237,)\n"
+      " X_train = (1863, 128)\n",
+      " y_train = (1863,)\n",
+      " X_test = (622, 128)\n",
+      " y_test = (622,)\n"
      ]
     }
    ],
@@ -478,7 +479,7 @@
    ],
    "source": [
     "clf = LogisticRegressionCV(\n",
-    "    Cs=10, cv=10, scoring=\"accuracy\", verbose=False, multi_class=\"ovr\", max_iter=300\n",
+    "    Cs=10, cv=10, scoring=\"accuracy\", verbose=False, multi_class=\"ovr\", max_iter=300, n_jobs=4\n",
     ")\n",
     "clf.fit(X_train, y_train)"
    ]
@@ -518,7 +519,7 @@
     {
      "data": {
       "text/plain": [
-       "0.7223960661600357"
+       "0.8504823151125402"
       ]
      },
      "execution_count": 17,


### PR DESCRIPTION
[x] installs gensim==4.1.2 (https://github.com/stellargraph/stellargraph/issues/2010 and https://github.com/RaRe-Technologies/gensim/issues/3226)
[x] fixes typo (?): notebook states training on "75%" but `train_test_split` ratio set to "0.1", which also affects final accuracy (85% new / 72% old)
[x] sets `n_jobs=4` as default value in LogisticRegressionCV is resulting in non-convergence