### PR TITLE
tighten test_rescale_laplacian bound

### DIFF
--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -223,7 +223,7 @@ def test_rescale_laplacian(example_graph):
     node_list = list(example_graph.nodes())
     Aadj = example_graph.to_adjacency_matrix()
     rl = rescale_laplacian(normalized_laplacian(Aadj))
-    assert rl.max() < 1
+    assert rl.max() < 0.8
     assert rl.get_shape() == Aadj.get_shape()
 
 


### PR DESCRIPTION
**Patch description**
Hi,

The test `test_rescale_laplacian` in `test_utils.py` has an assertion bound (`assert rl.max() < 1`) that is too loose. This means potential bug in the code could still pass the original test.

To quantify this I conducted some experiments where I generated multiple mutations of the source code under test and ran each mutant and the original code 100 times to build a distribution of their outputs. Each mutant is generated using simple mutation operators (e.g. > can become < ) on source code covered by the test. I used KS-test to find mutants that produced a different distribution from the original and use those mutants as a proxy for bugs that could be introduced. In the graph below I show the distribution of both the original code and also the mutants with a different distribution.

<p align="center">
<img src="https://user-images.githubusercontent.com/95935342/150856564-a3fb0cad-5da3-4bdb-9335-3b5e46aeb5a1.png" width="450">
</p>

Here we see that the bound of `1` is too loose since the original distribution (in orange) is less than `1`. Furthermore in this graph we can observe that there are many mutants (proxy for bugs) that are below the bound as well and that is undesirable since the test should aim to catch potential bugs in code. I quantify the "bug detection" of this assertion by varying the bound in a trade-off graph below.

<p align="center">
<img src="https://user-images.githubusercontent.com/95935342/150856606-8e1147b7-a2ef-4a70-a245-f96fc2167fab.png" width="450">
</p>

In this graph, I plot the mutant catch rate (ratio of mutant outputs that fail the test) and the original pass rate (ratio of original output that pass the test). The original bound of `1` (red dotted line) has a catch rate of 0.51.

To improve this test, I propose to tighten the bound to `0.8` (the blue dotted line). The new bound has a catch rate of 0.56 (+0.05 increase compare to original) while still has >99 % pass rate (test is not flaky, I ran the updated test 500 times and observed 100 % pass rate). I think this is a good balance between improving the bug-detection ability of the test while keep the flakiness of the test low.

Do you guys think this makes sense? Please let me know if this looks good or if you have any other suggestions or questions. 

My Environment:
```
python=3.7.11
tensorflow=2.7.0
```

my stellargraph Experiment SHA:
`3c2c8c18ab4c5c16660f350d8e23d7dc39e738de`
