### PR TITLE
Corrected arg description in `stellargraph/data/explorer.py::DirectedBreadthFirstNeighbours`

### DIFF
--- a/stellargraph/data/explorer.py
+++ b/stellargraph/data/explorer.py
@@ -847,8 +847,8 @@ class DirectedBreadthFirstNeighbours(GraphWalk):
         Args:
             nodes (list): A list of root node ids such that from each node n BFWs will be generated up to the
             given depth d.
-            in_size (int): The number of in-directed nodes to sample with replacement at each depth of the walk.
-            out_size (int): The number of out-directed nodes to sample with replacement at each depth of the walk.
+            in_size (list of int): The number of in-directed nodes to sample with replacement at each depth of the walk.
+            out_size (list of int): The number of out-directed nodes to sample with replacement at each depth of the walk.
             n (int, default 1): Number of walks per node id.
             seed (int, optional): Random number generator seed; default is None
             weighted (bool, optional): If True, sample neighbours using the edge weights in the graph.
@@ -935,14 +935,12 @@ class DirectedBreadthFirstNeighbours(GraphWalk):
 
     def _check_neighbourhood_sizes(self, in_size, out_size):
         """
-        Checks that the parameter values are valid or raises ValueError exceptions with a message indicating the
-        parameter (the first one encountered in the checks) with invalid value.
+        Checks that the parameter values are valid and are of equal length or raises ValueError exceptions
+        with a message indicating the parameter (the first one encountered in the checks) with invalid value.
 
         Args:
-            nodes: <list> A list of root node ids such that from each node n BFWs will be generated up to the
-            given depth d.
-            n_size: <list> The number of neighbouring nodes to expand at each depth of the walk.
-            seed: <int> Random number generator seed; default is None
+            in_size (list of int): List of number of in-directed nodes to be sampled at each depth.
+            out_size (list of int): List of number of out-directed nodes to be sampled at each depth.
         """
         self._check_sizes(in_size)
         self._check_sizes(out_size)


### PR DESCRIPTION
In the overridden method `def run(...)` of the `class DirectedBreadthFirstNeighbours(GraphWalk)` defined in file [stellargraph/data/explorer.py](https://github.com/stellargraph/stellargraph/blob/develop/stellargraph/data/explorer.py#L843), the description had mentioned that `in_size` and `out_size` were arguments of type `int`, but the context and the usage of the variables clearly suggests that their typing should be `list[int]`.

Also the method `def _check_neighbourhood_sizes(...)` of the same class, seems to have completely different argument descriptions, that has been corrected along with some additional information regarding the functionality of the method.

Regards,
Dinesh Chukkala